### PR TITLE
feat: support generate `Bytes` type for thrift string

### DIFF
--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -435,7 +435,7 @@ where
 
         quote! {
             pub mod #ns_name {
-                #![allow(unused_variables, dead_code, missing_docs, clippy::unused_unit, clippy::needless_borrow, unused_mut)]
+                #![allow(warnings, clippy::all)]
                 #stream
             }
         }

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -137,7 +137,7 @@ impl ToTokens for CodegenTy {
                 tokens.extend(quote!( ::std::sync::Arc<#ty> ))
             }
             CodegenTy::LazyStaticRef(ty) => ty.to_tokens(tokens),
-            CodegenTy::Bytes => tokens.extend(quote! { ::bytes::Bytes }),
+            CodegenTy::Bytes => tokens.extend(quote! { ::pilota::Bytes }),
         }
     }
 }
@@ -150,6 +150,11 @@ impl TyKind {
     pub(crate) fn to_codegen_const_ty(&self) -> CodegenTy {
         ConstTyTransformer.codegen_item_ty(self)
     }
+}
+
+pub enum StringRepr {
+    String,
+    Bytes,
 }
 
 pub trait TyTransformer {

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -17,6 +17,7 @@ use crate::{
     rir::Mod,
     symbol::{DefId, FileId, Ident, Symbol},
     tags::{TagId, Tags},
+    ty::StringRepr,
 };
 
 struct ModuleData {
@@ -356,6 +357,15 @@ impl Resolver {
 
     fn lower_type(&mut self, ty: &ir::Ty) -> Ty {
         let kind = match &ty.kind {
+            ir::TyKind::String
+                if ty
+                    .tags
+                    .get::<StringRepr>()
+                    .map(|repr| matches!(repr, StringRepr::Bytes))
+                    .unwrap_or(false) =>
+            {
+                ty::Bytes
+            }
             ir::TyKind::String => ty::String,
             ir::TyKind::Void => ty::Void,
             ir::TyKind::U8 => ty::U8,

--- a/pilota-build/test_data/must_gen_items.rs
+++ b/pilota-build/test_data/must_gen_items.rs
@@ -1,12 +1,5 @@
 pub mod must_gen_items {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod must_gen_items {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {

--- a/pilota-build/test_data/protobuf/bytes_vec.rs
+++ b/pilota-build/test_data/protobuf/bytes_vec.rs
@@ -1,15 +1,8 @@
 pub mod bytes_vec {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     #[derive(PartialOrd, Hash, Eq, Ord, :: prost :: Message, Clone, PartialEq)]
     pub struct A {
         #[prost(bytes, tag = "1")]
-        pub a: ::bytes::Bytes,
+        pub a: ::pilota::Bytes,
     }
 }

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -1,12 +1,5 @@
 pub mod nested_message {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod tt1 {
         pub mod t2 {
             #[derive(:: prost :: Message, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/binary_bytes.rs
+++ b/pilota-build/test_data/thrift/binary_bytes.rs
@@ -1,16 +1,9 @@
 pub mod binary_bytes {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod binary_bytes {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
-            pub bytes: ::bytes::Bytes,
+            pub bytes: ::pilota::Bytes,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for A {

--- a/pilota-build/test_data/thrift/binary_bytes.thrift
+++ b/pilota-build/test_data/thrift/binary_bytes.thrift
@@ -1,3 +1,3 @@
 struct A {
-    1: required binary bytes(pilota.rust_type = "bytes"),
+    1: required binary bytes,
 }

--- a/pilota-build/test_data/thrift/binary_vec.thrift
+++ b/pilota-build/test_data/thrift/binary_vec.thrift
@@ -1,3 +1,0 @@
-struct A {
-    1: required binary bytes,
-}

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -1,12 +1,5 @@
 pub mod const_val {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod const_val {
         impl ::std::convert::From<Index> for i32 {
             fn from(e: Index) -> Self {

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -1,12 +1,5 @@
 pub mod enum_test {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod enum_test {
         impl ::std::convert::From<Index> for i32 {
             fn from(e: Index) -> Self {

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -1,12 +1,5 @@
 pub mod normal {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod normal {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -1,12 +1,5 @@
 pub mod pilota_name {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod pilota_name {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Test2 {

--- a/pilota-build/test_data/thrift/recursive_type.rs
+++ b/pilota-build/test_data/thrift/recursive_type.rs
@@ -1,12 +1,5 @@
 pub mod recursive_type {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod recursive_type {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -1,12 +1,5 @@
 pub mod self_kw {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod self_kw {
         impl ::std::convert::From<Index> for i32 {
             fn from(e: Index) -> Self {

--- a/pilota-build/test_data/thrift/string_bytes.rs
+++ b/pilota-build/test_data/thrift/string_bytes.rs
@@ -1,16 +1,9 @@
-pub mod binary_vec {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
-    pub mod binary_vec {
+pub mod string_bytes {
+    #![allow(warnings, clippy::all)]
+    pub mod string_bytes {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
-            pub bytes: ::bytes::Bytes,
+            pub bytes: ::pilota::Bytes,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for A {

--- a/pilota-build/test_data/thrift/string_bytes.thrift
+++ b/pilota-build/test_data/thrift/string_bytes.thrift
@@ -1,0 +1,3 @@
+struct A {
+    1: required string bytes(pilota.rust_type = "bytes"),
+}

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -1,12 +1,5 @@
 pub mod wrapper_arc {
-    #![allow(
-        unused_variables,
-        dead_code,
-        missing_docs,
-        clippy::unused_unit,
-        clippy::needless_borrow,
-        unused_mut
-    )]
+    #![allow(warnings, clippy::all)]
     pub mod wrapper_arc {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Test {

--- a/pilota/src/lib.rs
+++ b/pilota/src/lib.rs
@@ -8,6 +8,7 @@ pub mod thrift;
 // reexport
 pub use async_recursion;
 pub use async_trait;
+pub use bytes::Bytes;
 pub use derivative;
 pub use lazy_static;
 pub use thiserror::Error as ThisError;

--- a/pilota/src/thrift/binary.rs
+++ b/pilota/src/thrift/binary.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Bytes, BytesMut};
 use linkedbytes::LinkedBytes;
 use tokio::io::{AsyncRead, AsyncReadExt};
 


### PR DESCRIPTION
```thrift
struct A {
    1: required string bytes(pilota.rust_type = "bytes"),
}
```
Generated:
```rust
pub struct A {
    pub bytes: ::pilota::Bytes,
}
```