### PR TITLE
fix: newtype write_bytes with mismatched input type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "derivative",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -435,7 +435,7 @@ impl CodegenBackend for ThriftBackend {
         t: &NewType,
     ) {
         let name = self.rust_name(def_id).as_syn_ident();
-        let encode = self.codegen_encode_ty(&t.ty, &quote!(&**self));
+        let encode = self.codegen_encode_ty(&t.ty, &quote!((&**self)));
         let encode_size = self.codegen_ty_size(&t.ty, &quote! { &**self });
 
         stream.extend(self.codegen_impl_message_with_helper(

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -135,7 +135,7 @@ pub mod serde {
                 protocol: &mut T,
             ) -> ::std::result::Result<(), ::pilota::thrift::Error> {
                 use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_i32(*&**self)?;
+                protocol.write_i32(*(&**self))?;
                 Ok(())
             }
             fn decode<T: ::pilota::thrift::TInputProtocol>(


### PR DESCRIPTION
change `&**self.clone()` to `(&**self).clone()`
