### PR TITLE
feat: support generate Vec<u8> for thrift binary

### DIFF
--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -297,6 +297,11 @@ pub enum StringRepr {
     String,
 }
 
+pub enum BytesRepr {
+    Vec,
+    Bytes,
+}
+
 pub(crate) struct DefaultTyTransformer;
 
 impl TyTransformer for DefaultTyTransformer {}

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -17,7 +17,7 @@ use crate::{
     rir::Mod,
     symbol::{DefId, FileId, Ident, Symbol},
     tags::{RustWrapperArc, TagId, Tags},
-    ty::{Folder, StringRepr, TyKind},
+    ty::{BytesRepr, Folder, StringRepr, TyKind},
 };
 
 struct ModuleData {
@@ -401,6 +401,15 @@ impl Resolver {
             ir::TyKind::Void => ty::Void,
             ir::TyKind::U8 => ty::U8,
             ir::TyKind::Bool => ty::Bool,
+            ir::TyKind::Bytes
+                if ty
+                    .tags
+                    .get::<BytesRepr>()
+                    .map(|repr| matches!(repr, BytesRepr::Vec))
+                    .unwrap_or(false) =>
+            {
+                ty::BytesVec
+            }
             ir::TyKind::Bytes => ty::Bytes,
             ir::TyKind::I8 => ty::I8,
             ir::TyKind::I16 => ty::I16,

--- a/pilota-build/test_data/thrift/binary_bytes.rs
+++ b/pilota-build/test_data/thrift/binary_bytes.rs
@@ -4,6 +4,7 @@ pub mod binary_bytes {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
             pub bytes: ::pilota::Bytes,
+            pub vec: ::std::vec::Vec<u8>,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for A {
@@ -15,6 +16,7 @@ pub mod binary_bytes {
                 let struct_ident = ::pilota::thrift::TStructIdentifier { name: "A" };
                 protocol.write_struct_begin(&struct_ident)?;
                 protocol.write_bytes_field(1i16, (&self.bytes).clone())?;
+                protocol.write_bytes_vec_field(2i16, &&self.vec)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
                 Ok(())
@@ -23,6 +25,7 @@ pub mod binary_bytes {
                 protocol: &mut T,
             ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
                 let mut bytes = None;
+                let mut vec = None;
                 protocol.read_struct_begin()?;
                 loop {
                     let field_ident = protocol.read_field_begin()?;
@@ -34,6 +37,9 @@ pub mod binary_bytes {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
                             bytes = Some(protocol.read_bytes()?);
                         }
+                        Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
+                            vec = Some(protocol.read_bytes_vec()?);
+                        }
                         _ => {
                             protocol.skip(field_ident.field_type)?;
                         }
@@ -42,13 +48,15 @@ pub mod binary_bytes {
                 }
                 protocol.read_struct_end()?;
                 let Some (bytes) = bytes else { return Err (:: pilota :: thrift :: Error :: Protocol (:: pilota :: thrift :: ProtocolError :: new (:: pilota :: thrift :: ProtocolErrorKind :: InvalidData , "field bytes is required" . to_string ()))) } ;
-                let data = Self { bytes };
+                let Some (vec) = vec else { return Err (:: pilota :: thrift :: Error :: Protocol (:: pilota :: thrift :: ProtocolError :: new (:: pilota :: thrift :: ProtocolErrorKind :: InvalidData , "field vec is required" . to_string ()))) } ;
+                let data = Self { bytes, vec };
                 Ok(data)
             }
             async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
                 protocol: &mut T,
             ) -> ::std::result::Result<Self, ::pilota::thrift::Error> {
                 let mut bytes = None;
+                let mut vec = None;
                 protocol.read_struct_begin().await?;
                 loop {
                     let field_ident = protocol.read_field_begin().await?;
@@ -60,6 +68,9 @@ pub mod binary_bytes {
                         Some(1i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
                             bytes = Some(protocol.read_bytes().await?);
                         }
+                        Some(2i16) if field_ident.field_type == ::pilota::thrift::TType::Binary => {
+                            vec = Some(protocol.read_bytes_vec().await?);
+                        }
                         _ => {
                             protocol.skip(field_ident.field_type).await?;
                         }
@@ -68,13 +79,15 @@ pub mod binary_bytes {
                 }
                 protocol.read_struct_end().await?;
                 let Some (bytes) = bytes else { return Err (:: pilota :: thrift :: Error :: Protocol (:: pilota :: thrift :: ProtocolError :: new (:: pilota :: thrift :: ProtocolErrorKind :: InvalidData , "field bytes is required" . to_string ()))) } ;
-                let data = Self { bytes };
+                let Some (vec) = vec else { return Err (:: pilota :: thrift :: Error :: Protocol (:: pilota :: thrift :: ProtocolError :: new (:: pilota :: thrift :: ProtocolErrorKind :: InvalidData , "field vec is required" . to_string ()))) } ;
+                let data = Self { bytes, vec };
                 Ok(data)
             }
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 use ::pilota::thrift::TLengthProtocolExt;
                 protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "A" })
                     + protocol.write_bytes_field_len(Some(1i16), &self.bytes)
+                    + protocol.write_bytes_vec_field_len(Some(2i16), &self.vec)
                     + protocol.write_field_stop_len()
                     + protocol.write_struct_end_len()
             }

--- a/pilota-build/test_data/thrift/binary_bytes.thrift
+++ b/pilota-build/test_data/thrift/binary_bytes.thrift
@@ -1,3 +1,4 @@
 struct A {
     1: required binary bytes,
+    2: required binary vec(pilota.rust_type="vec"),
 }


### PR DESCRIPTION
```thrift
struct A {
    1: required binary bytes,
    2: required binary vec(pilota.rust_type="vec"),
}
```
Generated:
```rust
pub struct A {
    pub bytes: ::pilota::Bytes,
    pub vec: ::std::vec::Vec<u8>,
}
```