### PR TITLE
feat: support struct field arc

### DIFF
--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -79,7 +79,7 @@ where
             if let Some(rust_wrapper_arc) =
                 tags.as_ref().and_then(|tags| tags.get::<RustWrapperArc>())
             {
-                if rust_wrapper_arc == "true" && s.name.to_string().contains("ArgsSend") {
+                if rust_wrapper_arc == "true" {
                     ty = quote::quote! { ::std::sync::Arc<#ty> }
                 }
             }

--- a/pilota-build/src/tags.rs
+++ b/pilota-build/src/tags.rs
@@ -32,6 +32,10 @@ impl TypeMap {
     pub fn contains<T: 'static>(&self) -> bool {
         self.0.contains_key(&TypeId::of::<T>())
     }
+
+    pub fn remove<T: 'static>(&mut self) {
+        self.0.remove(&TypeId::of::<T>());
+    }
 }
 
 crate::newtype_index!(pub struct TagId { .. });

--- a/pilota-build/test_data/thrift/req_arc.thrift
+++ b/pilota-build/test_data/thrift/req_arc.thrift
@@ -1,7 +1,0 @@
-struct TEST {
-    1: required string ID,
-}
-
-service TestService {
-    string test(1: TEST req(pilota.rust_wrapper_arc = "true"));
-}

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -1,4 +1,4 @@
-pub mod req_arc {
+pub mod wrapper_arc {
     #![allow(
         unused_variables,
         dead_code,
@@ -7,10 +7,10 @@ pub mod req_arc {
         clippy::needless_borrow,
         unused_mut
     )]
-    pub mod req_arc {
+    pub mod wrapper_arc {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Test {
-            pub id: ::std::string::String,
+            pub id: ::std::sync::Arc<::std::string::String>,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for Test {

--- a/pilota-build/test_data/thrift/wrapper_arc.thrift
+++ b/pilota-build/test_data/thrift/wrapper_arc.thrift
@@ -1,0 +1,7 @@
+struct TEST {
+    1: required string ID(pilota.rust_wrapper_arc="true"),
+}
+
+service TestService {
+    string test(1: TEST req(pilota.rust_wrapper_arc="true"));
+}


### PR DESCRIPTION
## Motivation
```Thrift
struct TEST {
    1: required string ID(pilota.rust_wrapper_arc="true"),
}
```
Generated code:
```Rust
pub struct Test {
    pub id: ::std::sync::Arc<::std::string::String>,
}
```