### PR TITLE
fix: `a.b.c` as a symbol in thrift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "derivative",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -402,7 +402,8 @@ impl Lower<Arc<thrift_parser::File>> for ThriftLower {
                                 .split('/')
                                 .last()
                                 .unwrap()
-                                .trim_end_matches(".thrift"),
+                                .trim_end_matches(".thrift")
+                                .replace('.', "_"),
                         ),
                         this.lower_include(i),
                     )
@@ -428,7 +429,14 @@ impl Lower<Arc<thrift_parser::File>> for ThriftLower {
                     .as_ref()
                     .map(|p| this.lower_path(p))
                     .unwrap_or_else(|| Path {
-                        segments: Arc::from([f.path.file_stem().unwrap().to_str().unwrap().into()]),
+                        segments: Arc::from([f
+                            .path
+                            .file_stem()
+                            .unwrap()
+                            .to_str()
+                            .unwrap()
+                            .replace('.', "_")
+                            .into()]),
                     }),
                 items: f
                     .items


### PR DESCRIPTION

## Motivation
fix: `a.b.c` as a symbol in thrift

## Solution
try to find `a.b.c` in symbol table if `a` not exists.
