### PR TITLE
fix: change arc annotation name

### DIFF
--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -16,7 +16,7 @@ use crate::{
         ty::{AdtDef, AdtKind, CodegenTy},
     },
     symbol::{DefId, EnumRepr, IdentName},
-    tags::RustType,
+    tags::RustWrapperArc,
     Context,
 };
 
@@ -76,8 +76,10 @@ where
                 ty = quote::quote! { ::std::option::Option<#ty> }
             }
 
-            if let Some(rust_type) = tags.as_ref().and_then(|tags| tags.get::<RustType>()) {
-                if rust_type == "Arc" && s.name.to_string().contains("ArgsSend") {
+            if let Some(rust_wrapper_arc) =
+                tags.as_ref().and_then(|tags| tags.get::<RustWrapperArc>())
+            {
+                if rust_wrapper_arc == "true" && s.name.to_string().contains("ArgsSend") {
                     ty = quote::quote! { ::std::sync::Arc<#ty> }
                 }
             }

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -442,7 +442,7 @@ impl ThriftLower {
         }
 
         annotations.iter().for_each(
-            |annotation| with_tags!(annotation -> crate::tags::PilotaName | crate::tags::RustType),
+            |annotation| with_tags!(annotation -> crate::tags::PilotaName | crate::tags::RustType | crate::tags::RustWrapperArc),
         );
 
         tags

--- a/pilota-build/src/tags.rs
+++ b/pilota-build/src/tags.rs
@@ -146,6 +146,27 @@ impl Annotation for RustType {
     const KEY: &'static str = "pilota.rust_type";
 }
 
+#[derive(Debug)]
+pub struct RustWrapperArc(pub smol_str::SmolStr);
+
+impl PartialEq<str> for RustWrapperArc {
+    fn eq(&self, other: &str) -> bool {
+        &self.0 == other
+    }
+}
+
+impl FromStr for RustWrapperArc {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(smol_str::SmolStr::new(s)))
+    }
+}
+
+impl Annotation for RustWrapperArc {
+    const KEY: &'static str = "pilota.rust_wrapper_arc";
+}
+
 pub mod protobuf {
 
     #[derive(Copy, Clone, PartialEq, Eq)]

--- a/pilota-build/test_data/thrift/req_arc.thrift
+++ b/pilota-build/test_data/thrift/req_arc.thrift
@@ -3,5 +3,5 @@ struct TEST {
 }
 
 service TestService {
-    string test(1: TEST req(pilota.rust_type = "Arc"));
+    string test(1: TEST req(pilota.rust_wrapper_arc = "true"));
 }


### PR DESCRIPTION
## Motivation
Older:
```thrift
service TestService {
    string test(1: TEST req(pilota.rust_type = "arc"));
}
```
Newer:
```thrift
service TestService {
    string test(1: TEST req(pilota.rust_wrapper_arc = "true"));
}
```