### PR TITLE
fix oneof field position in pb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/test_data/protobuf/oneof.proto
+++ b/pilota-build/test_data/protobuf/oneof.proto
@@ -1,8 +1,14 @@
 syntax = "proto3";
 
 message Test {
+    int32 c = 1;
     oneof type {
         string s = 2;
         int32 i = 4;
+    }
+    int64 j = 5;
+    oneof test {
+        string a = 6;
+        int32 b = 8;
     }
 }

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -2,12 +2,21 @@ pub mod oneof {
     #![allow(warnings, clippy::all)]
     #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
     pub struct Test {
+        pub c: i32,
+
         pub r#type: ::std::option::Option<test::Type>,
+
+        pub j: i64,
+
+        pub test: ::std::option::Option<test::Test>,
     }
     impl ::pilota::prost::Message for Test {
         #[inline]
         fn encoded_len(&self) -> usize {
-            0 + self.r#type.as_ref().map_or(0, |msg| msg.encoded_len())
+            0 + ::pilota::prost::encoding::int32::encoded_len(1, &self.c)
+                + self.r#type.as_ref().map_or(0, |msg| msg.encoded_len())
+                + ::pilota::prost::encoding::int64::encoded_len(5, &self.j)
+                + self.test.as_ref().map_or(0, |msg| msg.encoded_len())
         }
 
         #[allow(unused_variables)]
@@ -15,7 +24,12 @@ pub mod oneof {
         where
             B: ::pilota::prost::bytes::BufMut,
         {
+            ::pilota::prost::encoding::int32::encode(1, &self.c, buf);
             if let Some(_pilota_inner_value) = self.r#type.as_ref() {
+                _pilota_inner_value.encode(buf);
+            }
+            ::pilota::prost::encoding::int64::encode(5, &self.j, buf);
+            if let Some(_pilota_inner_value) = self.test.as_ref() {
                 _pilota_inner_value.encode(buf);
             }
         }
@@ -33,11 +47,46 @@ pub mod oneof {
         {
             const STRUCT_NAME: &'static str = stringify!(Test);
             match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.c;
+                    ::pilota::prost::encoding::int32::merge(
+                        wire_type,
+                        _inner_pilota_value,
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(c));
+                        error
+                    })
+                }
                 2 | 4 => {
                     let mut _inner_pilota_value = &mut self.r#type;
                     test::Type::merge(&mut _inner_pilota_value, tag, wire_type, buf, ctx).map_err(
                         |mut error| {
                             error.push(STRUCT_NAME, stringify!(r#type));
+                            error
+                        },
+                    )
+                }
+                5 => {
+                    let mut _inner_pilota_value = &mut self.j;
+                    ::pilota::prost::encoding::int64::merge(
+                        wire_type,
+                        _inner_pilota_value,
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(j));
+                        error
+                    })
+                }
+                6 | 8 => {
+                    let mut _inner_pilota_value = &mut self.test;
+                    test::Test::merge(&mut _inner_pilota_value, tag, wire_type, buf, ctx).map_err(
+                        |mut error| {
+                            error.push(STRUCT_NAME, stringify!(test));
                             error
                         },
                     )
@@ -48,6 +97,78 @@ pub mod oneof {
     }
 
     pub mod test {
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
+        #[derivative(Default)]
+        #[derive(Clone, PartialEq)]
+
+        pub enum Test {
+            #[derivative(Default)]
+            A(::pilota::FastStr),
+
+            B(i32),
+        }
+        impl Test {
+            pub fn encode<B>(&self, buf: &mut B)
+            where
+                B: ::pilota::prost::bytes::BufMut,
+            {
+                match self {
+                    Test::A(value) => {
+                        ::pilota::prost::encoding::faststr::encode(6, &*value, buf);
+                    }
+                    Test::B(value) => {
+                        ::pilota::prost::encoding::int32::encode(8, &*value, buf);
+                    }
+                }
+            }
+
+            #[inline]
+            pub fn encoded_len(&self) -> usize {
+                match self {
+                    Test::A(value) => ::pilota::prost::encoding::faststr::encoded_len(6, &*value),
+                    Test::B(value) => ::pilota::prost::encoding::int32::encoded_len(8, &*value),
+                }
+            }
+
+            #[inline]
+            pub fn merge<B>(
+                field: &mut ::core::option::Option<Self>,
+                tag: u32,
+                wire_type: ::pilota::prost::encoding::WireType,
+                buf: &mut B,
+                ctx: ::pilota::prost::encoding::DecodeContext,
+            ) -> ::core::result::Result<(), ::pilota::prost::DecodeError>
+            where
+                B: ::pilota::prost::bytes::Buf,
+            {
+                match tag {
+                    6 => match field {
+                        ::core::option::Option::Some(Test::A(ref mut value)) => {
+                            ::pilota::prost::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::prost::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(Test::A(owned_value));
+                        }
+                    },
+                    8 => match field {
+                        ::core::option::Option::Some(Test::B(ref mut value)) => {
+                            ::pilota::prost::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::prost::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(Test::B(owned_value));
+                        }
+                    },
+                    _ => unreachable!(concat!("invalid ", stringify!(Test), " tag: {}"), tag),
+                };
+                Ok(())
+            }
+        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]


### PR DESCRIPTION
```protobuf
message Test {
    int32 c = 1;
    oneof type {
        string s = 2;
        int32 i = 4;
    }
    int64 j = 5;
    oneof test {
        string a = 6;
        int32 b = 8;
    }
}
```
Before fix:
```rust
pub struct Test {
    pub c: i32,

    pub j: i64,

    pub r#type: ::std::option::Option<test::Type>,

    pub test: ::std::option::Option<test::Test>,
}
```
After fix:
```rust
pub struct Test {
    pub c: i32,

    pub r#type: ::std::option::Option<test::Type>,

    pub j: i64,

    pub test: ::std::option::Option<test::Test>,
}
```