### PR TITLE
chore: better error hints

### DIFF
--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -446,8 +446,12 @@ impl Lower {
 
 impl Parser for ProtobufParser {
     fn input<P: AsRef<std::path::Path>>(&mut self, path: P) {
-        self.input_files
-            .insert(path.as_ref().normalize().unwrap().into_path_buf());
+        let p = path.as_ref();
+        self.input_files.insert(
+            p.normalize()
+                .expect(&format!("normalize path failed: {}", p.display()))
+                .into_path_buf(),
+        );
         self.inner.input(path);
     }
 

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -642,8 +642,12 @@ impl super::Parser for ThriftParser {
         self.files.iter().for_each(|f| {
             input_files.push(
                 lower.lower(
-                    self.db
-                        .parse(f.to_path_buf().normalize().unwrap().into_path_buf()),
+                    self.db.parse(
+                        f.to_path_buf()
+                            .normalize()
+                            .expect(&format!("normalize path failed: {}", f.display()))
+                            .into_path_buf(),
+                    ),
                 ),
             );
         });


### PR DESCRIPTION
Specify which idl file path was not found.