### PR TITLE
feat: generate faststr for thrift string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "faststr"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30e8b7deaa08b8ce5efe5d91bf00eee3d20e5e327a1cac209d4f9b2f39f503f"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,18 +185,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "linkedbytes"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0703494cf80f30244b1a85c18fea20e4a4ba32d7d2799ffad1e7774303bf0c"
+checksum = "1eb697040b79d318dd14b4219e6764c72ac84b5b07836551ce35b6847427db09"
 dependencies = [
  "bytes",
- "smol_str",
+ "faststr",
  "tokio",
 ]
 
@@ -370,9 +379,9 @@ dependencies = [
  "async-trait",
  "bytes",
  "derivative",
+ "faststr",
  "lazy_static",
  "linkedbytes",
- "smol_str",
  "thiserror",
  "tokio",
 ]
@@ -384,6 +393,7 @@ dependencies = [
  "async-trait",
  "derivative",
  "diffy",
+ "faststr",
  "fxhash",
  "heck 0.4.0",
  "itertools",
@@ -400,7 +410,6 @@ dependencies = [
  "quote",
  "salsa",
  "scoped-tls",
- "smol_str",
  "syn",
  "tempfile",
  "tokio",
@@ -580,12 +589,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "serde"
-version = "1.0.148"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,19 +610,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "smol_str"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -671,14 +665,15 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
  "autocfg",
  "bytes",
  "memchr",
  "pin-project-lite",
+ "windows-sys",
 ]
 
 [[package]]
@@ -793,3 +788,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -20,7 +20,6 @@ maintenance = { status = "actively-developed" }
 pilota-thrift-parser = { path = "../pilota-thrift-parser", version = "0.4" }
 
 heck = "0.4"
-smol_str = "0.1"
 syn = "1"
 normpath = "0.3"
 fxhash = "0.2"
@@ -39,6 +38,7 @@ petgraph = "0.6"
 # We will switch to the official one when https://github.com/stepancheg/rust-protobuf/pull/646 is fixed.
 protobuf-parse = { package = "protobuf-parse2", version = "4.0.0-alpha.2" }
 protobuf = { package = "protobuf2", version = "4.0.0-alpha.2" }
+faststr = "0.1"
 
 [build-dependencies]
 itertools = "0.10"

--- a/pilota-build/src/codegen/pkg_tree.rs
+++ b/pilota-build/src/codegen/pkg_tree.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
 
+use faststr::FastStr;
 use itertools::Itertools;
 
 #[derive(Debug)]
 pub struct PkgNode {
-    pub path: Arc<[smol_str::SmolStr]>,
+    pub path: Arc<[FastStr]>,
     pub children: Arc<[PkgNode]>,
 }
 
-fn from_pkgs(base_path: &[smol_str::SmolStr], pkgs: &[Arc<[smol_str::SmolStr]>]) -> Arc<[PkgNode]> {
+fn from_pkgs(base_path: &[FastStr], pkgs: &[Arc<[FastStr]>]) -> Arc<[PkgNode]> {
     let groups = pkgs.iter().into_group_map_by(|p| p.first().unwrap());
 
     Arc::from_iter(groups.into_iter().map(|(k, v)| {
@@ -33,11 +34,11 @@ fn from_pkgs(base_path: &[smol_str::SmolStr], pkgs: &[Arc<[smol_str::SmolStr]>])
 }
 
 impl PkgNode {
-    pub fn from_pkgs(pkgs: &[Arc<[smol_str::SmolStr]>]) -> Arc<[PkgNode]> {
+    pub fn from_pkgs(pkgs: &[Arc<[FastStr]>]) -> Arc<[PkgNode]> {
         from_pkgs(&[], pkgs)
     }
 
-    pub fn ident(&self) -> smol_str::SmolStr {
+    pub fn ident(&self) -> FastStr {
         self.path.last().unwrap().clone()
     }
 }

--- a/pilota-build/src/codegen/protobuf/mod.rs
+++ b/pilota-build/src/codegen/protobuf/mod.rs
@@ -51,7 +51,7 @@ impl ProstPlugin {
             };
         }
         match &ty.kind {
-            ty::String | ty::SmolStr => quote!(string),
+            ty::String | ty::FastStr => quote!(string),
             ty::Bool => quote!(bool),
             ty::BytesVec | ty::Bytes => quote!(bytes),
             ty::I32 => quote!(int32),

--- a/pilota-build/src/codegen/thrift/decode_helper.rs
+++ b/pilota-build/src/codegen/thrift/decode_helper.rs
@@ -41,7 +41,7 @@ impl DecodeHelper {
     protocol_method!(read_bytes_vec);
     protocol_method!(read_byte);
     protocol_method!(read_string);
-    protocol_method!(read_smolstr);
+    protocol_method!(read_faststr);
     protocol_method!(read_list_begin);
     protocol_method!(read_list_end);
     protocol_method!(read_set_begin);

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -10,7 +10,7 @@ use crate::{
 impl ThriftBackend {
     pub(crate) fn ttype(&self, ty: &Ty) -> TokenStream {
         match &ty.kind {
-            ty::String | ty::SmolStr => quote! {::pilota::thrift::TType::Binary},
+            ty::String | ty::FastStr => quote! {::pilota::thrift::TType::Binary},
             ty::Void => quote! {::pilota::thrift::TType::Void},
             ty::U8 => quote! {::pilota::thrift::TType::I8},
             ty::Bool => quote! {::pilota::thrift::TType::Bool},
@@ -42,8 +42,8 @@ impl ThriftBackend {
 
     pub(crate) fn codegen_encode_ty(&self, ty: &Ty, ident: &Ident) -> TokenStream {
         match &ty.kind {
-            ty::String => quote! { protocol.write_string(#ident)?; },
-            ty::SmolStr => quote! { protocol.write_smolstr(#ident.clone())?; },
+            ty::String => quote! { protocol.write_string(&#ident)?; },
+            ty::FastStr => quote! { protocol.write_faststr(#ident.clone())?; },
             ty::Void => quote! {
                 protocol.write_struct_begin(&*::pilota::thrift::VOID_IDENT)?;
                 protocol.write_struct_end()?;
@@ -118,7 +118,7 @@ impl ThriftBackend {
     pub(crate) fn codegen_ty_size(&self, ty: &Ty, ident: &Ident) -> TokenStream {
         match &ty.kind {
             ty::String => quote! { protocol.write_string_len(&#ident) },
-            ty::SmolStr => quote! { protocol.write_smolstr_len(#ident) },
+            ty::FastStr => quote! { protocol.write_faststr_len(#ident) },
             ty::Void => {
                 quote! { protocol.write_struct_begin_len(&*::pilota::thrift::VOID_IDENT) +  protocol.write_struct_end_len() }
             }
@@ -206,7 +206,7 @@ impl ThriftBackend {
     pub(crate) fn codegen_decode_ty(&self, helper: &DecodeHelper, ty: &Ty) -> TokenStream {
         match &ty.kind {
             ty::String => helper.codegen_read_string(),
-            ty::SmolStr => helper.codegen_read_smolstr(),
+            ty::FastStr => helper.codegen_read_faststr(),
             ty::Void => {
                 let read_struct_begin = helper.codegen_read_struct_begin();
                 let read_struct_end = helper.codegen_read_struct_end();

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -185,7 +185,7 @@ impl Lower {
                 let mut s = String::new();
                 parent_messages.iter().for_each(|m| {
                     s.push_str(m);
-                    s.push_str(".")
+                    s.push('.')
                 });
                 s
             },
@@ -326,10 +326,10 @@ impl Lower {
         if nested_items.is_empty() {
             item
         } else {
-            let name = item.name().clone();
+            let name = item.name();
             nested_items.push(Arc::new(item));
             let mut tags = Tags::default();
-            tags.insert(PilotaName(name.0.mod_ident().clone()));
+            tags.insert(PilotaName(name.0.mod_ident()));
             Item {
                 related_items: Default::default(),
                 tags: Arc::from(tags),
@@ -404,7 +404,7 @@ impl Lower {
 
                 let file_id = *self.files.get(f.name()).unwrap();
 
-                let package = self.str2path(&f.package());
+                let package = self.str2path(f.package());
 
                 let enums = f.enum_type.iter().map(|e| self.lower_enum(e));
                 let messages = f
@@ -414,7 +414,7 @@ impl Lower {
                 let services = f.service.iter().map(|s| self.lower_service(s));
 
                 let f = Arc::from(ir::File {
-                    package: package.clone(),
+                    package,
                     uses: f
                         .dependency
                         .iter()

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -382,9 +382,7 @@ impl ThriftLower {
         if let Some(rust_type) = rust_type {
             if let thrift_parser::Ty::String = &ty {
                 let mut tags = Tags::default();
-                if rust_type == "bytes" {
-                    tags.insert(StringRepr::Bytes);
-                } else if rust_type == "string" {
+                if rust_type == "string" {
                     tags.insert(StringRepr::String)
                 }
                 return ir::Ty {
@@ -526,7 +524,7 @@ impl Lower<Arc<thrift_parser::File>> for ThriftLower {
                             .unwrap()
                             .trim_end_matches(".thrift")
                             .split('.')
-                            .map(|s| Ident::from(s))
+                            .map(Ident::from)
                             .collect_vec(),
                         this.lower_include(i),
                     )

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -357,17 +357,16 @@ impl Resolver {
 
     fn lower_type(&mut self, ty: &ir::Ty) -> Ty {
         let kind = match &ty.kind {
-            ir::TyKind::String => {
-                if let Some(repr) = ty.tags.get::<StringRepr>() {
-                    match repr {
-                        StringRepr::String => ty::String,
-                        StringRepr::Bytes => ty::Bytes,
-                        StringRepr::SmolStr => ty::SmolStr,
-                    }
-                } else {
-                    ty::SmolStr
-                }
+            ir::TyKind::String
+                if ty
+                    .tags
+                    .get::<StringRepr>()
+                    .map(|repr| matches!(repr, StringRepr::String))
+                    .unwrap_or(false) =>
+            {
+                ty::String
             }
+            ir::TyKind::String => ty::FastStr,
             ir::TyKind::Void => ty::Void,
             ir::TyKind::U8 => ty::U8,
             ir::TyKind::Bool => ty::Bool,

--- a/pilota-build/src/symbol.rs
+++ b/pilota-build/src/symbol.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Display, ops::Deref};
 
+use faststr::FastStr;
 use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use phf::phf_set;
 use quote::{format_ident, IdentFragment};
@@ -74,7 +75,7 @@ lazy_static::lazy_static! {
 }
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
-pub struct Symbol(pub smol_str::SmolStr);
+pub struct Symbol(pub FastStr);
 
 impl std::borrow::Borrow<str> for Symbol {
     fn borrow(&self) -> &str {
@@ -92,7 +93,7 @@ impl Deref for Symbol {
 
 impl<T> From<T> for Symbol
 where
-    T: Into<smol_str::SmolStr>,
+    T: Into<FastStr>,
 {
     fn from(t: T) -> Self {
         Symbol(t.into())
@@ -153,7 +154,7 @@ impl Display for Ident {
 
 impl<T> From<T> for Ident
 where
-    T: Into<smol_str::SmolStr>,
+    T: Into<FastStr>,
 {
     fn from(t: T) -> Self {
         Ident {
@@ -163,42 +164,42 @@ where
 }
 
 pub trait IdentName {
-    fn struct_ident(&self) -> smol_str::SmolStr {
+    fn struct_ident(&self) -> FastStr {
         self.upper_camel_ident()
     }
 
-    fn enum_ident(&self) -> smol_str::SmolStr {
+    fn enum_ident(&self) -> FastStr {
         self.upper_camel_ident()
     }
 
-    fn mod_ident(&self) -> smol_str::SmolStr {
+    fn mod_ident(&self) -> FastStr {
         self.snake_ident()
     }
 
-    fn variant_ident(&self) -> smol_str::SmolStr {
+    fn variant_ident(&self) -> FastStr {
         self.upper_camel_ident()
     }
-    fn fn_ident(&self) -> smol_str::SmolStr {
+    fn fn_ident(&self) -> FastStr {
         self.snake_ident()
     }
-    fn field_ident(&self) -> smol_str::SmolStr {
+    fn field_ident(&self) -> FastStr {
         self.snake_ident()
     }
-    fn const_ident(&self) -> smol_str::SmolStr {
+    fn const_ident(&self) -> FastStr {
         self.shouty_snake_case()
     }
 
-    fn trait_ident(&self) -> smol_str::SmolStr {
+    fn trait_ident(&self) -> FastStr {
         self.upper_camel_ident()
     }
 
-    fn newtype_ident(&self) -> smol_str::SmolStr {
+    fn newtype_ident(&self) -> FastStr {
         self.upper_camel_ident()
     }
 
-    fn upper_camel_ident(&self) -> smol_str::SmolStr;
-    fn snake_ident(&self) -> smol_str::SmolStr;
-    fn shouty_snake_case(&self) -> smol_str::SmolStr;
+    fn upper_camel_ident(&self) -> FastStr;
+    fn snake_ident(&self) -> FastStr;
+    fn shouty_snake_case(&self) -> FastStr;
 
     fn as_syn_ident(&self) -> syn::Ident;
 }
@@ -215,16 +216,16 @@ fn str2ident(s: &str) -> syn::Ident {
 }
 
 impl IdentName for &str {
-    fn upper_camel_ident(&self) -> smol_str::SmolStr {
+    fn upper_camel_ident(&self) -> FastStr {
         let s = self.to_upper_camel_case();
         s.into()
     }
 
-    fn snake_ident(&self) -> smol_str::SmolStr {
+    fn snake_ident(&self) -> FastStr {
         self.to_snake_case().into()
     }
 
-    fn shouty_snake_case(&self) -> smol_str::SmolStr {
+    fn shouty_snake_case(&self) -> FastStr {
         self.to_shouty_snake_case().into()
     }
 
@@ -233,16 +234,16 @@ impl IdentName for &str {
     }
 }
 
-impl IdentName for smol_str::SmolStr {
-    fn upper_camel_ident(&self) -> smol_str::SmolStr {
+impl IdentName for FastStr {
+    fn upper_camel_ident(&self) -> FastStr {
         (&**self).upper_camel_ident()
     }
 
-    fn snake_ident(&self) -> smol_str::SmolStr {
+    fn snake_ident(&self) -> FastStr {
         (&**self).snake_ident()
     }
 
-    fn shouty_snake_case(&self) -> smol_str::SmolStr {
+    fn shouty_snake_case(&self) -> FastStr {
         (&**self).shouty_snake_case()
     }
 

--- a/pilota-build/src/tags.rs
+++ b/pilota-build/src/tags.rs
@@ -7,6 +7,8 @@ use std::{
     str::FromStr,
 };
 
+use faststr::FastStr;
+
 #[derive(Default, Debug)]
 pub struct TypeMap(HashMap<TypeId, Box<dyn Any + Sync + Send>>);
 
@@ -111,7 +113,7 @@ pub mod thrift {
 }
 
 #[derive(Clone)]
-pub struct PilotaName(pub smol_str::SmolStr);
+pub struct PilotaName(pub FastStr);
 
 pub trait Annotation: FromStr {
     const KEY: &'static str;
@@ -121,7 +123,7 @@ impl FromStr for PilotaName {
     type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(smol_str::SmolStr::new(s)))
+        Ok(Self(FastStr::new(s)))
     }
 }
 
@@ -130,11 +132,11 @@ impl Annotation for PilotaName {
 }
 
 #[derive(Debug)]
-pub struct RustType(pub smol_str::SmolStr);
+pub struct RustType(pub FastStr);
 
 impl PartialEq<str> for RustType {
     fn eq(&self, other: &str) -> bool {
-        &self.0 == other
+        self.0 == other
     }
 }
 
@@ -142,7 +144,7 @@ impl FromStr for RustType {
     type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(smol_str::SmolStr::new(s)))
+        Ok(Self(FastStr::new(s)))
     }
 }
 
@@ -151,11 +153,11 @@ impl Annotation for RustType {
 }
 
 #[derive(Debug)]
-pub struct RustWrapperArc(pub smol_str::SmolStr);
+pub struct RustWrapperArc(pub FastStr);
 
 impl PartialEq<str> for RustWrapperArc {
     fn eq(&self, other: &str) -> bool {
-        &self.0 == other
+        self.0 == other
     }
 }
 
@@ -163,7 +165,7 @@ impl FromStr for RustWrapperArc {
     type Err = std::convert::Infallible;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(smol_str::SmolStr::new(s)))
+        Ok(Self(FastStr::new(s)))
     }
 }
 

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -3,7 +3,7 @@ pub mod pilota_name {
     pub mod pilota_name {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Test2 {
-            pub id: ::pilota::SmolStr,
+            pub id: ::pilota::FastStr,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for Test2 {
@@ -16,7 +16,7 @@ pub mod pilota_name {
                 {
                     let value = &self.id;
                     protocol.write_field_begin(::pilota::thrift::TType::Binary, 1i16)?;
-                    protocol.write_smolstr(value.clone())?;
+                    protocol.write_faststr(value.clone())?;
                     protocol.write_field_end()?;
                 }
                 protocol.write_field_stop()?;
@@ -36,7 +36,7 @@ pub mod pilota_name {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            id = Some(protocol.read_smolstr()?);
+                            id = Some(protocol.read_faststr()?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type)?;
@@ -71,7 +71,7 @@ pub mod pilota_name {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            id = Some(protocol.read_smolstr().await?);
+                            id = Some(protocol.read_faststr().await?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type).await?;
@@ -102,7 +102,7 @@ pub mod pilota_name {
                             name: Some("ID"),
                             field_type: ::pilota::thrift::TType::Binary,
                             id: Some(1i16),
-                        }) + protocol.write_smolstr_len(value)
+                        }) + protocol.write_faststr_len(value)
                             + protocol.write_field_end_len()
                     }
                     + protocol.write_field_stop_len()
@@ -112,8 +112,8 @@ pub mod pilota_name {
         pub const LANG_ID: &'static str = "id";
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Test1 {
-            pub id: ::pilota::SmolStr,
-            pub hello: ::pilota::SmolStr,
+            pub id: ::pilota::FastStr,
+            pub hello: ::pilota::FastStr,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for Test1 {
@@ -126,13 +126,13 @@ pub mod pilota_name {
                 {
                     let value = &self.id;
                     protocol.write_field_begin(::pilota::thrift::TType::Binary, 1i16)?;
-                    protocol.write_smolstr(value.clone())?;
+                    protocol.write_faststr(value.clone())?;
                     protocol.write_field_end()?;
                 }
                 {
                     let value = &self.hello;
                     protocol.write_field_begin(::pilota::thrift::TType::Binary, 2i16)?;
-                    protocol.write_smolstr(value.clone())?;
+                    protocol.write_faststr(value.clone())?;
                     protocol.write_field_end()?;
                 }
                 protocol.write_field_stop()?;
@@ -153,10 +153,10 @@ pub mod pilota_name {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            id = Some(protocol.read_smolstr()?);
+                            id = Some(protocol.read_faststr()?);
                         }
                         Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            hello = Some(protocol.read_smolstr()?);
+                            hello = Some(protocol.read_faststr()?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type)?;
@@ -205,10 +205,10 @@ pub mod pilota_name {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            id = Some(protocol.read_smolstr().await?);
+                            id = Some(protocol.read_faststr().await?);
                         }
                         Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            hello = Some(protocol.read_smolstr().await?);
+                            hello = Some(protocol.read_faststr().await?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type).await?;
@@ -252,7 +252,7 @@ pub mod pilota_name {
                             name: Some("ID"),
                             field_type: ::pilota::thrift::TType::Binary,
                             id: Some(1i16),
-                        }) + protocol.write_smolstr_len(value)
+                        }) + protocol.write_faststr_len(value)
                             + protocol.write_field_end_len()
                     }
                     + {
@@ -261,7 +261,7 @@ pub mod pilota_name {
                             name: Some("Id"),
                             field_type: ::pilota::thrift::TType::Binary,
                             id: Some(2i16),
-                        }) + protocol.write_smolstr_len(value)
+                        }) + protocol.write_faststr_len(value)
                             + protocol.write_field_end_len()
                     }
                     + protocol.write_field_stop_len()

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -68,7 +68,7 @@ pub mod self_kw {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
-            pub r#type: ::pilota::SmolStr,
+            pub r#type: ::pilota::FastStr,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for A {
@@ -81,7 +81,7 @@ pub mod self_kw {
                 {
                     let value = &self.r#type;
                     protocol.write_field_begin(::pilota::thrift::TType::Binary, 1i16)?;
-                    protocol.write_smolstr(value.clone())?;
+                    protocol.write_faststr(value.clone())?;
                     protocol.write_field_end()?;
                 }
                 protocol.write_field_stop()?;
@@ -101,7 +101,7 @@ pub mod self_kw {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            r#type = Some(protocol.read_smolstr()?);
+                            r#type = Some(protocol.read_faststr()?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type)?;
@@ -136,7 +136,7 @@ pub mod self_kw {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            r#type = Some(protocol.read_smolstr().await?);
+                            r#type = Some(protocol.read_faststr().await?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type).await?;
@@ -166,7 +166,7 @@ pub mod self_kw {
                             name: Some("type"),
                             field_type: ::pilota::thrift::TType::Binary,
                             id: Some(1i16),
-                        }) + protocol.write_smolstr_len(value)
+                        }) + protocol.write_faststr_len(value)
                             + protocol.write_field_end_len()
                     }
                     + protocol.write_field_stop_len()

--- a/pilota-build/test_data/thrift/string.rs
+++ b/pilota-build/test_data/thrift/string.rs
@@ -1,10 +1,9 @@
-pub mod string_bytes {
+pub mod string {
     #![allow(warnings, clippy::all)]
-    pub mod string_bytes {
+    pub mod string {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
-            pub smol: ::pilota::SmolStr,
-            pub bytes: ::pilota::Bytes,
+            pub faststr: ::pilota::FastStr,
             pub string: ::std::string::String,
         }
         #[::async_trait::async_trait]
@@ -16,21 +15,15 @@ pub mod string_bytes {
                 let struct_ident = ::pilota::thrift::TStructIdentifier { name: "A" };
                 protocol.write_struct_begin(&struct_ident)?;
                 {
-                    let value = &self.smol;
+                    let value = &self.faststr;
                     protocol.write_field_begin(::pilota::thrift::TType::Binary, 1i16)?;
-                    protocol.write_smolstr(value.clone())?;
-                    protocol.write_field_end()?;
-                }
-                {
-                    let value = &self.bytes;
-                    protocol.write_field_begin(::pilota::thrift::TType::Binary, 2i16)?;
-                    protocol.write_bytes(value.clone())?;
+                    protocol.write_faststr(value.clone())?;
                     protocol.write_field_end()?;
                 }
                 {
                     let value = &self.string;
-                    protocol.write_field_begin(::pilota::thrift::TType::Binary, 3i16)?;
-                    protocol.write_string(value)?;
+                    protocol.write_field_begin(::pilota::thrift::TType::Binary, 2i16)?;
+                    protocol.write_string(&value)?;
                     protocol.write_field_end()?;
                 }
                 protocol.write_field_stop()?;
@@ -40,8 +33,7 @@ pub mod string_bytes {
             fn decode<T: ::pilota::thrift::TInputProtocol>(
                 protocol: &mut T,
             ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
-                let mut smol = None;
-                let mut bytes = None;
+                let mut faststr = None;
                 let mut string = None;
                 protocol.read_struct_begin()?;
                 loop {
@@ -52,12 +44,9 @@ pub mod string_bytes {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            smol = Some(protocol.read_smolstr()?);
+                            faststr = Some(protocol.read_faststr()?);
                         }
                         Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            bytes = Some(protocol.read_bytes()?);
-                        }
-                        Some(3i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
                             string = Some(protocol.read_string()?);
                         }
                         _ => {
@@ -67,23 +56,13 @@ pub mod string_bytes {
                     protocol.read_field_end()?;
                 }
                 protocol.read_struct_end()?;
-                let smol = if let Some(smol) = smol {
-                    smol
+                let faststr = if let Some(faststr) = faststr {
+                    faststr
                 } else {
                     return Err(::pilota::thrift::Error::Protocol(
                         ::pilota::thrift::ProtocolError::new(
                             ::pilota::thrift::ProtocolErrorKind::InvalidData,
-                            "field smol is required".to_string(),
-                        ),
-                    ));
-                };
-                let bytes = if let Some(bytes) = bytes {
-                    bytes
-                } else {
-                    return Err(::pilota::thrift::Error::Protocol(
-                        ::pilota::thrift::ProtocolError::new(
-                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
-                            "field bytes is required".to_string(),
+                            "field faststr is required".to_string(),
                         ),
                     ));
                 };
@@ -98,8 +77,7 @@ pub mod string_bytes {
                     ));
                 };
                 let data = Self {
-                    smol: smol,
-                    bytes: bytes,
+                    faststr: faststr,
                     string: string,
                 };
                 Ok(data)
@@ -107,8 +85,7 @@ pub mod string_bytes {
             async fn decode_async<C: ::tokio::io::AsyncRead + Unpin + Send>(
                 protocol: &mut ::pilota::thrift::TAsyncBinaryProtocol<C>,
             ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
-                let mut smol = None;
-                let mut bytes = None;
+                let mut faststr = None;
                 let mut string = None;
                 protocol.read_struct_begin().await?;
                 loop {
@@ -119,12 +96,9 @@ pub mod string_bytes {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            smol = Some(protocol.read_smolstr().await?);
+                            faststr = Some(protocol.read_faststr().await?);
                         }
                         Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            bytes = Some(protocol.read_bytes().await?);
-                        }
-                        Some(3i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
                             string = Some(protocol.read_string().await?);
                         }
                         _ => {
@@ -134,23 +108,13 @@ pub mod string_bytes {
                     protocol.read_field_end().await?;
                 }
                 protocol.read_struct_end().await?;
-                let smol = if let Some(smol) = smol {
-                    smol
+                let faststr = if let Some(faststr) = faststr {
+                    faststr
                 } else {
                     return Err(::pilota::thrift::Error::Protocol(
                         ::pilota::thrift::ProtocolError::new(
                             ::pilota::thrift::ProtocolErrorKind::InvalidData,
-                            "field smol is required".to_string(),
-                        ),
-                    ));
-                };
-                let bytes = if let Some(bytes) = bytes {
-                    bytes
-                } else {
-                    return Err(::pilota::thrift::Error::Protocol(
-                        ::pilota::thrift::ProtocolError::new(
-                            ::pilota::thrift::ProtocolErrorKind::InvalidData,
-                            "field bytes is required".to_string(),
+                            "field faststr is required".to_string(),
                         ),
                     ));
                 };
@@ -165,8 +129,7 @@ pub mod string_bytes {
                     ));
                 };
                 let data = Self {
-                    smol: smol,
-                    bytes: bytes,
+                    faststr: faststr,
                     string: string,
                 };
                 Ok(data)
@@ -174,21 +137,12 @@ pub mod string_bytes {
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "A" })
                     + {
-                        let value = &self.smol;
+                        let value = &self.faststr;
                         protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
-                            name: Some("smol"),
+                            name: Some("faststr"),
                             field_type: ::pilota::thrift::TType::Binary,
                             id: Some(1i16),
-                        }) + protocol.write_smolstr_len(value)
-                            + protocol.write_field_end_len()
-                    }
-                    + {
-                        let value = &self.bytes;
-                        protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
-                            name: Some("bytes"),
-                            field_type: ::pilota::thrift::TType::Binary,
-                            id: Some(2i16),
-                        }) + protocol.write_bytes_len(value)
+                        }) + protocol.write_faststr_len(value)
                             + protocol.write_field_end_len()
                     }
                     + {
@@ -196,7 +150,7 @@ pub mod string_bytes {
                         protocol.write_field_begin_len(&::pilota::thrift::TFieldIdentifier {
                             name: Some("string"),
                             field_type: ::pilota::thrift::TType::Binary,
-                            id: Some(3i16),
+                            id: Some(2i16),
                         }) + protocol.write_string_len(&value)
                             + protocol.write_field_end_len()
                     }

--- a/pilota-build/test_data/thrift/string.thrift
+++ b/pilota-build/test_data/thrift/string.thrift
@@ -1,0 +1,4 @@
+struct A {
+    1: required string faststr,
+    2: required string string(pilota.rust_type = "string"),
+}

--- a/pilota-build/test_data/thrift/string_bytes.thrift
+++ b/pilota-build/test_data/thrift/string_bytes.thrift
@@ -1,5 +1,0 @@
-struct A {
-    1: required string smol,
-    2: required string bytes(pilota.rust_type = "bytes"),
-    3: required string string(pilota.rust_type = "string"),
-}

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -3,7 +3,7 @@ pub mod wrapper_arc {
     pub mod wrapper_arc {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Test {
-            pub id: ::std::sync::Arc<::pilota::SmolStr>,
+            pub id: ::std::sync::Arc<::pilota::FastStr>,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for Test {
@@ -16,7 +16,7 @@ pub mod wrapper_arc {
                 {
                     let value = &self.id;
                     protocol.write_field_begin(::pilota::thrift::TType::Binary, 1i16)?;
-                    protocol.write_smolstr(value.clone())?;
+                    protocol.write_faststr(value.clone())?;
                     protocol.write_field_end()?;
                 }
                 protocol.write_field_stop()?;
@@ -36,7 +36,7 @@ pub mod wrapper_arc {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            id = Some(protocol.read_smolstr()?);
+                            id = Some(protocol.read_faststr()?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type)?;
@@ -71,7 +71,7 @@ pub mod wrapper_arc {
                     let field_id = field_ident.id;
                     match field_id {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
-                            id = Some(protocol.read_smolstr().await?);
+                            id = Some(protocol.read_faststr().await?);
                         }
                         _ => {
                             protocol.skip(field_ident.field_type).await?;
@@ -102,7 +102,7 @@ pub mod wrapper_arc {
                             name: Some("ID"),
                             field_type: ::pilota::thrift::TType::Binary,
                             id: Some(1i16),
-                        }) + protocol.write_smolstr_len(value)
+                        }) + protocol.write_faststr_len(value)
                             + protocol.write_field_end_len()
                     }
                     + protocol.write_field_stop_len()
@@ -114,7 +114,7 @@ pub mod wrapper_arc {
         #[derive(Clone, PartialEq)]
         pub enum TestServiceTestResult {
             #[derivative(Default)]
-            Ok(::pilota::SmolStr),
+            Ok(::pilota::FastStr),
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for TestServiceTestResult {
@@ -128,7 +128,7 @@ pub mod wrapper_arc {
                 match self {
                     TestServiceTestResult::Ok(ref value) => {
                         protocol.write_field_begin(::pilota::thrift::TType::Binary, 0i16)?;
-                        protocol.write_smolstr(value.clone())?;
+                        protocol.write_faststr(value.clone())?;
                         protocol.write_field_end()?;
                     }
                 }
@@ -150,7 +150,7 @@ pub mod wrapper_arc {
                     match field_id {
                         Some(0i16) => {
                             if ret.is_none() {
-                                ret = Some(TestServiceTestResult::Ok(protocol.read_smolstr()?));
+                                ret = Some(TestServiceTestResult::Ok(protocol.read_faststr()?));
                             } else {
                                 return Err(::pilota::thrift::new_protocol_error(
                                     ::pilota::thrift::ProtocolErrorKind::InvalidData,
@@ -189,7 +189,7 @@ pub mod wrapper_arc {
                         Some(0i16) => {
                             if ret.is_none() {
                                 ret =
-                                    Some(TestServiceTestResult::Ok(protocol.read_smolstr().await?));
+                                    Some(TestServiceTestResult::Ok(protocol.read_faststr().await?));
                             } else {
                                 return Err(::pilota::thrift::new_protocol_error(
                                     ::pilota::thrift::ProtocolErrorKind::InvalidData,
@@ -222,7 +222,7 @@ pub mod wrapper_arc {
                             name: Some("Ok"),
                             field_type: ::pilota::thrift::TType::Binary,
                             id: Some(0i16),
-                        }) + protocol.write_smolstr_len(value)
+                        }) + protocol.write_faststr_len(value)
                             + protocol.write_field_end_len()
                     }
                 } + protocol.write_field_stop_len()

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -23,8 +23,8 @@ async-trait = "0.1"
 async-recursion = "1"
 tokio = { version = "1", features = ["io-util"] }
 lazy_static = "1"
-linkedbytes = { version = "0.1", features = ["smolstr"] }
+linkedbytes = { version = "0.1", features = ["faststr"] }
 derivative = "2"
 anyhow = "1"
 thiserror = "1"
-smol_str = "0.1"
+faststr = "0.1"

--- a/pilota/src/lib.rs
+++ b/pilota/src/lib.rs
@@ -10,8 +10,8 @@ pub use async_recursion;
 pub use async_trait;
 pub use bytes::Bytes;
 pub use derivative;
+pub use faststr::FastStr;
 pub use lazy_static;
-pub use smol_str::SmolStr;
 pub use thiserror::Error as ThisError;
 pub use tokio::io::AsyncRead;
 


### PR DESCRIPTION
## Motivation
```thrift
struct A {
    1: required string faststr,
    2: required string string(pilota.rust_type = "string"),
}
```
Generated:
```Rust
pub struct A {
    pub faststr: ::pilota::FastStr,
    pub string: ::std::string::String,
}
```