### PR TITLE
fix: misuse of array type in a hashmap

### DIFF
--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -383,6 +383,10 @@ where
                 let stream = els.iter().map(|el| self.lit_into_ty(el, inner));
                 quote! { [#(#stream),*] }
             }
+            (Literal::List(els), CodegenTy::Vec(inner)) => {
+                let stream = els.iter().map(|el| self.lit_into_ty(el, inner));
+                quote! { ::std::vec![#(#stream),*] }
+            }
             _ => panic!("unexpected literal {:?} with ty {:?}", lit, ty),
         }
     }

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -303,6 +303,17 @@ impl TyTransformer for DefaultTyTransformer {}
 
 pub(crate) struct ConstTyTransformer;
 
+impl ConstTyTransformer {
+    #[inline]
+    fn dyn_codegen_item_ty(&self, kind: &TyKind) -> CodegenTy {
+        let mut ty = self.codegen_item_ty(&kind);
+        if let CodegenTy::Array(_inner, _) = ty {
+            ty = CodegenTy::Vec(_inner);
+        }
+        ty
+    }
+}
+
 impl TyTransformer for ConstTyTransformer {
     #[inline]
     fn string(&self) -> CodegenTy {
@@ -322,14 +333,14 @@ impl TyTransformer for ConstTyTransformer {
     #[inline]
     fn set(&self, ty: &Ty) -> CodegenTy {
         CodegenTy::StaticRef(Arc::from(CodegenTy::Set(Arc::from(
-            self.codegen_item_ty(&ty.kind),
+            self.dyn_codegen_item_ty(&ty.kind),
         ))))
     }
 
     #[inline]
     fn map(&self, key: &Ty, value: &Ty) -> CodegenTy {
-        let key = self.codegen_item_ty(&key.kind);
-        let value = self.codegen_item_ty(&value.kind);
+        let key = self.dyn_codegen_item_ty(&key.kind);
+        let value = self.dyn_codegen_item_ty(&value.kind);
         CodegenTy::StaticRef(Arc::from(CodegenTy::Map(Arc::from(key), Arc::from(value))))
     }
 }

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -70,5 +70,6 @@ pub mod const_val {
         }
         ::pilota::lazy_static::lazy_static! { pub static ref TEST_MAP : :: std :: collections :: HashMap < Index , & 'static str > = { let mut map = :: std :: collections :: HashMap :: with_capacity (2usize) ; map . insert (Index :: A , "hello") ; map . insert (Index :: B , "world") ; map } ; }
         pub const TEST_LIST: [&'static str; 2usize] = ["hello", "world"];
+        ::pilota::lazy_static::lazy_static! { pub static ref TEST_MAP_LIST : :: std :: collections :: HashMap < i32 , :: std :: vec :: Vec < & 'static str > > = { let mut map = :: std :: collections :: HashMap :: with_capacity (1usize) ; map . insert (1i32 , :: std :: vec ! ["hello"]) ; map } ; }
     }
 }

--- a/pilota-build/test_data/thrift/const_val.thrift
+++ b/pilota-build/test_data/thrift/const_val.thrift
@@ -13,3 +13,8 @@ const list<string> TEST_LIST = [
     "hello",
     "world",
 ];
+
+
+const map<i32, list<string>> TEST_MAP_LIST = {
+    1: ["hello"]
+}


### PR DESCRIPTION
## Motivation
fix: misuse of array type in a hashmap
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
