### PR TITLE
feat: support put client request in Arc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,19 +3,10 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.62"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "async-recursion"
@@ -30,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -71,9 +62,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
 ]
@@ -170,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -185,15 +176,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -260,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "oorandom"
@@ -303,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "petgraph"
@@ -420,9 +411,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -483,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
@@ -498,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "regex-syntax",
 ]
@@ -516,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -566,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -578,9 +569,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 
 [[package]]
 name = "sharded-slab"
@@ -599,9 +590,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol_str"
@@ -614,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -639,18 +630,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -668,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -680,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -692,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -703,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -724,12 +715,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
@@ -742,15 +733,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "valuable"
@@ -760,13 +751,13 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/pilota-build/src/ir/mod.rs
+++ b/pilota-build/src/ir/mod.rs
@@ -51,6 +51,7 @@ pub struct Arg {
     pub ty: Ty,
     pub name: Ident,
     pub id: i32,
+    pub tags: Arc<Tags>,
 }
 
 #[derive(Clone, Debug)]

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -70,8 +70,8 @@ impl Context {
     }
 
     pub fn node_tags(&self, def_id: DefId) -> Option<Arc<Tags>> {
-        let tag_id = self.node(def_id).unwrap().tags;
-        self.tags(tag_id)
+        let tags_id = self.node(def_id).unwrap().tags;
+        self.tags(tags_id)
     }
 
     pub fn contains_tag<T: 'static>(&self, tags_id: TagId) -> bool {

--- a/pilota-build/src/middle/rir.rs
+++ b/pilota-build/src/middle/rir.rs
@@ -21,6 +21,7 @@ pub struct Arg {
     pub ty: Ty,
     pub name: Ident,
     pub id: i32,
+    pub tags_id: TagId,
 }
 
 #[derive(Clone, Debug)]
@@ -72,6 +73,7 @@ pub struct Field {
     pub id: i32,
     pub ty: Ty,
     pub kind: FieldKind,
+    pub tags_id: TagId,
 }
 
 impl Field {

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -129,7 +129,7 @@ impl ToTokens for CodegenTy {
             }),
             CodegenTy::Arc(ty) => {
                 let ty = &**ty;
-                tokens.extend(quote!( ::alloc::sync::Arc<#ty> ))
+                tokens.extend(quote!( ::std::sync::Arc<#ty> ))
             }
             CodegenTy::LazyStaticRef(ty) => ty.to_tokens(tokens),
             CodegenTy::Bytes => tokens.extend(quote! { ::bytes::Bytes }),

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -356,6 +356,7 @@ impl Lower {
                                     m.input_type.as_deref(),
                                     &Default::default(),
                                 ),
+                                tags: Arc::new(Tags::default()),
                             }],
                             oneway: false,
                             ret: self.lower_ty(None, m.output_type.as_deref(), &Default::default()),

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -200,8 +200,22 @@ impl ThriftLower {
                 related_items.push(name);
                 result.push(self.mk_item(kind, Default::default()));
             }
+
             let name: Ident = format!(
-                "{}{}Args",
+                "{}{}ArgsSend",
+                service.name.to_upper_camel_case().as_str(),
+                method_name.to_upper_camel_case()
+            )
+            .into();
+            let kind = ir::ItemKind::Message(ir::Message {
+                name: name.clone(),
+                fields: f.arguments.iter().map(|a| self.lower_field(a)).collect(),
+            });
+            related_items.push(name);
+            result.push(self.mk_item(kind, Default::default()));
+
+            let name: Ident = format!(
+                "{}{}ArgsRecv",
                 service.name.to_upper_camel_case().as_str(),
                 method_name.to_upper_camel_case()
             )
@@ -233,6 +247,7 @@ impl ThriftLower {
                     ty: self.lower_ty(&a.ty),
                     id: a.id,
                     name: self.lower_ident(&a.name),
+                    tags: Arc::new(self.extract_tags(&a.annotations)),
                 })
                 .collect(),
             ret: self.lower_ty(&method.result_type),

--- a/pilota-build/test_data/thrift/req_arc.rs
+++ b/pilota-build/test_data/thrift/req_arc.rs
@@ -1,0 +1,460 @@
+pub mod req_arc {
+    #![allow(
+        unused_variables,
+        dead_code,
+        missing_docs,
+        clippy::unused_unit,
+        clippy::needless_borrow,
+        unused_mut
+    )]
+    pub mod req_arc {
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct Test {
+            pub id: ::std::string::String,
+        }
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for Test {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::Error> {
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "TEST" };
+                protocol.write_struct_begin(&struct_ident)?;
+                {
+                    let value = &self.id;
+                    protocol.write_field_begin(::pilota::thrift::TType::String, 1i16)?;
+                    protocol.write_string(value)?;
+                    protocol.write_field_end()?;
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut id = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            id = Some(protocol.read_string()?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                    protocol.read_field_end()?;
+                }
+                protocol.read_struct_end()?;
+                let id = if let Some(id) = id {
+                    id
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field id is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { id };
+                Ok(data)
+            }
+            async fn decode_async<C: ::tokio::io::AsyncRead + Unpin + Send>(
+                protocol: &mut ::pilota::thrift::TAsyncBinaryProtocol<C>,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut id = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::String => {
+                            id = Some(protocol.read_string().await?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                    protocol.read_field_end().await?;
+                }
+                protocol.read_struct_end().await?;
+                let id = if let Some(id) = id {
+                    id
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field id is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { id };
+                Ok(data)
+            }
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &T) -> usize {
+                protocol
+                    .write_struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "TEST" })
+                    + {
+                        let value = &self.id;
+                        protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
+                            name: Some("ID"),
+                            field_type: ::pilota::thrift::TType::String,
+                            id: Some(1i16),
+                        }) + protocol.write_string_len(&value)
+                            + protocol.write_field_end_len()
+                    }
+                    + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, :: pilota :: derivative :: Derivative)]
+        #[derivative(Default)]
+        #[derive(Clone, PartialEq)]
+        pub enum TestServiceTestResult {
+            #[derivative(Default)]
+            Ok(::std::string::String),
+        }
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for TestServiceTestResult {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::Error> {
+                protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestResult",
+                })?;
+                match self {
+                    TestServiceTestResult::Ok(ref value) => {
+                        protocol.write_field_begin(::pilota::thrift::TType::String, 0i16)?;
+                        protocol.write_string(value)?;
+                        protocol.write_field_end()?;
+                    }
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut ret = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(0i16) => {
+                            if ret.is_none() {
+                                ret = Some(TestServiceTestResult::Ok(protocol.read_string()?));
+                            } else {
+                                return Err(::pilota::thrift::new_protocol_error(
+                                    ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ));
+                            }
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                protocol.read_field_end()?;
+                protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Err(::pilota::thrift::new_protocol_error(
+                        ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+            async fn decode_async<C: ::tokio::io::AsyncRead + Unpin + Send>(
+                protocol: &mut ::pilota::thrift::TAsyncBinaryProtocol<C>,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut ret = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(0i16) => {
+                            if ret.is_none() {
+                                ret =
+                                    Some(TestServiceTestResult::Ok(protocol.read_string().await?));
+                            } else {
+                                return Err(::pilota::thrift::new_protocol_error(
+                                    ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ));
+                            }
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                }
+                protocol.read_field_end().await?;
+                protocol.read_struct_end().await?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Err(::pilota::thrift::new_protocol_error(
+                        ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &T) -> usize {
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestResult",
+                }) + match self {
+                    TestServiceTestResult::Ok(ref value) => {
+                        protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
+                            name: Some("Ok"),
+                            field_type: ::pilota::thrift::TType::String,
+                            id: Some(0i16),
+                        }) + protocol.write_string_len(&value)
+                            + protocol.write_field_end_len()
+                    }
+                } + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct TestServiceTestArgsSend {
+            pub req: ::std::sync::Arc<Test>,
+        }
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for TestServiceTestArgsSend {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::Error> {
+                let struct_ident = ::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestArgsSend",
+                };
+                protocol.write_struct_begin(&struct_ident)?;
+                {
+                    let value = &self.req;
+                    protocol.write_field_begin(::pilota::thrift::TType::Struct, 1i16)?;
+                    ::pilota::thrift::Message::encode(value, protocol)?;
+                    protocol.write_field_end()?;
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut req = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            req = Some(::pilota::thrift::Message::decode(protocol)?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                    protocol.read_field_end()?;
+                }
+                protocol.read_struct_end()?;
+                let req = if let Some(req) = req {
+                    req
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field req is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { req };
+                Ok(data)
+            }
+            async fn decode_async<C: ::tokio::io::AsyncRead + Unpin + Send>(
+                protocol: &mut ::pilota::thrift::TAsyncBinaryProtocol<C>,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut req = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            req = Some(::pilota::thrift::Message::decode_async(protocol).await?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                    protocol.read_field_end().await?;
+                }
+                protocol.read_struct_end().await?;
+                let req = if let Some(req) = req {
+                    req
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field req is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { req };
+                Ok(data)
+            }
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &T) -> usize {
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestArgsSend",
+                }) + {
+                    let value = &self.req;
+                    protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
+                        name: Some("req"),
+                        field_type: ::pilota::thrift::TType::Struct,
+                        id: Some(1i16),
+                    }) + ::pilota::thrift::Message::size(value, protocol)
+                        + protocol.write_field_end_len()
+                } + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct TestServiceTestArgsRecv {
+            pub req: Test,
+        }
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::Error> {
+                let struct_ident = ::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestArgsRecv",
+                };
+                protocol.write_struct_begin(&struct_ident)?;
+                {
+                    let value = &self.req;
+                    protocol.write_field_begin(::pilota::thrift::TType::Struct, 1i16)?;
+                    ::pilota::thrift::Message::encode(value, protocol)?;
+                    protocol.write_field_end()?;
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut req = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            req = Some(::pilota::thrift::Message::decode(protocol)?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                    protocol.read_field_end()?;
+                }
+                protocol.read_struct_end()?;
+                let req = if let Some(req) = req {
+                    req
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field req is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { req };
+                Ok(data)
+            }
+            async fn decode_async<C: ::tokio::io::AsyncRead + Unpin + Send>(
+                protocol: &mut ::pilota::thrift::TAsyncBinaryProtocol<C>,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
+                let mut req = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            req = Some(::pilota::thrift::Message::decode_async(protocol).await?);
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                    protocol.read_field_end().await?;
+                }
+                protocol.read_struct_end().await?;
+                let req = if let Some(req) = req {
+                    req
+                } else {
+                    return Err(::pilota::thrift::Error::Protocol(
+                        ::pilota::thrift::ProtocolError::new(
+                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
+                            "field req is required".to_string(),
+                        ),
+                    ));
+                };
+                let data = Self { req };
+                Ok(data)
+            }
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &T) -> usize {
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestArgsRecv",
+                }) + {
+                    let value = &self.req;
+                    protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
+                        name: Some("req"),
+                        field_type: ::pilota::thrift::TType::Struct,
+                        id: Some(1i16),
+                    }) + ::pilota::thrift::Message::size(value, protocol)
+                        + protocol.write_field_end_len()
+                } + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+        #[::async_trait::async_trait]
+        pub trait TestService {}
+    }
+}

--- a/pilota-build/test_data/thrift/req_arc.thrift
+++ b/pilota-build/test_data/thrift/req_arc.thrift
@@ -1,0 +1,7 @@
+struct TEST {
+    1: required string ID,
+}
+
+service TestService {
+    string test(1: TEST req(pilota.rust_type = "Arc"));
+}


### PR DESCRIPTION
## Motivation
Support client request type use Arc.
```thrift
struct TEST {
    1: required string ID,
}

service TestService {
    string test(1: TEST req(pilota.rust_type = "Arc"));
}
```