### PR TITLE
gen newtype for enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.6.11"
+version = "0.6.12"
 dependencies = [
  "async-trait",
  "criterion",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.6.11"
+version = "0.6.12"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -466,7 +466,7 @@ impl ThriftLower {
         }
 
         annotations.iter().for_each(
-            |annotation| with_tags!(annotation -> crate::tags::PilotaName | crate::tags::RustType | crate::tags::RustWrapperArc | crate::tags::SerdeAttribute),
+            |annotation| with_tags!(annotation -> crate::tags::PilotaName | crate::tags::RustType | crate::tags::RustWrapperArc | crate::tags::SerdeAttribute | crate::tags::EnumMode),
         );
 
         tags

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     db::RirDatabase,
     rir::{EnumVariant, Field, Item},
     symbol::{DefId, EnumRepr},
+    tags::EnumMode,
     ty::{self, Ty, Visitor},
     Context, IdentName,
 };
@@ -385,7 +386,16 @@ pub struct EnumNumPlugin;
 impl Plugin for EnumNumPlugin {
     fn on_item(&mut self, cx: &mut Context, def_id: DefId, item: Arc<Item>) {
         match &*item {
-            Item::Enum(e) if e.repr.is_some() => {
+            Item::Enum(e)
+                if e.repr.is_some()
+                    && cx
+                        .node_tags(def_id)
+                        .unwrap()
+                        .get::<EnumMode>()
+                        .copied()
+                        .unwrap_or(EnumMode::Enum)
+                        == EnumMode::Enum =>
+            {
                 let name_str = &*cx.rust_name(def_id);
                 let name = name_str.as_syn_ident();
                 let num_ty = match e.repr {

--- a/pilota-build/src/tags.rs
+++ b/pilota-build/src/tags.rs
@@ -134,6 +134,27 @@ impl Annotation for PilotaName {
 #[derive(Debug)]
 pub struct RustType(pub FastStr);
 
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub enum EnumMode {
+    NewType,
+    Enum,
+}
+
+impl FromStr for EnumMode {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "new_type" => Self::NewType,
+            _ => Self::Enum,
+        })
+    }
+}
+
+impl Annotation for EnumMode {
+    const KEY: &'static str = "pilota.enum_mode";
+}
+
 impl PartialEq<str> for RustType {
     fn eq(&self, other: &str) -> bool {
         self.0 == other

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -223,8 +223,8 @@ pub mod serde {
         pub enum C {
             #[derivative(Default)]
             #[serde(rename = "DD")]
-            D,
-            E,
+            D = 0i32,
+            E = 1i32,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for C {

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -280,8 +280,8 @@ pub mod pilota_name {
         #[derive(Copy)]
         pub enum Index {
             #[derivative(Default)]
-            AA,
-            B,
+            AA = 0i32,
+            B = 1i32,
         }
         #[::async_trait::async_trait]
         impl ::pilota::thrift::Message for Index {


### PR DESCRIPTION
## Motivation
```thrift
enum Hello {
    H,
    E = 3,
    L,
}(pilota.enum_mode = "new_type")
```
会生成下面这段代码
```rust
pub struct Hello(i32);
impl Hello {
    pub const H: Self = Self(0i32);
    pub const E: Self = Self(3i32);
    pub const L: Self = Self(4i32);
    pub fn inner(&self) -> i32 {
        self.0
    }
}
impl ::std::convert::From<i32> for Hello {
    fn from(value: i32) -> Self {
        Self(value)
    }
}

```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
