### PR TITLE
peek keyword for thrift-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "async-trait",
  "derivative",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "nom",
 ]

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"
@@ -17,7 +17,7 @@ keywords = ["serialization", "thrift", "protobuf", "volo"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-pilota-thrift-parser = { path = "../pilota-thrift-parser", version = "0.1.0" }
+pilota-thrift-parser = { path = "../pilota-thrift-parser", version = "0.2" }
 
 heck = "0.4"
 syn = "1"

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Pilota thrift Parser."
 documentation = "https://docs.rs/pilota"

--- a/pilota-thrift-parser/src/descriptor/mod.rs
+++ b/pilota-thrift-parser/src/descriptor/mod.rs
@@ -6,6 +6,7 @@ mod function;
 mod identifier;
 mod include;
 mod literal;
+mod namespace;
 mod service;
 mod struct_;
 mod ty;
@@ -21,6 +22,7 @@ pub use function::Function;
 pub use identifier::Ident;
 pub use include::{CppInclude, Include};
 pub use literal::Literal;
+pub use namespace::{Namespace, Scope};
 pub use service::Service;
 pub use struct_::{Exception, Struct, StructLike, Union};
 pub use ty::{CppType, Ty, Type};
@@ -44,6 +46,9 @@ where
 
 #[derive(Debug)]
 pub enum Item {
+    Include(Include),
+    CppInclude(CppInclude),
+    Namespace(Namespace),
     Typedef(Typedef),
     Constant(Constant),
     Enum(Enum),
@@ -75,8 +80,6 @@ item_from!(Service);
 pub struct File {
     pub path: Arc<PathBuf>,
     pub package: Option<Path>,
-    pub includes: Vec<Include>,
-    pub cpp_includes: Vec<CppInclude>,
     pub items: Vec<Item>,
 }
 

--- a/pilota-thrift-parser/src/descriptor/namespace.rs
+++ b/pilota-thrift-parser/src/descriptor/namespace.rs
@@ -1,0 +1,11 @@
+use crate::{Annotations, Path};
+
+#[derive(Debug, Clone)]
+pub struct Scope(pub String);
+
+#[derive(Debug, Clone)]
+pub struct Namespace {
+    pub scope: Scope,
+    pub name: Path,
+    pub annotations: Option<Annotations>,
+}

--- a/pilota-thrift-parser/src/parser/field.rs
+++ b/pilota-thrift-parser/src/parser/field.rs
@@ -33,7 +33,7 @@ impl Parser for Field {
                 opt(Attribute::parse),
                 opt(blank),
                 Type::parse,
-                blank,
+                opt(blank),
                 Ident::parse,
                 opt(blank),
                 opt(map(

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -7,13 +7,7 @@ use nom::{
 };
 
 use super::super::{descriptor::Annotations, parser::*};
-
-#[derive(Debug, Clone)]
-pub struct Namespace {
-    pub scope: Scope,
-    pub name: Path,
-    pub annotations: Option<Annotations>,
-}
+use crate::{Namespace, Scope};
 
 impl Parser for Namespace {
     fn parse(input: &str) -> IResult<&str, Namespace> {
@@ -35,9 +29,6 @@ impl Parser for Namespace {
         )(input)
     }
 }
-
-#[derive(Debug, Clone)]
-pub struct Scope(pub String);
 
 impl Parser for Scope {
     fn parse(input: &str) -> IResult<&str, Scope> {

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -1,7 +1,7 @@
 use nom::{
     bytes::complete::tag,
     combinator::{map, opt},
-    sequence::tuple,
+    sequence::{delimited, tuple},
     IResult,
 };
 
@@ -71,13 +71,15 @@ mod tests {
         let str = r#"struct MGetRequest {
             1: set<i64> Ids (go.tag = "json:\"Ids\" split:\"type=tenant\""),
             2: optional set<ExtendField> extendFields,
+
+
+            3: optional set<ExtendField>extendFields2,
         
             255: base.Base Base,
         }
         "#;
 
-        let (remain, _res) = Struct::parse(str).unwrap();
-        println!("{:?}", remain);
+        Struct::parse(str).unwrap();
     }
 
     #[test]
@@ -93,7 +95,15 @@ mod tests {
             8: string SessionDict (agw.source="header", agw.key="Tt-Agw-Loader-Session-rsp")
             9: abtest_version.VersionRsp                                AbtestVersionRsp (go.tag = 'json:\"-\"')
         }"#;
-        let (remain, _res) = Struct::parse(str).unwrap();
-        println!("{:?}", remain);
+        Struct::parse(str).unwrap();
+    }
+
+    #[test]
+    fn test_struct3() {
+        let str = r#"struct TestComment {
+            // 1
+        }
+        "#;
+        Struct::parse(str).unwrap();
     }
 }


### PR DESCRIPTION
## Motivation
```thrift
struct {
    1: 123,23
}
```
parser should report error for this code. but for now, the parser will not consume these token and ignore it.

## Solution
peek keyword like `struct`, `enum`.... and prase
