### PR TITLE
fix: missing `;`

### DIFF
--- a/pilota-build/src/codegen/protobuf/mod.rs
+++ b/pilota-build/src/codegen/protobuf/mod.rs
@@ -215,7 +215,7 @@ impl ProtobufBackend {
                     FieldKind::Optional => format! {
                         r#"if let Some(_pilota_inner_value) = {ident}.as_ref() {{
                                 {encode_fn}({tag}, _pilota_inner_value, buf);
-                            }}"#
+                            }};"#
                     }
                     .into(),
                 }
@@ -225,7 +225,7 @@ impl ProtobufBackend {
                     format!(
                         r#"for msg in &{ident} {{
                             ::pilota::prost::encoding::message::encode({tag}, msg, buf);
-                        }}"#
+                        }};"#
                     )
                     .into()
                 } else {

--- a/pilota-build/test_data/protobuf/bytes.rs
+++ b/pilota-build/test_data/protobuf/bytes.rs
@@ -19,7 +19,7 @@ pub mod bytes {
         {
             if let Some(_pilota_inner_value) = self.a.as_ref() {
                 ::pilota::prost::encoding::bytes::encode(1, _pilota_inner_value, buf);
-            }
+            };
         }
 
         #[allow(unused_variables)]

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -203,7 +203,7 @@ pub mod nested_message {
                 {
                     if let Some(_pilota_inner_value) = self.a.as_ref() {
                         ::pilota::prost::encoding::int32::encode(1, _pilota_inner_value, buf);
-                    }
+                    };
                     ::pilota::prost::encoding::hash_map::encode(
                         ::pilota::prost::encoding::int32::encode,
                         ::pilota::prost::encoding::int32::encoded_len,

--- a/pilota-build/test_data/protobuf/optional.rs
+++ b/pilota-build/test_data/protobuf/optional.rs
@@ -19,7 +19,7 @@ pub mod optional {
         {
             if let Some(_pilota_inner_value) = self.page_number.as_ref() {
                 ::pilota::prost::encoding::int32::encode(2, _pilota_inner_value, buf);
-            }
+            };
         }
 
         #[allow(unused_variables)]

--- a/pilota-build/test_data/protobuf/string.rs
+++ b/pilota-build/test_data/protobuf/string.rs
@@ -21,7 +21,7 @@ pub mod string {
         {
             if let Some(_pilota_inner_value) = self.a.as_ref() {
                 ::pilota::prost::encoding::faststr::encode(1, _pilota_inner_value, buf);
-            }
+            };
             ::pilota::prost::encoding::faststr::encode(2, &self.b, buf);
         }
 


### PR DESCRIPTION
## Motivation
fix: missing `;`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
