### PR TITLE
fix(pilota-build): use prefixed `field_id` to support `field_id` as field identifier

### DIFF
--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -332,9 +332,8 @@ impl ThriftBackend {
                 if field_ident.field_type == ::pilota::thrift::TType::Stop {{
                     break;
                 }}
-                let field_id = field_ident.id;
-                __pilota_decoding_field_id = field_id;
-                match field_id {{
+                __pilota_decoding_field_id = field_ident.id;
+                match __pilota_decoding_field_id {{
                     {match_fields}
                     _ => {{
                         {skip_ttype};

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -333,7 +333,7 @@ impl ThriftBackend {
                     break;
                 }}
                 __pilota_decoding_field_id = field_ident.id;
-                match __pilota_decoding_field_id {{
+                match field_ident.id {{
                     {match_fields}
                     _ => {{
                         {skip_ttype};
@@ -541,8 +541,7 @@ impl CodegenBackend for ThriftBackend {
                                 if field_ident.field_type == ::pilota::thrift::TType::Stop {{
                                     break;
                                 }}
-                                let field_id = field_ident.id;
-                                match field_id {{
+                                match field_ident.id {{
                                     {fields}
                                     _ => {{
                                         {skip};

--- a/pilota-build/test_data/must_gen_items.rs
+++ b/pilota-build/test_data/must_gen_items.rs
@@ -40,9 +40,8 @@ pub mod must_gen_items {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                                 a = Some(protocol.read_i32()?);
                             }
@@ -88,9 +87,8 @@ pub mod must_gen_items {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                                 a = Some(protocol.read_i32().await?);
                             }

--- a/pilota-build/test_data/must_gen_items.rs
+++ b/pilota-build/test_data/must_gen_items.rs
@@ -41,7 +41,7 @@ pub mod must_gen_items {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                                 a = Some(protocol.read_i32()?);
                             }
@@ -88,7 +88,7 @@ pub mod must_gen_items {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                                 a = Some(protocol.read_i32().await?);
                             }

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -54,7 +54,7 @@ pub mod serde {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -124,7 +124,7 @@ pub mod serde {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -53,9 +53,8 @@ pub mod serde {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -124,9 +123,8 @@ pub mod serde {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/binary_bytes.rs
+++ b/pilota-build/test_data/thrift/binary_bytes.rs
@@ -42,7 +42,7 @@ pub mod binary_bytes {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -114,7 +114,7 @@ pub mod binary_bytes {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/binary_bytes.rs
+++ b/pilota-build/test_data/thrift/binary_bytes.rs
@@ -41,9 +41,8 @@ pub mod binary_bytes {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -114,9 +113,8 @@ pub mod binary_bytes {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/decode_error.rs
+++ b/pilota-build/test_data/thrift/decode_error.rs
@@ -37,9 +37,8 @@ pub mod decode_error {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -96,9 +95,8 @@ pub mod decode_error {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -187,9 +185,8 @@ pub mod decode_error {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(3)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -246,9 +243,8 @@ pub mod decode_error {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(3)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -337,9 +333,8 @@ pub mod decode_error {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -396,9 +391,8 @@ pub mod decode_error {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {

--- a/pilota-build/test_data/thrift/decode_error.rs
+++ b/pilota-build/test_data/thrift/decode_error.rs
@@ -38,7 +38,7 @@ pub mod decode_error {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -96,7 +96,7 @@ pub mod decode_error {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -186,7 +186,7 @@ pub mod decode_error {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(3)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -244,7 +244,7 @@ pub mod decode_error {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(3)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -334,7 +334,7 @@ pub mod decode_error {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -392,7 +392,7 @@ pub mod decode_error {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -197,9 +197,8 @@ pub mod default_value {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -321,9 +320,8 @@ pub mod default_value {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -198,7 +198,7 @@ pub mod default_value {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -321,7 +321,7 @@ pub mod default_value {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -41,7 +41,7 @@ pub mod normal {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                                 a = Some(protocol.read_i32()?);
                             }
@@ -88,7 +88,7 @@ pub mod normal {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                                 a = Some(protocol.read_i32().await?);
                             }
@@ -173,7 +173,7 @@ pub mod normal {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -222,7 +222,7 @@ pub mod normal {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -40,9 +40,8 @@ pub mod normal {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                                 a = Some(protocol.read_i32()?);
                             }
@@ -88,9 +87,8 @@ pub mod normal {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                                 a = Some(protocol.read_i32().await?);
                             }
@@ -174,9 +172,8 @@ pub mod normal {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -224,9 +221,8 @@ pub mod normal {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -349,8 +349,7 @@ pub mod pilota_name {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResultSend::Ok(
@@ -390,8 +389,7 @@ pub mod pilota_name {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResultSend::Ok(

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -37,9 +37,8 @@ pub mod pilota_name {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -96,9 +95,8 @@ pub mod pilota_name {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -190,9 +188,8 @@ pub mod pilota_name {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -252,9 +249,8 @@ pub mod pilota_name {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -352,9 +348,8 @@ pub mod pilota_name {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -425,9 +420,8 @@ pub mod pilota_name {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -536,9 +530,8 @@ pub mod pilota_name {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -598,9 +591,8 @@ pub mod pilota_name {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -38,7 +38,7 @@ pub mod pilota_name {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -96,7 +96,7 @@ pub mod pilota_name {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -189,7 +189,7 @@ pub mod pilota_name {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -250,7 +250,7 @@ pub mod pilota_name {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -349,7 +349,7 @@ pub mod pilota_name {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -421,7 +421,7 @@ pub mod pilota_name {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -531,7 +531,7 @@ pub mod pilota_name {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -592,7 +592,7 @@ pub mod pilota_name {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -691,8 +691,7 @@ pub mod pilota_name {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResult::Ok(
@@ -732,8 +731,7 @@ pub mod pilota_name {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResult::Ok(

--- a/pilota-build/test_data/thrift/recursive_type.rs
+++ b/pilota-build/test_data/thrift/recursive_type.rs
@@ -41,7 +41,7 @@ pub mod recursive_type {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -92,7 +92,7 @@ pub mod recursive_type {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {

--- a/pilota-build/test_data/thrift/recursive_type.rs
+++ b/pilota-build/test_data/thrift/recursive_type.rs
@@ -40,9 +40,8 @@ pub mod recursive_type {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -92,9 +91,8 @@ pub mod recursive_type {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -115,9 +115,8 @@ pub mod self_kw {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -174,9 +173,8 @@ pub mod self_kw {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -116,7 +116,7 @@ pub mod self_kw {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -174,7 +174,7 @@ pub mod self_kw {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/string.rs
+++ b/pilota-build/test_data/thrift/string.rs
@@ -42,7 +42,7 @@ pub mod string {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -114,7 +114,7 @@ pub mod string {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/string.rs
+++ b/pilota-build/test_data/thrift/string.rs
@@ -41,9 +41,8 @@ pub mod string {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -114,9 +113,8 @@ pub mod string {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -40,8 +40,7 @@ pub mod void {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         _ => {
                             protocol.skip(field_ident.field_type)?;
                         }
@@ -66,8 +65,7 @@ pub mod void {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         _ => {
                             protocol.skip(field_ident.field_type).await?;
                         }
@@ -127,7 +125,7 @@ pub mod void {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
                             }
@@ -171,7 +169,7 @@ pub mod void {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             _ => {
                                 protocol.skip(field_ident.field_type).await?;
                             }
@@ -249,7 +247,7 @@ pub mod void {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
                             }
@@ -293,7 +291,7 @@ pub mod void {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             _ => {
                                 protocol.skip(field_ident.field_type).await?;
                             }

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -369,8 +369,7 @@ pub mod void {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         _ => {
                             protocol.skip(field_ident.field_type)?;
                         }
@@ -395,8 +394,7 @@ pub mod void {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         _ => {
                             protocol.skip(field_ident.field_type).await?;
                         }

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -126,9 +126,8 @@ pub mod void {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
                             }
@@ -171,9 +170,8 @@ pub mod void {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             _ => {
                                 protocol.skip(field_ident.field_type).await?;
                             }
@@ -250,9 +248,8 @@ pub mod void {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
                             }
@@ -295,9 +292,8 @@ pub mod void {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             _ => {
                                 protocol.skip(field_ident.field_type).await?;
                             }

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -34,7 +34,7 @@ pub mod wrapper_arc {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
                             }
@@ -75,7 +75,7 @@ pub mod wrapper_arc {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             _ => {
                                 protocol.skip(field_ident.field_type).await?;
                             }
@@ -151,7 +151,7 @@ pub mod wrapper_arc {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -214,7 +214,7 @@ pub mod wrapper_arc {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -355,7 +355,7 @@ pub mod wrapper_arc {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -474,7 +474,7 @@ pub mod wrapper_arc {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -658,7 +658,7 @@ pub mod wrapper_arc {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -719,7 +719,7 @@ pub mod wrapper_arc {
                             break;
                         }
                         __pilota_decoding_field_id = field_ident.id;
-                        match __pilota_decoding_field_id {
+                        match field_ident.id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -818,8 +818,7 @@ pub mod wrapper_arc {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResult::Ok(protocol.read_faststr()?));
@@ -857,8 +856,7 @@ pub mod wrapper_arc {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret =

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -155,8 +155,7 @@ pub mod wrapper_arc {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResultRecv::Ok(
@@ -196,8 +195,7 @@ pub mod wrapper_arc {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResultRecv::Ok(
@@ -438,8 +436,7 @@ pub mod wrapper_arc {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResultSend::Ok(::std::sync::Arc::new(
@@ -479,8 +476,7 @@ pub mod wrapper_arc {
                     if field_ident.field_type == ::pilota::thrift::TType::Stop {
                         break;
                     }
-                    let field_id = field_ident.id;
-                    match field_id {
+                    match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
                                 ret = Some(TestServiceTestResultSend::Ok(::std::sync::Arc::new(

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -33,9 +33,8 @@ pub mod wrapper_arc {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
                             }
@@ -75,9 +74,8 @@ pub mod wrapper_arc {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             _ => {
                                 protocol.skip(field_ident.field_type).await?;
                             }
@@ -152,9 +150,8 @@ pub mod wrapper_arc {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -216,9 +213,8 @@ pub mod wrapper_arc {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -358,9 +354,8 @@ pub mod wrapper_arc {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -478,9 +473,8 @@ pub mod wrapper_arc {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
@@ -663,9 +657,8 @@ pub mod wrapper_arc {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
@@ -725,9 +718,8 @@ pub mod wrapper_arc {
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
                             break;
                         }
-                        let field_id = field_ident.id;
-                        __pilota_decoding_field_id = field_id;
-                        match field_id {
+                        __pilota_decoding_field_id = field_ident.id;
+                        match __pilota_decoding_field_id {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {


### PR DESCRIPTION
## Motivation

The use of `field_id` as variable in the field decode codgen causes a conflict with [Parquet](https://parquet.apache.org/)'s Thrift file (it has a struct with a field named [`field_id`](https://github.com/apache/parquet-format/blob/c185faf0c4fc0c7d3075d1abd4ed0985cdbe5d87/src/main/thrift/parquet.thrift#L401)). 

## Solution

This PR modifies the codegen to remove that variable to support fields with `field_id` as identifier.