### PR TITLE
custom rust name by `pilota.name` annotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "quote",
  "salsa",
  "scoped-tls",
+ "smol_str",
  "syn",
  "tempfile",
  "tokio",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -20,6 +20,7 @@ maintenance = { status = "actively-developed" }
 pilota-thrift-parser = { path = "../pilota-thrift-parser", version = "0.2" }
 
 heck = "0.4"
+smol_str = "0.1"
 syn = "1"
 normpath = "0.3"
 fxhash = "0.2"

--- a/pilota-build/src/codegen/pkg_tree.rs
+++ b/pilota-build/src/codegen/pkg_tree.rs
@@ -2,15 +2,13 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 
-use crate::{middle::rir::ItemPath, symbol::Symbol};
-
 #[derive(Debug)]
 pub struct PkgNode {
-    pub path: ItemPath,
+    pub path: Arc<[smol_str::SmolStr]>,
     pub children: Arc<[PkgNode]>,
 }
 
-fn from_pkgs(base_path: &[Symbol], pkgs: &[ItemPath]) -> Arc<[PkgNode]> {
+fn from_pkgs(base_path: &[smol_str::SmolStr], pkgs: &[Arc<[smol_str::SmolStr]>]) -> Arc<[PkgNode]> {
     let groups = pkgs.iter().into_group_map_by(|p| p.first().unwrap());
 
     Arc::from_iter(groups.into_iter().map(|(k, v)| {
@@ -23,23 +21,23 @@ fn from_pkgs(base_path: &[Symbol], pkgs: &[ItemPath]) -> Arc<[PkgNode]> {
         let pkgs = v
             .into_iter()
             .filter(|p| p.len() > 1)
-            .map(|p| ItemPath::from(&p[1..]))
+            .map(|p| Arc::from(&p[1..]))
             .collect::<Vec<_>>();
 
         let children = from_pkgs(&path, &pkgs);
         PkgNode {
-            path: ItemPath::from(path),
+            path: Arc::from(path),
             children,
         }
     }))
 }
 
 impl PkgNode {
-    pub fn from_pkgs(pkgs: &[ItemPath]) -> Arc<[PkgNode]> {
+    pub fn from_pkgs(pkgs: &[Arc<[smol_str::SmolStr]>]) -> Arc<[PkgNode]> {
         from_pkgs(&[], pkgs)
     }
 
-    pub fn ident(&self) -> Symbol {
+    pub fn ident(&self) -> smol_str::SmolStr {
         self.path.last().unwrap().clone()
     }
 }

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -9,7 +9,7 @@ use self::tls::with_cur_item;
 use super::{adjust::Adjust, rir::NodeKind};
 use crate::{
     db::{RirDatabase, RootDatabase},
-    symbol::{DefId, Symbol},
+    symbol::{DefId, IdentName, Symbol},
     tags::{TagId, Tags},
     Plugin,
 };
@@ -57,9 +57,9 @@ impl Context {
         self.tags_map.get(&tags_id).cloned()
     }
 
-    pub fn node_tags(&self, def_id: DefId) -> Arc<Tags> {
+    pub fn node_tags(&self, def_id: DefId) -> Option<Arc<Tags>> {
         let tag_id = self.node(def_id).unwrap().tags;
-        self.tags(tag_id).unwrap()
+        self.tags(tag_id)
     }
 
     pub fn contains_tag<T: 'static>(&self, tags_id: TagId) -> bool {
@@ -69,7 +69,9 @@ impl Context {
     }
 
     pub fn node_contains_tag<T: 'static>(&self, def_id: DefId) -> bool {
-        self.node_tags(def_id).contains::<T>()
+        self.node_tags(def_id)
+            .and_then(|tags| tags.contains::<T>().then_some(true))
+            .is_some()
     }
 
     pub fn symbol_name(&self, def_id: DefId) -> Symbol {
@@ -77,9 +79,87 @@ impl Context {
         item.symbol_name()
     }
 
-    fn related_path(&self, p1: &[Symbol], p2: &[Symbol]) -> syn::Path {
+    pub fn rust_name(&self, def_id: DefId) -> smol_str::SmolStr {
+        let node = self.node(def_id).unwrap();
+
+        if let Some(name) = self
+            .tags(node.tags)
+            .and_then(|tags| tags.get::<crate::tags::PilotaName>().cloned())
+        {
+            return name.0;
+        }
+
+        match self.node(def_id).unwrap().kind {
+            NodeKind::Item(item) => match &*item {
+                crate::rir::Item::Message(m) => (&**m.name).struct_ident(),
+                crate::rir::Item::Enum(e) => (&**e.name).enum_ident(),
+                crate::rir::Item::Service(s) => (&**s.name).trait_ident(),
+                crate::rir::Item::NewType(t) => (&**t.name).newtype_ident(),
+                crate::rir::Item::Const(c) => (&**c.name).const_ident(),
+                crate::rir::Item::Mod(m) => (&**m.name).mod_ident(),
+            },
+            NodeKind::Variant(v) => (&**v.name).variant_ident(),
+            NodeKind::Field(f) => (&**f.name).field_ident(),
+            NodeKind::Method(m) => (&**m.name).fn_ident(),
+        }
+    }
+
+    pub fn mod_path(&self, def_id: DefId) -> Arc<[smol_str::SmolStr]> {
+        fn calc_item_path(cx: &Context, def_id: DefId, segs: &mut Vec<smol_str::SmolStr>) {
+            let node = cx.node(def_id).unwrap();
+            if let Some(parent) = node.parent {
+                calc_item_path(cx, parent, segs)
+            } else {
+                let file = cx.file(node.file_id).unwrap();
+                let package = &file.package;
+                segs.extend(package.iter().map(|s| (&*s.0).mod_ident()))
+            }
+
+            if let NodeKind::Item(item) = node.kind {
+                if let crate::rir::Item::Mod(_) = &*item {
+                    segs.push(cx.rust_name(def_id));
+                }
+            }
+        }
+
+        let mut segs = Default::default();
+
+        calc_item_path(self, def_id, &mut segs);
+
+        Arc::from(segs)
+    }
+
+    pub fn item_path(&self, def_id: DefId) -> Arc<[smol_str::SmolStr]> {
+        fn calc_item_path(db: &Context, def_id: DefId, segs: &mut Vec<smol_str::SmolStr>) {
+            let node = db.node(def_id).unwrap();
+
+            match node.kind {
+                NodeKind::Item(_) => {}
+                _ => calc_item_path(db, node.parent.unwrap(), segs),
+            }
+
+            let name = match node.kind {
+                NodeKind::Item(item) => match &*item {
+                    crate::rir::Item::Const(_) => (&*item.symbol_name()).const_ident(),
+                    crate::rir::Item::Mod(_) => return,
+                    _ => (&*item.symbol_name()).upper_camel_ident(),
+                },
+                NodeKind::Variant(v) => (&**v.name).variant_ident(),
+                _ => panic!(),
+            };
+            segs.push(name);
+        }
+
+        let mut segs = Vec::from(&*self.mod_path(def_id));
+
+        calc_item_path(&self, def_id, &mut segs);
+
+        Arc::from(segs)
+    }
+
+    fn related_path(&self, p1: &[smol_str::SmolStr], p2: &[smol_str::SmolStr]) -> syn::Path {
         if p1 == p2 {
-            return syn::Path::from(format_ident!("{}", p2.last().unwrap()));
+            return syn::Path::from(format_ident!("{}", p2.last().unwrap().as_syn_ident()));
         }
         let mut i = 0;
         while i < p1.len() && i < p2.len() && p1[i] == p2[i] {
@@ -89,7 +169,7 @@ impl Context {
 
         enum Kind {
             Super,
-            Ident(Symbol),
+            Ident(smol_str::SmolStr),
         }
         let path = (0..p1.len() - i)
             .map(|_| Kind::Super)
@@ -102,7 +182,7 @@ impl Context {
             segs.push(match k {
                 Kind::Super => PathSegment::from(syn::token::Super(Span::call_site())),
                 Kind::Ident(ident) => {
-                    let ident = format_ident!("{}", ident);
+                    let ident = ident.as_syn_ident();
                     PathSegment::from(ident)
                 }
             });

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -12,13 +12,13 @@ use super::Parser;
 use crate::{
     index::Idx,
     ir::{self, FieldKind, Item, Path, TyKind},
-    symbol::{EnumRepr, FileId, Ident},
+    symbol::{EnumRepr, FileId, Ident, IdentName},
     tags::{
         protobuf::{
             ClientStreaming, Fixed32, Fixed64, OneOf, Repeated, SFixed32, SFixed64, SInt32, SInt64,
             ServerStreaming,
         },
-        Tags,
+        PilotaName, Tags,
     },
 };
 
@@ -310,13 +310,15 @@ impl Lower {
         if nested_items.is_empty() {
             item
         } else {
-            let name = item.name().to_lower_camel_case();
+            let name = item.name().clone();
             nested_items.push(Arc::new(item));
+            let mut tags = Tags::default();
+            tags.insert(PilotaName(name.0.mod_ident().clone()));
             Item {
                 related_items: Default::default(),
-                tags: Default::default(),
+                tags: Arc::from(tags),
                 kind: ir::ItemKind::Mod(ir::Mod {
-                    name: Ident::new(name),
+                    name: Ident::from(format!("pilota_protobuf_mod_{}", name)),
                     items: nested_items,
                 }),
             }

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -174,12 +174,15 @@ impl Resolver {
                 .or_else(|| {
                     // fuzzy find for protobuf
                     match ns {
-                        Namespace::Value => b.value.get(&sym.to_snake_case()).and_then(|def_id| {
-                            self.def_modules[def_id].resolutions.value.get(&sym)
-                        }),
+                        Namespace::Value => {
+                            b.ty.get(&Symbol::from(format!("pilota_protobuf_mod_{}", sym)))
+                                .and_then(|def_id| {
+                                    self.def_modules[def_id].resolutions.value.get(&sym)
+                                })
+                        }
                         Namespace::Ty => b
                             .ty
-                            .get(&sym.to_snake_case())
+                            .get(&Symbol::from(format!("pilota_protobuf_mod_{}", sym)))
                             .and_then(|def_id| self.def_modules[def_id].resolutions.ty.get(&sym)),
                     }
                 })
@@ -224,7 +227,7 @@ impl Resolver {
                 ir::FieldKind::Required => FieldKind::Required,
                 ir::FieldKind::Optional => FieldKind::Optional,
             },
-            name: f.name.to_snake_case(),
+            name: f.name.clone(),
             ty: self.lower_type(&f.ty),
         });
 
@@ -302,7 +305,7 @@ impl Resolver {
                         Namespace::Value => &table.value,
                         Namespace::Ty => &table.ty,
                     };
-                    ModuleId::Node(*table.get(ident).unwrap_or_else(|| {
+                    ModuleId::Node(*table.get(&**ident).unwrap_or_else(|| {
                         panic!("can not find {} in file {:?}", ident, file.package)
                     }))
                 }
@@ -319,7 +322,7 @@ impl Resolver {
 
                             ModuleId::Node(
                                 *table
-                                    .get(ident)
+                                    .get(&**ident)
                                     .unwrap_or_else(|| panic!("can not find {}", ident)),
                             )
                         }

--- a/pilota-build/src/tags.rs
+++ b/pilota-build/src/tags.rs
@@ -4,6 +4,7 @@ use std::{
     fmt::Debug,
     hash::Hash,
     ops::{Deref, DerefMut},
+    str::FromStr,
 };
 
 #[derive(Default, Debug)]
@@ -103,6 +104,25 @@ macro_rules! new_type {
 
 pub mod thrift {
     pub struct EntryMessage;
+}
+
+#[derive(Clone)]
+pub struct PilotaName(pub smol_str::SmolStr);
+
+pub trait Annotation: FromStr {
+    const KEY: &'static str;
+}
+
+impl FromStr for PilotaName {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(smol_str::SmolStr::new(s)))
+    }
+}
+
+impl Annotation for PilotaName {
+    const KEY: &'static str = "pilota.name";
 }
 
 pub mod protobuf {

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -1,0 +1,176 @@
+pub mod pilota_name {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::unused_unit,
+        clippy::needless_borrow,
+        unused_mut
+    )]
+    pub mod pilota_name {
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct Test {
+            pub id: ::std::string::String,
+            pub hello: ::std::string::String,
+        }
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for Test {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::Error> {
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Test" };
+                protocol.write_struct_begin(&struct_ident)?;
+                {
+                    let value = &self.id;
+                    let field = ::pilota::thrift::TFieldIdentifier {
+                        name: Some("ID"),
+                        field_type: ::pilota::thrift::TType::String,
+                        id: Some(1i16),
+                    };
+                    protocol.write_field_begin(&field)?;
+                    protocol.write_string(value)?;
+                    protocol.write_field_end()?;
+                }
+                {
+                    let value = &self.hello;
+                    let field = ::pilota::thrift::TFieldIdentifier {
+                        name: Some("Id"),
+                        field_type: ::pilota::thrift::TType::String,
+                        id: Some(2i16),
+                    };
+                    protocol.write_field_begin(&field)?;
+                    protocol.write_string(value)?;
+                    protocol.write_field_end()?;
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut id = None;
+                let mut hello = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            id = Some(protocol.read_string()?);
+                        }
+                        Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            hello = Some(protocol.read_string()?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                    protocol.read_field_end()?;
+                }
+                protocol.read_struct_end()?;
+                let id = if let Some(id) = id {
+                    id
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field id is required".to_string(),
+                        ),
+                    ));
+                };
+                let hello = if let Some(hello) = hello {
+                    hello
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field hello is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { id, hello };
+                Ok(data)
+            }
+            async fn decode_async<C: ::tokio::io::AsyncRead + Unpin + Send>(
+                protocol: &mut ::pilota::thrift::TAsyncBinaryProtocol<C>,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut id = None;
+                let mut hello = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            id = Some(protocol.read_string().await?);
+                        }
+                        Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            hello = Some(protocol.read_string().await?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                    protocol.read_field_end().await?;
+                }
+                protocol.read_struct_end().await?;
+                let id = if let Some(id) = id {
+                    id
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field id is required".to_string(),
+                        ),
+                    ));
+                };
+                let hello = if let Some(hello) = hello {
+                    hello
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field hello is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { id, hello };
+                Ok(data)
+            }
+        }
+        impl ::pilota::thrift::Size for Test {
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &T) -> usize {
+                protocol
+                    .write_struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Test" })
+                    + {
+                        let value = &self.id;
+                        protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
+                            name: Some("ID"),
+                            field_type: ::pilota::thrift::TType::String,
+                            id: Some(1i16),
+                        }) + protocol.write_string_len(&value)
+                            + protocol.write_field_end_len()
+                    }
+                    + {
+                        let value = &self.hello;
+                        protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
+                            name: Some("Id"),
+                            field_type: ::pilota::thrift::TType::String,
+                            id: Some(2i16),
+                        }) + protocol.write_string_len(&value)
+                            + protocol.write_field_end_len()
+                    }
+                    + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift/pilota_name.thrift
+++ b/pilota-build/test_data/thrift/pilota_name.thrift
@@ -1,0 +1,5 @@
+
+struct Test {
+    1: required string ID,
+    2: required string Id (pilota.name="hello"),
+}

--- a/pilota-thrift-parser/src/descriptor/annotation.rs
+++ b/pilota-thrift-parser/src/descriptor/annotation.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
-use super::{Literal, Path};
+use super::Literal;
 
 #[derive(Debug, Clone)]
 pub struct Annotation {
-    pub key: Path,
+    pub key: String,
     pub value: Literal,
 }
 

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -1,6 +1,7 @@
 use nom::{
-    bytes::complete::tag,
-    combinator::{map, opt},
+    bytes::complete::{tag, take_while},
+    character::complete::satisfy,
+    combinator::{map, opt, recognize},
     multi::many1,
     sequence::tuple,
     IResult,
@@ -20,7 +21,10 @@ impl Parser for Annotations {
                 many1(map(
                     tuple((
                         opt(blank),
-                        Path::parse,
+                        recognize(tuple((
+                            satisfy(|c| c.is_ascii_alphabetic() || c == '_'),
+                            take_while(|c: char| c.is_ascii_alphanumeric() || c == '_' || c == '.'),
+                        ))),
                         opt(blank),
                         tag("="),
                         opt(blank),
@@ -28,7 +32,10 @@ impl Parser for Annotations {
                         opt(blank),
                         opt(list_separator),
                     )),
-                    |(_, p, _, _, _, lit, _, _)| Annotation { key: p, value: lit },
+                    |(_, p, _, _, _, lit, _, _)| Annotation {
+                        key: p.to_owned(),
+                        value: lit,
+                    },
                 )),
                 tag(")"),
             )),

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -1,7 +1,7 @@
 use nom::{
     bytes::complete::tag,
     combinator::{map, opt},
-    sequence::{delimited, tuple},
+    sequence::tuple,
     IResult,
 };
 


### PR DESCRIPTION

## Motivation

custom the filed name in idl by `pilota.name` annotation
```thrift
struct A {
  1: required string A (pilota.name = "hello"),
}
```
generate rust code

```rust

struct A {
    hello: String,
}
```

