### PR TITLE
fix: missing `_` in pb encode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/codegen/protobuf/mod.rs
+++ b/pilota-build/src/codegen/protobuf/mod.rs
@@ -230,7 +230,7 @@ impl ProtobufBackend {
                     .into()
                 } else {
                     let encode: FastStr = if self.is_one_of(ty) {
-                        "pilota_inner_value.encode(buf);".into()
+                        "_pilota_inner_value.encode(buf);".into()
                     } else {
                         let ident: FastStr = match kind {
                             FieldKind::Required => format!("(&{ident})").into(),

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -16,7 +16,7 @@ pub mod oneof {
             B: ::pilota::prost::bytes::BufMut,
         {
             if let Some(_pilota_inner_value) = self.r#type.as_ref() {
-                pilota_inner_value.encode(buf);
+                _pilota_inner_value.encode(buf);
             }
         }
 


### PR DESCRIPTION
missing `_` in protobuf oneof encode