### PR TITLE
feat: support bytes as binary type in thrift

### DIFF
--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -14,7 +14,7 @@ impl ThriftBackend {
             ty::Void => quote! {::pilota::thrift::TType::Void},
             ty::U8 => quote! {::pilota::thrift::TType::I08},
             ty::Bool => quote! {::pilota::thrift::TType::Bool},
-            ty::Bytes => quote! {::pilota::thrift::TType::String},
+            ty::BytesVec | ty::Bytes => quote! {::pilota::thrift::TType::String},
             ty::I8 => quote! {::pilota::thrift::TType::I08},
             ty::I16 => quote! { ::pilota::thrift::TType::I16 },
             ty::I32 => quote! { ::pilota::thrift::TType::I32 },
@@ -49,7 +49,7 @@ impl ThriftBackend {
             },
             ty::U8 => quote! { protocol.write_byte(*#ident)?; },
             ty::Bool => quote! { protocol.write_bool(*#ident)?; },
-            ty::Bytes => quote! { protocol.write_bytes(&#ident)?;},
+            ty::BytesVec | ty::Bytes => quote! { protocol.write_bytes(&#ident)?;},
             ty::I8 => quote! { protocol.write_i8(*#ident)?; },
             ty::I16 => quote! { protocol.write_i16(*#ident)?; },
             ty::I32 => quote! { protocol.write_i32(*#ident)?; },
@@ -123,7 +123,7 @@ impl ThriftBackend {
                 quote! { protocol.write_byte_len(*#ident) }
             }
             ty::Bool => quote! { protocol.write_bool_len(*#ident) },
-            ty::Bytes => quote! { protocol.write_bytes_len(#ident)},
+            ty::BytesVec | ty::Bytes => quote! { protocol.write_bytes_len(#ident)},
             ty::I8 => quote! { protocol.write_i8_len(*#ident) },
             ty::I16 => quote! { protocol.write_i16_len(*#ident) },
             ty::I32 => quote! { protocol.write_i32_len(*#ident) },
@@ -213,7 +213,13 @@ impl ThriftBackend {
             }
             ty::U8 => helper.codegen_read_byte(),
             ty::Bool => helper.codegen_read_bool(),
-            ty::Bytes => helper.codegen_read_bytes(),
+            ty::BytesVec => helper.codegen_read_bytes(),
+            ty::Bytes => {
+                let read_bytes = helper.codegen_read_bytes();
+                quote!(
+                    ::bytes::Bytes::from(#read_bytes)
+                )
+            }
             ty::I8 => helper.codegen_read_i8(),
             ty::I16 => helper.codegen_read_i16(),
             ty::I32 => helper.codegen_read_i32(),

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -13,10 +13,7 @@ use crate::{
     ir::{self, FieldKind, Item, Path, TyKind},
     symbol::{EnumRepr, FileId, Ident, IdentName},
     tags::{
-        protobuf::{
-            ClientStreaming, Fixed32, Fixed64, OneOf, Repeated, SFixed32, SFixed64, SInt32, SInt64,
-            ServerStreaming,
-        },
+        protobuf::{ClientStreaming, OneOf, ProstType, Repeated, ServerStreaming},
         PilotaName, Tags,
     },
 };
@@ -100,11 +97,11 @@ impl Lower {
                 }
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_INT32 => ir::TyKind::I32,
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_FIXED64 => {
-                    tags.insert(Fixed64);
+                    tags.insert(ProstType::Fixed64);
                     ir::TyKind::UInt64
                 }
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_FIXED32 => {
-                    tags.insert(Fixed32);
+                    tags.insert(ProstType::Fixed32);
                     ir::TyKind::UInt32
                 }
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_BOOL => ir::TyKind::Bool,
@@ -117,19 +114,19 @@ impl Lower {
                     ir::TyKind::UInt32
                 }
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_SFIXED32 => {
-                    tags.insert(SFixed32);
+                    tags.insert(ProstType::SFixed32);
                     ir::TyKind::I32
                 }
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_SFIXED64 => {
-                    tags.insert(SFixed64);
+                    tags.insert(ProstType::SFixed64);
                     ir::TyKind::I64
                 }
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_SINT32 => {
-                    tags.insert(SInt32);
+                    tags.insert(ProstType::SInt32);
                     ir::TyKind::I32
                 }
                 protobuf::descriptor::field_descriptor_proto::Type::TYPE_SINT64 => {
-                    tags.insert(SInt64);
+                    tags.insert(ProstType::SInt64);
                     ir::TyKind::I64
                 }
 

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -16,6 +16,7 @@ use crate::{
     rir::Mod,
     symbol::{DefId, FileId, Ident, Symbol},
     tags::{TagId, Tags},
+    ty::BytesRepr,
 };
 
 struct ModuleData {
@@ -350,7 +351,16 @@ impl Resolver {
             ir::TyKind::Void => ty::Void,
             ir::TyKind::U8 => ty::U8,
             ir::TyKind::Bool => ty::Bool,
-            ir::TyKind::Bytes => ty::Bytes,
+            ir::TyKind::Bytes
+                if ty
+                    .tags
+                    .get::<BytesRepr>()
+                    .map(|repr| matches!(repr, BytesRepr::Bytes))
+                    == Some(true) =>
+            {
+                ty::Bytes
+            }
+            ir::TyKind::Bytes => ty::BytesVec,
             ir::TyKind::I8 => ty::I8,
             ir::TyKind::I16 => ty::I16,
             ir::TyKind::I32 => ty::I32,

--- a/pilota-build/src/tags.rs
+++ b/pilota-build/src/tags.rs
@@ -125,7 +125,38 @@ impl Annotation for PilotaName {
     const KEY: &'static str = "pilota.name";
 }
 
+#[derive(Debug)]
+pub struct RustType(pub smol_str::SmolStr);
+
+impl PartialEq<str> for RustType {
+    fn eq(&self, other: &str) -> bool {
+        &self.0 == other
+    }
+}
+
+impl FromStr for RustType {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(smol_str::SmolStr::new(s)))
+    }
+}
+
+impl Annotation for RustType {
+    const KEY: &'static str = "pilota.rust_type";
+}
+
 pub mod protobuf {
+
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    pub enum ProstType {
+        SInt32,
+        SInt64,
+        Fixed32,
+        Fixed64,
+        SFixed32,
+        SFixed64,
+    }
 
     new_type! {
         #[derive(Debug)]
@@ -135,14 +166,5 @@ pub mod protobuf {
 
         pub struct ClientStreaming;
         pub struct ServerStreaming;
-
-        pub struct SInt32;
-        pub struct SInt64;
-
-        pub struct Fixed32;
-        pub struct Fixed64;
-
-        pub struct SFixed32;
-        pub struct SFixed64;
     }
 }

--- a/pilota-build/test_data/protobuf/bytes_vec.proto
+++ b/pilota-build/test_data/protobuf/bytes_vec.proto
@@ -1,0 +1,3 @@
+message A {
+    optional bytes a = 1;
+}

--- a/pilota-build/test_data/protobuf/bytes_vec.rs
+++ b/pilota-build/test_data/protobuf/bytes_vec.rs
@@ -1,0 +1,15 @@
+pub mod bytes_vec {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::unused_unit,
+        clippy::needless_borrow,
+        unused_mut
+    )]
+    #[derive(PartialOrd, Hash, Eq, Ord, :: prost :: Message, Clone, PartialEq)]
+    pub struct A {
+        #[prost(bytes, tag = "1")]
+        pub a: ::std::vec::Vec<u8>,
+    }
+}

--- a/pilota-build/test_data/thrift/binary_bytes.rs
+++ b/pilota-build/test_data/thrift/binary_bytes.rs
@@ -1,0 +1,119 @@
+pub mod binary_bytes {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::unused_unit,
+        clippy::needless_borrow,
+        unused_mut
+    )]
+    pub mod binary_bytes {
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct A {
+            pub bytes: ::bytes::Bytes,
+        }
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for A {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::Error> {
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "A" };
+                protocol.write_struct_begin(&struct_ident)?;
+                {
+                    let value = &self.bytes;
+                    protocol.write_field_begin(::pilota::thrift::TType::String, 1i16)?;
+                    protocol.write_bytes(&value)?;
+                    protocol.write_field_end()?;
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut bytes = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            bytes = Some(::bytes::Bytes::from(protocol.read_bytes()?));
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                    protocol.read_field_end()?;
+                }
+                protocol.read_struct_end()?;
+                let bytes = if let Some(bytes) = bytes {
+                    bytes
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field bytes is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { bytes };
+                Ok(data)
+            }
+            async fn decode_async<C: ::tokio::io::AsyncRead + Unpin + Send>(
+                protocol: &mut ::pilota::thrift::TAsyncBinaryProtocol<C>,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut bytes = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            bytes = Some(::bytes::Bytes::from(protocol.read_bytes().await?));
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                    protocol.read_field_end().await?;
+                }
+                protocol.read_struct_end().await?;
+                let bytes = if let Some(bytes) = bytes {
+                    bytes
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field bytes is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { bytes };
+                Ok(data)
+            }
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &T) -> usize {
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "A" })
+                    + {
+                        let value = &self.bytes;
+                        protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
+                            name: Some("bytes"),
+                            field_type: ::pilota::thrift::TType::String,
+                            id: Some(1i16),
+                        }) + protocol.write_bytes_len(value)
+                            + protocol.write_field_end_len()
+                    }
+                    + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift/binary_bytes.thrift
+++ b/pilota-build/test_data/thrift/binary_bytes.thrift
@@ -1,0 +1,3 @@
+struct A {
+    1: required binary bytes(pilota.rust_type = "bytes"),
+}

--- a/pilota-build/test_data/thrift/binary_vec.rs
+++ b/pilota-build/test_data/thrift/binary_vec.rs
@@ -1,0 +1,119 @@
+pub mod binary_vec {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::unused_unit,
+        clippy::needless_borrow,
+        unused_mut
+    )]
+    pub mod binary_vec {
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct A {
+            pub bytes: ::std::vec::Vec<u8>,
+        }
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for A {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::Error> {
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "A" };
+                protocol.write_struct_begin(&struct_ident)?;
+                {
+                    let value = &self.bytes;
+                    protocol.write_field_begin(::pilota::thrift::TType::String, 1i16)?;
+                    protocol.write_bytes(&value)?;
+                    protocol.write_field_end()?;
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut bytes = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            bytes = Some(protocol.read_bytes()?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                    protocol.read_field_end()?;
+                }
+                protocol.read_struct_end()?;
+                let bytes = if let Some(bytes) = bytes {
+                    bytes
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field bytes is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { bytes };
+                Ok(data)
+            }
+            async fn decode_async<C: ::tokio::io::AsyncRead + Unpin + Send>(
+                protocol: &mut ::pilota::thrift::TAsyncBinaryProtocol<C>,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut bytes = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            bytes = Some(protocol.read_bytes().await?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                    protocol.read_field_end().await?;
+                }
+                protocol.read_struct_end().await?;
+                let bytes = if let Some(bytes) = bytes {
+                    bytes
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field bytes is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { bytes };
+                Ok(data)
+            }
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &T) -> usize {
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "A" })
+                    + {
+                        let value = &self.bytes;
+                        protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
+                            name: Some("bytes"),
+                            field_type: ::pilota::thrift::TType::String,
+                            id: Some(1i16),
+                        }) + protocol.write_bytes_len(value)
+                            + protocol.write_field_end_len()
+                    }
+                    + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift/binary_vec.thrift
+++ b/pilota-build/test_data/thrift/binary_vec.thrift
@@ -1,0 +1,3 @@
+struct A {
+    1: required binary bytes,
+}


### PR DESCRIPTION
## Motivation
feat: support bytes as binary type in thrift

## Solution
Generate 
```rust
struct A {
  a: ::bytes::Bytes,
}
```
for thrift idl
```thrift
struct A {
  1: required binary a(pilota.rust_type="bytes"),
}
```
