### PR TITLE
don't generate unused item for thrift codegen

### DIFF
--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -244,15 +244,10 @@ impl ThriftBackend {
             if self.field_is_box(f) {
                 read_field = quote! {::std::boxed::Box::new(#read_field) };
             };
-            let skip = helper.codegen_skip_ttype(quote! { field_ident.field_type });
 
             quote! {
-                Some(#field_id) => {
-                    if field_ident.field_type == #ttype {
-                        #field_ident = Some(#read_field);
-                    } else {
-                        #skip;
-                    }
+                Some(#field_id) if field_ident.field_type == #ttype  => {
+                    #field_ident = Some(#read_field);
                 },
             }
         });

--- a/pilota-build/src/db.rs
+++ b/pilota-build/src/db.rs
@@ -8,7 +8,8 @@ use crate::{
         ty::{AdtDef, AdtKind, CodegenTy, TyKind},
         type_graph::TypeGraph,
     },
-    symbol::{DefId, FileId},
+    rir::{ItemPath, NodeKind},
+    symbol::{DefId, FileId, Symbol},
 };
 
 #[derive(Default)]
@@ -38,15 +39,14 @@ pub trait RirDatabase {
     #[salsa::input]
     fn files(&self) -> Arc<FxHashMap<FileId, Arc<rir::File>>>;
     #[salsa::input]
-    fn pkgs(&self) -> Arc<FxHashMap<rir::ItemPath, Arc<rir::Pkg>>>;
-    #[salsa::input]
     fn type_graph(&self) -> Arc<TypeGraph>;
 
     fn node(&self, def_id: DefId) -> Option<rir::Node>;
     fn file(&self, file_id: FileId) -> Option<Arc<rir::File>>;
     fn item(&self, def_id: DefId) -> Option<Arc<rir::Item>>;
     fn expect_item(&self, def_id: DefId) -> Arc<rir::Item>;
-    fn pkg(&self, path: rir::ItemPath) -> Option<Arc<rir::Pkg>>;
+    fn mod_path(&self, def_id: DefId) -> ItemPath;
+    fn item_path(&self, def_id: DefId) -> ItemPath;
     fn codegen_item_ty(&self, ty: TyKind) -> CodegenTy;
     fn codegen_const_ty(&self, ty: TyKind) -> CodegenTy;
     fn codegen_ty(&self, def_id: DefId) -> CodegenTy;
@@ -73,8 +73,62 @@ fn expect_item(db: &dyn RirDatabase, def_id: DefId) -> Arc<rir::Item> {
     db.item(def_id).unwrap()
 }
 
-fn pkg(db: &dyn RirDatabase, path: rir::ItemPath) -> Option<Arc<rir::Pkg>> {
-    db.pkgs().get(&path).cloned()
+fn mod_path(db: &dyn RirDatabase, def_id: DefId) -> ItemPath {
+    fn calc_item_path(db: &dyn RirDatabase, def_id: DefId, segs: &mut Vec<Symbol>) {
+        let node = db.node(def_id).unwrap();
+        if let Some(parent) = node.parent {
+            calc_item_path(db, parent, segs)
+        } else {
+            let file = db.file(node.file_id).unwrap();
+            let package = &file.package;
+            segs.extend_from_slice(package)
+        }
+
+        match node.kind {
+            NodeKind::Item(item) => {
+                if matches!(&*item, rir::Item::Mod(_)) {
+                    segs.push(item.symbol_name());
+                }
+            }
+            _ => {}
+        };
+    }
+
+    let mut segs = Default::default();
+
+    calc_item_path(db, def_id, &mut segs);
+
+    ItemPath::from(segs)
+}
+
+fn item_path(db: &dyn RirDatabase, def_id: DefId) -> ItemPath {
+    fn calc_item_path(db: &dyn RirDatabase, def_id: DefId, segs: &mut Vec<Symbol>) {
+        let node = db.node(def_id).unwrap();
+        if let Some(parent) = node.parent {
+            calc_item_path(db, parent, segs)
+        } else {
+            let file = db.file(node.file_id).unwrap();
+            let package = &file.package;
+            segs.extend_from_slice(package)
+        }
+
+        let name = match node.kind {
+            NodeKind::Item(item) => match &*item {
+                rir::Item::Const(_) => item.symbol_name().to_shouty_snake_case(),
+                rir::Item::Mod(m) => (&*m.name).clone(),
+                _ => item.symbol_name().to_upper_camel_case(),
+            },
+            NodeKind::Variant(v) => (*v.name).to_upper_camel_case(),
+            _ => panic!(),
+        };
+        segs.push(name);
+    }
+
+    let mut segs = Default::default();
+
+    calc_item_path(db, def_id, &mut segs);
+
+    ItemPath::from(segs)
 }
 
 fn file(db: &dyn RirDatabase, file_id: FileId) -> Option<Arc<rir::File>> {

--- a/pilota-build/src/ir/mod.rs
+++ b/pilota-build/src/ir/mod.rs
@@ -147,6 +147,7 @@ pub enum ItemKind {
 #[derive(Clone, Debug)]
 pub struct Item {
     pub kind: ItemKind,
+    pub related_items: Vec<Ident>,
     pub tags: Arc<Tags>,
 }
 

--- a/pilota-build/src/middle/rir.rs
+++ b/pilota-build/src/middle/rir.rs
@@ -197,6 +197,16 @@ pub struct Node {
     pub kind: NodeKind,
     pub parent: Option<DefId>,
     pub tags: TagId,
+    pub related_nodes: Vec<DefId>,
+}
+
+impl Node {
+    pub(crate) fn expect_item(&self) -> &Item {
+        match &self.kind {
+            NodeKind::Item(item) => &item,
+            _ => panic!(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/pilota-build/src/parser/mod.rs
+++ b/pilota-build/src/parser/mod.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::ir::File;
+use crate::{ir::File, symbol::FileId};
 
 pub(crate) mod protobuf;
 pub(crate) mod thrift;
@@ -14,6 +14,7 @@ pub use self::protobuf::ProtobufParser;
 
 pub struct ParseResult {
     pub files: Vec<Arc<File>>,
+    pub(crate) input_files: Vec<FileId>,
 }
 
 pub trait Parser {

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -164,6 +164,7 @@ impl Lower {
 
     fn lower_enum(&self, e: &EnumDescriptorProto) -> ir::Item {
         ir::Item {
+            related_items: Default::default(),
             tags: Default::default(),
             kind: ir::ItemKind::Enum(ir::Enum {
                 name: e.name().into(),
@@ -218,6 +219,7 @@ impl Lower {
         message.oneof_decl.iter().enumerate().for_each(|(idx, d)| {
             let fields = oneof_fields.remove(&(idx as i32)).unwrap();
             nested_items.push(Arc::new(ir::Item {
+                related_items: Default::default(),
                 tags: Arc::new(crate::tags!(OneOf)),
                 kind: ir::ItemKind::Enum(ir::Enum {
                     name: d.name().into(),
@@ -246,6 +248,7 @@ impl Lower {
             .for_each(|(_, m)| nested_items.push(Arc::new(self.lower_message(m))));
 
         let item = ir::Item {
+            related_items: Default::default(),
             tags: Default::default(),
             kind: ir::ItemKind::Message(ir::Message {
                 fields: fields
@@ -309,6 +312,7 @@ impl Lower {
             let name = item.name().to_lower_camel_case();
             nested_items.push(Arc::new(item));
             Item {
+                related_items: Default::default(),
                 tags: Default::default(),
                 kind: ir::ItemKind::Mod(ir::Mod {
                     name: Ident::new(name),
@@ -321,6 +325,7 @@ impl Lower {
     pub fn lower_service(&self, service: &ServiceDescriptorProto) -> ir::Item {
         ir::Item {
             tags: Default::default(),
+            related_items: Default::default(),
             kind: ir::ItemKind::Service(ir::Service {
                 name: service.name().into(),
                 methods: service
@@ -433,6 +438,7 @@ impl Parser for ProtobufParser {
 
         super::ParseResult {
             files: Lower::default().lower(&descriptors),
+            input_files: vec![],
         }
     }
 }

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -18,6 +18,7 @@ fn diff_file(old: impl AsRef<Path>, new: impl AsRef<Path>) {
 fn test_protobuf(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     test_with_builder(source, target, |source, target| {
         crate::Builder::protobuf()
+            .remove_unused(false)
             .include_dirs(vec![source.parent().unwrap().to_path_buf()])
             .compile(&[source], target)
     });
@@ -48,7 +49,9 @@ fn test_with_builder<F: FnOnce(&Path, &Path)>(
 
 fn test_thrift(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     test_with_builder(source, target, |source, target| {
-        crate::Builder::thrift().compile(&[source], target)
+        crate::Builder::thrift()
+            .remove_unused(false)
+            .compile(&[source], target)
     });
 }
 

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -24,7 +24,7 @@ pub mod nested_message {
             #[derive(PartialOrd, Hash, Eq, Ord, :: prost :: Message, Clone, PartialEq)]
             pub struct Tt1 {
                 #[prost(message, tag = "1", optional)]
-                pub t2: ::std::option::Option<T2::T2>,
+                pub t2: ::std::option::Option<t2::T2>,
             }
         }
     }

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -46,12 +46,8 @@ pub mod normal {
                     }
                     let field_id = field_ident.id;
                     match field_id {
-                        Some(1i16) => {
-                            if field_ident.field_type == ::pilota::thrift::TType::I32 {
-                                a = Some(protocol.read_i32()?);
-                            } else {
-                                protocol.skip(field_ident.field_type)?;
-                            }
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
+                            a = Some(protocol.read_i32()?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type)?;
@@ -75,12 +71,8 @@ pub mod normal {
                     }
                     let field_id = field_ident.id;
                     match field_id {
-                        Some(1i16) => {
-                            if field_ident.field_type == ::pilota::thrift::TType::I32 {
-                                a = Some(protocol.read_i32().await?);
-                            } else {
-                                protocol.skip(field_ident.field_type).await?;
-                            }
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
+                            a = Some(protocol.read_i32().await?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type).await?;
@@ -148,12 +140,8 @@ pub mod normal {
                     }
                     let field_id = field_ident.id;
                     match field_id {
-                        Some(2i16) => {
-                            if field_ident.field_type == ::pilota::thrift::TType::Struct {
-                                a = Some(::pilota::thrift::Message::decode(protocol)?);
-                            } else {
-                                protocol.skip(field_ident.field_type)?;
-                            }
+                        Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            a = Some(::pilota::thrift::Message::decode(protocol)?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type)?;
@@ -177,12 +165,8 @@ pub mod normal {
                     }
                     let field_id = field_ident.id;
                     match field_id {
-                        Some(2i16) => {
-                            if field_ident.field_type == ::pilota::thrift::TType::Struct {
-                                a = Some(::pilota::thrift::Message::decode_async(protocol).await?);
-                            } else {
-                                protocol.skip(field_ident.field_type).await?;
-                            }
+                        Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            a = Some(::pilota::thrift::Message::decode_async(protocol).await?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type).await?;

--- a/pilota-build/test_data/thrift/recursive_type.rs
+++ b/pilota-build/test_data/thrift/recursive_type.rs
@@ -46,14 +46,10 @@ pub mod recursive_type {
                     }
                     let field_id = field_ident.id;
                     match field_id {
-                        Some(1i16) => {
-                            if field_ident.field_type == ::pilota::thrift::TType::Struct {
-                                a = Some(::std::boxed::Box::new(
-                                    ::pilota::thrift::Message::decode(protocol)?,
-                                ));
-                            } else {
-                                protocol.skip(field_ident.field_type)?;
-                            }
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            a = Some(::std::boxed::Box::new(::pilota::thrift::Message::decode(
+                                protocol,
+                            )?));
                         }
                         _ => {
                             protocol.skip(field_ident.field_type)?;
@@ -77,14 +73,10 @@ pub mod recursive_type {
                     }
                     let field_id = field_ident.id;
                     match field_id {
-                        Some(1i16) => {
-                            if field_ident.field_type == ::pilota::thrift::TType::Struct {
-                                a = Some(::std::boxed::Box::new(
-                                    ::pilota::thrift::Message::decode_async(protocol).await?,
-                                ));
-                            } else {
-                                protocol.skip(field_ident.field_type).await?;
-                            }
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            a = Some(::std::boxed::Box::new(
+                                ::pilota::thrift::Message::decode_async(protocol).await?,
+                            ));
                         }
                         _ => {
                             protocol.skip(field_ident.field_type).await?;


### PR DESCRIPTION
## Motivation
speed up thrift codegen and rust compile time for codegen file

## Solution
don't generate unused item for thrift codegen

