### PR TITLE
feat: support arc for resp

### DIFF
--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -295,16 +295,6 @@ pub trait TyTransformer {
     }
 }
 
-pub enum StringRepr {
-    FastStr,
-    String,
-}
-
-pub enum BytesRepr {
-    Vec,
-    Bytes,
-}
-
 pub(crate) struct DefaultTyTransformer<'s>(&'s dyn RirDatabase);
 
 impl TyTransformer for DefaultTyTransformer<'_> {

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -154,11 +154,11 @@ pub mod pilota_name {
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
-        pub struct TestServiceTestArgsSend {
+        pub struct TestServiceTestArgsRecv {
             pub req: Test2,
         }
         #[::async_trait::async_trait]
-        impl ::pilota::thrift::Message for TestServiceTestArgsSend {
+        impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
                 protocol: &mut T,
@@ -166,7 +166,7 @@ pub mod pilota_name {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 let struct_ident = ::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestArgsSend",
+                    name: "TestServiceTestArgsRecv",
                 };
 
                 protocol.write_struct_begin(&struct_ident)?;
@@ -215,7 +215,7 @@ pub mod pilota_name {
                                 err,
                             )),
                             format!(
-                                "decode struct `TestServiceTestArgsSend` field(#{}) failed",
+                                "decode struct `TestServiceTestArgsRecv` field(#{}) failed",
                                 field_id
                             ),
                         ));
@@ -280,7 +280,7 @@ pub mod pilota_name {
                                 err,
                             )),
                             format!(
-                                "decode struct `TestServiceTestArgsSend` field(#{}) failed",
+                                "decode struct `TestServiceTestArgsRecv` field(#{}) failed",
                                 field_id
                             ),
                         ));
@@ -307,9 +307,134 @@ pub mod pilota_name {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
                 protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestArgsSend",
+                    name: "TestServiceTestArgsRecv",
                 }) + protocol.write_struct_field_len(Some(1), &self.req)
                     + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
+        #[derivative(Default)]
+        #[derive(Clone, PartialEq)]
+
+        pub enum TestServiceTestResultSend {
+            #[derivative(Default)]
+            Ok(Test1),
+        }
+
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for TestServiceTestResultSend {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::EncodeError> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestResultSend",
+                })?;
+                match self {
+                    TestServiceTestResultSend::Ok(ref value) => {
+                        protocol.write_struct_field(0, value)?;
+                    }
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
+                let mut ret = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(0) => {
+                            if ret.is_none() {
+                                ret = Some(TestServiceTestResultSend::Ok(
+                                    ::pilota::thrift::Message::decode(protocol)?,
+                                ));
+                            } else {
+                                return Err(::pilota::thrift::DecodeError::new(
+                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ));
+                            }
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                protocol.read_field_end()?;
+                protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Err(::pilota::thrift::DecodeError::new(
+                        ::pilota::thrift::DecodeErrorKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
+                let mut ret = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(0) => {
+                            if ret.is_none() {
+                                ret = Some(TestServiceTestResultSend::Ok(
+                                    ::pilota::thrift::Message::decode_async(protocol).await?,
+                                ));
+                            } else {
+                                return Err(::pilota::thrift::DecodeError::new(
+                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ));
+                            }
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                }
+                protocol.read_field_end().await?;
+                protocol.read_struct_end().await?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Err(::pilota::thrift::DecodeError::new(
+                        ::pilota::thrift::DecodeErrorKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestResultSend",
+                }) + match self {
+                    TestServiceTestResultSend::Ok(ref value) => {
+                        protocol.write_struct_field_len(Some(0), value)
+                    }
+                } + protocol.write_field_stop_len()
                     + protocol.write_struct_end_len()
             }
         }
@@ -496,15 +621,12 @@ pub mod pilota_name {
                     + protocol.write_struct_end_len()
             }
         }
-        #[::async_trait::async_trait]
-        pub trait TestService {}
-        pub const LANG_ID: &'static str = "id";
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
-        pub struct TestServiceTestArgsRecv {
+        pub struct TestServiceTestArgsSend {
             pub req: Test2,
         }
         #[::async_trait::async_trait]
-        impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
+        impl ::pilota::thrift::Message for TestServiceTestArgsSend {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
                 protocol: &mut T,
@@ -512,7 +634,7 @@ pub mod pilota_name {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 let struct_ident = ::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestArgsRecv",
+                    name: "TestServiceTestArgsSend",
                 };
 
                 protocol.write_struct_begin(&struct_ident)?;
@@ -561,7 +683,7 @@ pub mod pilota_name {
                                 err,
                             )),
                             format!(
-                                "decode struct `TestServiceTestArgsRecv` field(#{}) failed",
+                                "decode struct `TestServiceTestArgsSend` field(#{}) failed",
                                 field_id
                             ),
                         ));
@@ -626,7 +748,7 @@ pub mod pilota_name {
                                 err,
                             )),
                             format!(
-                                "decode struct `TestServiceTestArgsRecv` field(#{}) failed",
+                                "decode struct `TestServiceTestArgsSend` field(#{}) failed",
                                 field_id
                             ),
                         ));
@@ -653,23 +775,26 @@ pub mod pilota_name {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
                 protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestArgsRecv",
+                    name: "TestServiceTestArgsSend",
                 }) + protocol.write_struct_field_len(Some(1), &self.req)
                     + protocol.write_field_stop_len()
                     + protocol.write_struct_end_len()
             }
         }
+        pub const LANG_ID: &'static str = "id";
+        #[::async_trait::async_trait]
+        pub trait TestService {}
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
 
-        pub enum TestServiceTestResult {
+        pub enum TestServiceTestResultRecv {
             #[derivative(Default)]
             Ok(Test1),
         }
 
         #[::async_trait::async_trait]
-        impl ::pilota::thrift::Message for TestServiceTestResult {
+        impl ::pilota::thrift::Message for TestServiceTestResultRecv {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
                 protocol: &mut T,
@@ -677,10 +802,10 @@ pub mod pilota_name {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestResult",
+                    name: "TestServiceTestResultRecv",
                 })?;
                 match self {
-                    TestServiceTestResult::Ok(ref value) => {
+                    TestServiceTestResultRecv::Ok(ref value) => {
                         protocol.write_struct_field(0, value)?;
                     }
                 }
@@ -703,7 +828,7 @@ pub mod pilota_name {
                     match field_id {
                         Some(0) => {
                             if ret.is_none() {
-                                ret = Some(TestServiceTestResult::Ok(
+                                ret = Some(TestServiceTestResultRecv::Ok(
                                     ::pilota::thrift::Message::decode(protocol)?,
                                 ));
                             } else {
@@ -744,7 +869,7 @@ pub mod pilota_name {
                     match field_id {
                         Some(0) => {
                             if ret.is_none() {
-                                ret = Some(TestServiceTestResult::Ok(
+                                ret = Some(TestServiceTestResultRecv::Ok(
                                     ::pilota::thrift::Message::decode_async(protocol).await?,
                                 ));
                             } else {
@@ -775,9 +900,9 @@ pub mod pilota_name {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
                 protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestResult",
+                    name: "TestServiceTestResultRecv",
                 }) + match self {
-                    TestServiceTestResult::Ok(ref value) => {
+                    TestServiceTestResultRecv::Ok(ref value) => {
                         protocol.write_struct_field_len(Some(0), value)
                     }
                 } + protocol.write_field_stop_len()

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -6,13 +6,13 @@ pub mod void {
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
 
-        pub enum TestTest123Result {
+        pub enum TestTest123ResultRecv {
             #[derivative(Default)]
             Ok(()),
         }
 
         #[::async_trait::async_trait]
-        impl ::pilota::thrift::Message for TestTest123Result {
+        impl ::pilota::thrift::Message for TestTest123ResultRecv {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
                 protocol: &mut T,
@@ -20,10 +20,10 @@ pub mod void {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
-                    name: "TestTest123Result",
+                    name: "TestTest123ResultRecv",
                 })?;
                 match self {
-                    TestTest123Result::Ok(ref value) => {}
+                    TestTest123ResultRecv::Ok(ref value) => {}
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
@@ -52,7 +52,7 @@ pub mod void {
                 if let Some(ret) = ret {
                     Ok(ret)
                 } else {
-                    Ok(TestTest123Result::Ok(()))
+                    Ok(TestTest123ResultRecv::Ok(()))
                 }
             }
 
@@ -78,7 +78,7 @@ pub mod void {
                 if let Some(ret) = ret {
                     Ok(ret)
                 } else {
-                    Ok(TestTest123Result::Ok(()))
+                    Ok(TestTest123ResultRecv::Ok(()))
                 }
             }
 
@@ -86,9 +86,9 @@ pub mod void {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
                 protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
-                    name: "TestTest123Result",
+                    name: "TestTest123ResultRecv",
                 }) + match self {
-                    TestTest123Result::Ok(ref value) => {}
+                    TestTest123ResultRecv::Ok(ref value) => {}
                 } + protocol.write_field_stop_len()
                     + protocol.write_struct_end_len()
             }
@@ -215,8 +215,6 @@ pub mod void {
                     + protocol.write_struct_end_len()
             }
         }
-        #[::async_trait::async_trait]
-        pub trait Test {}
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct TestTest123ArgsRecv {}
         #[::async_trait::async_trait]
@@ -339,5 +337,98 @@ pub mod void {
                     + protocol.write_struct_end_len()
             }
         }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
+        #[derivative(Default)]
+        #[derive(Clone, PartialEq)]
+
+        pub enum TestTest123ResultSend {
+            #[derivative(Default)]
+            Ok(()),
+        }
+
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for TestTest123ResultSend {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::EncodeError> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "TestTest123ResultSend",
+                })?;
+                match self {
+                    TestTest123ResultSend::Ok(ref value) => {}
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
+                let mut ret = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                protocol.read_field_end()?;
+                protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Ok(TestTest123ResultSend::Ok(()))
+                }
+            }
+
+            async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
+                let mut ret = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                }
+                protocol.read_field_end().await?;
+                protocol.read_struct_end().await?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Ok(TestTest123ResultSend::Ok(()))
+                }
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "TestTest123ResultSend",
+                }) + match self {
+                    TestTest123ResultSend::Ok(ref value) => {}
+                } + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+        #[::async_trait::async_trait]
+        pub trait Test {}
     }
 }

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -115,12 +115,139 @@ pub mod wrapper_arc {
                     + protocol.write_struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
-        pub struct TestServiceTestArgsSend {
-            pub req: ::std::sync::Arc<Test>,
+        #[::async_trait::async_trait]
+        pub trait TestService {}
+        #[derive(Debug, ::pilota::derivative::Derivative)]
+        #[derivative(Default)]
+        #[derive(Clone, PartialEq)]
+
+        pub enum TestServiceTestResultRecv {
+            #[derivative(Default)]
+            Ok(Test),
+        }
+
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for TestServiceTestResultRecv {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::EncodeError> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestResultRecv",
+                })?;
+                match self {
+                    TestServiceTestResultRecv::Ok(ref value) => {
+                        protocol.write_struct_field(0, value)?;
+                    }
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
+                let mut ret = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(0) => {
+                            if ret.is_none() {
+                                ret = Some(TestServiceTestResultRecv::Ok(
+                                    ::pilota::thrift::Message::decode(protocol)?,
+                                ));
+                            } else {
+                                return Err(::pilota::thrift::DecodeError::new(
+                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ));
+                            }
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                protocol.read_field_end()?;
+                protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Err(::pilota::thrift::DecodeError::new(
+                        ::pilota::thrift::DecodeErrorKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
+                let mut ret = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(0) => {
+                            if ret.is_none() {
+                                ret = Some(TestServiceTestResultRecv::Ok(
+                                    ::pilota::thrift::Message::decode_async(protocol).await?,
+                                ));
+                            } else {
+                                return Err(::pilota::thrift::DecodeError::new(
+                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ));
+                            }
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                }
+                protocol.read_field_end().await?;
+                protocol.read_struct_end().await?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Err(::pilota::thrift::DecodeError::new(
+                        ::pilota::thrift::DecodeErrorKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestResultRecv",
+                }) + match self {
+                    TestServiceTestResultRecv::Ok(ref value) => {
+                        protocol.write_struct_field_len(Some(0), value)
+                    }
+                } + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+        #[derive(Debug, Default, Clone, PartialEq)]
+        pub struct TestServiceTestArgsRecv {
+            pub req: Test,
         }
         #[::async_trait::async_trait]
-        impl ::pilota::thrift::Message for TestServiceTestArgsSend {
+        impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
                 protocol: &mut T,
@@ -128,7 +255,7 @@ pub mod wrapper_arc {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 let struct_ident = ::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestArgsSend",
+                    name: "TestServiceTestArgsRecv",
                 };
 
                 protocol.write_struct_begin(&struct_ident)?;
@@ -158,9 +285,7 @@ pub mod wrapper_arc {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                req = Some(::std::sync::Arc::new(
-                                    ::pilota::thrift::Message::decode(protocol)?,
-                                ));
+                                req = Some(::pilota::thrift::Message::decode(protocol)?);
                             }
 
                             _ => {
@@ -179,7 +304,7 @@ pub mod wrapper_arc {
                                 err,
                             )),
                             format!(
-                                "decode struct `TestServiceTestArgsSend` field(#{}) failed",
+                                "decode struct `TestServiceTestArgsRecv` field(#{}) failed",
                                 field_id
                             ),
                         ));
@@ -222,9 +347,8 @@ pub mod wrapper_arc {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                req = Some(::std::sync::Arc::new(
-                                    ::pilota::thrift::Message::decode_async(protocol).await?,
-                                ));
+                                req =
+                                    Some(::pilota::thrift::Message::decode_async(protocol).await?);
                             }
 
                             _ => {
@@ -245,7 +369,7 @@ pub mod wrapper_arc {
                                 err,
                             )),
                             format!(
-                                "decode struct `TestServiceTestArgsSend` field(#{}) failed",
+                                "decode struct `TestServiceTestArgsRecv` field(#{}) failed",
                                 field_id
                             ),
                         ));
@@ -272,9 +396,134 @@ pub mod wrapper_arc {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
                 protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestArgsSend",
+                    name: "TestServiceTestArgsRecv",
                 }) + protocol.write_struct_field_len(Some(1), &self.req)
                     + protocol.write_field_stop_len()
+                    + protocol.write_struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
+        #[derivative(Default)]
+        #[derive(Clone, PartialEq)]
+
+        pub enum TestServiceTestResultSend {
+            #[derivative(Default)]
+            Ok(::std::sync::Arc<Test>),
+        }
+
+        #[::async_trait::async_trait]
+        impl ::pilota::thrift::Message for TestServiceTestResultSend {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::EncodeError> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestResultSend",
+                })?;
+                match self {
+                    TestServiceTestResultSend::Ok(ref value) => {
+                        protocol.write_struct_field(0, value)?;
+                    }
+                }
+                protocol.write_field_stop()?;
+                protocol.write_struct_end()?;
+                Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
+                let mut ret = None;
+                protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(0) => {
+                            if ret.is_none() {
+                                ret = Some(TestServiceTestResultSend::Ok(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(protocol)?,
+                                )));
+                            } else {
+                                return Err(::pilota::thrift::DecodeError::new(
+                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ));
+                            }
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                protocol.read_field_end()?;
+                protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Err(::pilota::thrift::DecodeError::new(
+                        ::pilota::thrift::DecodeErrorKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
+                let mut ret = None;
+                protocol.read_struct_begin().await?;
+                loop {
+                    let field_ident = protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    }
+                    let field_id = field_ident.id;
+                    match field_id {
+                        Some(0) => {
+                            if ret.is_none() {
+                                ret = Some(TestServiceTestResultSend::Ok(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode_async(protocol).await?,
+                                )));
+                            } else {
+                                return Err(::pilota::thrift::DecodeError::new(
+                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ));
+                            }
+                        }
+                        _ => {
+                            protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+                }
+                protocol.read_field_end().await?;
+                protocol.read_struct_end().await?;
+                if let Some(ret) = ret {
+                    Ok(ret)
+                } else {
+                    Err(::pilota::thrift::DecodeError::new(
+                        ::pilota::thrift::DecodeErrorKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "TestServiceTestResultSend",
+                }) + match self {
+                    TestServiceTestResultSend::Ok(ref value) => {
+                        protocol.write_struct_field_len(Some(0), value)
+                    }
+                } + protocol.write_field_stop_len()
                     + protocol.write_struct_end_len()
             }
         }
@@ -626,12 +875,12 @@ pub mod wrapper_arc {
                     + protocol.write_struct_end_len()
             }
         }
-        #[derive(Debug, Default, Clone, PartialEq)]
-        pub struct TestServiceTestArgsRecv {
-            pub req: Test,
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct TestServiceTestArgsSend {
+            pub req: ::std::sync::Arc<Test>,
         }
         #[::async_trait::async_trait]
-        impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
+        impl ::pilota::thrift::Message for TestServiceTestArgsSend {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
                 protocol: &mut T,
@@ -639,7 +888,7 @@ pub mod wrapper_arc {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 let struct_ident = ::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestArgsRecv",
+                    name: "TestServiceTestArgsSend",
                 };
 
                 protocol.write_struct_begin(&struct_ident)?;
@@ -669,7 +918,9 @@ pub mod wrapper_arc {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                req = Some(::pilota::thrift::Message::decode(protocol)?);
+                                req = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(protocol)?,
+                                ));
                             }
 
                             _ => {
@@ -688,7 +939,7 @@ pub mod wrapper_arc {
                                 err,
                             )),
                             format!(
-                                "decode struct `TestServiceTestArgsRecv` field(#{}) failed",
+                                "decode struct `TestServiceTestArgsSend` field(#{}) failed",
                                 field_id
                             ),
                         ));
@@ -731,8 +982,9 @@ pub mod wrapper_arc {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                req =
-                                    Some(::pilota::thrift::Message::decode_async(protocol).await?);
+                                req = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode_async(protocol).await?,
+                                ));
                             }
 
                             _ => {
@@ -753,7 +1005,7 @@ pub mod wrapper_arc {
                                 err,
                             )),
                             format!(
-                                "decode struct `TestServiceTestArgsRecv` field(#{}) failed",
+                                "decode struct `TestServiceTestArgsSend` field(#{}) failed",
                                 field_id
                             ),
                         ));
@@ -780,135 +1032,11 @@ pub mod wrapper_arc {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
                 protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestArgsRecv",
+                    name: "TestServiceTestArgsSend",
                 }) + protocol.write_struct_field_len(Some(1), &self.req)
                     + protocol.write_field_stop_len()
                     + protocol.write_struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
-
-        pub enum TestServiceTestResult {
-            #[derivative(Default)]
-            Ok(::pilota::FastStr),
-        }
-
-        #[::async_trait::async_trait]
-        impl ::pilota::thrift::Message for TestServiceTestResult {
-            fn encode<T: ::pilota::thrift::TOutputProtocol>(
-                &self,
-                protocol: &mut T,
-            ) -> ::std::result::Result<(), ::pilota::thrift::EncodeError> {
-                #[allow(unused_imports)]
-                use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestResult",
-                })?;
-                match self {
-                    TestServiceTestResult::Ok(ref value) => {
-                        protocol.write_faststr_field(0, (value).clone())?;
-                    }
-                }
-                protocol.write_field_stop()?;
-                protocol.write_struct_end()?;
-                Ok(())
-            }
-
-            fn decode<T: ::pilota::thrift::TInputProtocol>(
-                protocol: &mut T,
-            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
-                let mut ret = None;
-                protocol.read_struct_begin()?;
-                loop {
-                    let field_ident = protocol.read_field_begin()?;
-                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
-                        break;
-                    }
-                    let field_id = field_ident.id;
-                    match field_id {
-                        Some(0) => {
-                            if ret.is_none() {
-                                ret = Some(TestServiceTestResult::Ok(protocol.read_faststr()?));
-                            } else {
-                                return Err(::pilota::thrift::DecodeError::new(
-                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
-                            }
-                        }
-                        _ => {
-                            protocol.skip(field_ident.field_type)?;
-                        }
-                    }
-                }
-                protocol.read_field_end()?;
-                protocol.read_struct_end()?;
-                if let Some(ret) = ret {
-                    Ok(ret)
-                } else {
-                    Err(::pilota::thrift::DecodeError::new(
-                        ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "received empty union from remote Message",
-                    ))
-                }
-            }
-
-            async fn decode_async<T: ::pilota::thrift::TAsyncInputProtocol>(
-                protocol: &mut T,
-            ) -> ::std::result::Result<Self, ::pilota::thrift::DecodeError> {
-                let mut ret = None;
-                protocol.read_struct_begin().await?;
-                loop {
-                    let field_ident = protocol.read_field_begin().await?;
-                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
-                        break;
-                    }
-                    let field_id = field_ident.id;
-                    match field_id {
-                        Some(0) => {
-                            if ret.is_none() {
-                                ret =
-                                    Some(TestServiceTestResult::Ok(protocol.read_faststr().await?));
-                            } else {
-                                return Err(::pilota::thrift::DecodeError::new(
-                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
-                            }
-                        }
-                        _ => {
-                            protocol.skip(field_ident.field_type).await?;
-                        }
-                    }
-                }
-                protocol.read_field_end().await?;
-                protocol.read_struct_end().await?;
-                if let Some(ret) = ret {
-                    Ok(ret)
-                } else {
-                    Err(::pilota::thrift::DecodeError::new(
-                        ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "received empty union from remote Message",
-                    ))
-                }
-            }
-
-            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
-                #[allow(unused_imports)]
-                use ::pilota::thrift::TLengthProtocolExt;
-                protocol.write_struct_begin_len(&::pilota::thrift::TStructIdentifier {
-                    name: "TestServiceTestResult",
-                }) + match self {
-                    TestServiceTestResult::Ok(ref value) => {
-                        protocol.write_faststr_field_len(Some(0), value)
-                    }
-                } + protocol.write_field_stop_len()
-                    + protocol.write_struct_end_len()
-            }
-        }
-        #[::async_trait::async_trait]
-        pub trait TestService {}
     }
 }

--- a/pilota-build/test_data/thrift/wrapper_arc.thrift
+++ b/pilota-build/test_data/thrift/wrapper_arc.thrift
@@ -9,5 +9,5 @@ struct TEST {
 }
 
 service TestService {
-    string test(1: TEST req(pilota.rust_wrapper_arc="true"));
+    TEST(pilota.rust_wrapper_arc="true") test(1: TEST req(pilota.rust_wrapper_arc="true"));
 }


### PR DESCRIPTION
```thrift
struct A {

}
struct TEST {
    1: required string ID,
    2: required list<list<A>> Name2(pilota.rust_wrapper_arc="true"),
    3: required map<i32, list<A>> Name3(pilota.rust_wrapper_arc="true"),
}

service TestService {
    TEST(pilota.rust_wrapper_arc="true") test(1: TEST req(pilota.rust_wrapper_arc="true"));
}
```
Resp is wrapped by Arc in the server, but not in the client.