### PR TITLE
feat(pilota-build):generate default impl for volo-cli init.

### DIFF
--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -323,6 +323,23 @@ where
         self.backend.codegen_service_impl(def_id, stream, s);
     }
 
+    /// get service information for volo-cli init, return path of service and
+    /// methods
+    pub fn get_init_service(&self, def_id: DefId) -> (String, String) {
+        let service_path = self.codegen_ty(def_id).global_path_for_volo_gen().into();
+        let methods = self.service_methods(def_id);
+
+        let methods = methods
+            .iter()
+            .map(|m| {
+                self.backend
+                    .codegen_service_method_with_global_path(def_id, m)
+            })
+            .join("\n");
+
+        (service_path, methods)
+    }
+
     pub fn write_new_type(&self, def_id: DefId, stream: &mut String, t: &middle::rir::NewType) {
         let name = self.rust_name(def_id);
         let ty = self.codegen_item_ty(t.ty.kind.clone());

--- a/pilota-build/src/codegen/traits.rs
+++ b/pilota-build/src/codegen/traits.rs
@@ -11,6 +11,15 @@ pub trait CodegenBackend: Clone {
     fn codegen_service_method(&self, _service_def_id: DefId, _method: &Method) -> String {
         Default::default()
     }
+    /// Generate methods for the service trait and use global paths to generate
+    /// the types of the arguments and outputs.
+    fn codegen_service_method_with_global_path(
+        &self,
+        _service_def_id: DefId,
+        _method: &Method,
+    ) -> String {
+        Default::default()
+    }
     fn codegen_enum_impl(&self, _def_id: DefId, _stream: &mut String, _e: &rir::Enum) {}
     fn codegen_newtype_impl(&self, _def_id: DefId, _stream: &mut String, _t: &rir::NewType) {}
 }

--- a/pilota-build/src/db.rs
+++ b/pilota-build/src/db.rs
@@ -50,6 +50,7 @@ pub trait RirDatabase {
 
     fn node(&self, def_id: DefId) -> Option<rir::Node>;
     fn file(&self, file_id: FileId) -> Option<Arc<rir::File>>;
+    fn file_id(&self, path: PathBuf) -> Option<FileId>;
     fn item(&self, def_id: DefId) -> Option<Arc<rir::Item>>;
     fn expect_item(&self, def_id: DefId) -> Arc<rir::Item>;
     fn codegen_item_ty(&self, ty: TyKind) -> CodegenTy;
@@ -80,6 +81,10 @@ fn expect_item(db: &dyn RirDatabase, def_id: DefId) -> Arc<rir::Item> {
 
 fn file(db: &dyn RirDatabase, file_id: FileId) -> Option<Arc<rir::File>> {
     db.files().get(&file_id).cloned()
+}
+
+fn file_id(db: &dyn RirDatabase, path: PathBuf) -> Option<FileId> {
+    db.file_ids_map().get(&path).cloned()
 }
 
 fn codegen_item_ty(db: &dyn RirDatabase, ty: TyKind) -> CodegenTy {

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -222,7 +222,7 @@ where
 
     pub fn build_cx(&mut self, services: Vec<IdlService>, out: Option<Output>) -> Context {
         let mut db = RootDatabase::default();
-        let mut parser = std::mem::replace(&mut self.parser, P::default());
+        let mut parser = std::mem::take(&mut self.parser);
         parser.inputs(services.iter().map(|s| &s.path));
         let ParseResult {
             files,
@@ -291,7 +291,7 @@ where
             input,
         );
 
-        let touches = std::mem::replace(&mut self.touches, Default::default());
+        let touches = std::mem::take(&mut self.touches);
         cx.collect(if self.ignore_unused {
             CollectMode::OnlyUsed { touches }
         } else {
@@ -370,6 +370,7 @@ where
         .unwrap();
     }
 
+    // gen service_global_name and methods for certain service in IdlService
     pub fn init_service(mut self, service: IdlService) -> anyhow::Result<(String, String)> {
         let _ = tracing_subscriber::fmt::try_init();
         let path = service.path.clone();

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -93,7 +93,9 @@ impl CodegenTy {
         }
     }
 
-    fn global_path(&self) -> FastStr {
+    /// get the global path for ty, for adt type, it will return the path
+    /// warpped in volo_gen
+    pub fn global_path_for_volo_gen(&self) -> FastStr {
         match self {
             CodegenTy::String => "::std::string::String".into(),
             CodegenTy::FastStr => "::pilota::FastStr".into(),
@@ -111,27 +113,31 @@ impl CodegenTy {
             CodegenTy::F32 => "f32".into(),
             CodegenTy::StaticRef(ty) => {
                 let ty = &**ty;
-                format!("&'static {}", ty.global_path()).into()
+                format!("&'static {}", ty.global_path_for_volo_gen()).into()
             }
             CodegenTy::Vec(ty) => {
                 let ty = &**ty;
-                format!("::std::vec::Vec<{}>", ty.global_path()).into()
+                format!("::std::vec::Vec<{}>", ty.global_path_for_volo_gen()).into()
             }
             CodegenTy::Array(ty, size) => {
                 let ty = &**ty;
-                format!("[{}; {}]", ty.global_path(), size).into()
+                format!("[{}; {}]", ty.global_path_for_volo_gen(), size).into()
             }
             CodegenTy::Set(ty) => {
                 let ty = &**ty;
-                format!("::std::collections::HashSet<{}>", ty.global_path()).into()
+                format!(
+                    "::std::collections::HashSet<{}>",
+                    ty.global_path_for_volo_gen()
+                )
+                .into()
             }
             CodegenTy::Map(k, v) => {
                 let k = &**k;
                 let v = &**v;
                 format!(
                     "::std::collections::HashMap<{}, {}>",
-                    k.global_path(),
-                    v.global_path()
+                    k.global_path_for_volo_gen(),
+                    v.global_path_for_volo_gen()
                 )
                 .into()
             }
@@ -142,9 +148,9 @@ impl CodegenTy {
             }),
             CodegenTy::Arc(ty) => {
                 let ty = &**ty;
-                format!("::std::sync::Arc<{}>", ty.global_path()).into()
+                format!("::std::sync::Arc<{}>", ty.global_path_for_volo_gen()).into()
             }
-            CodegenTy::LazyStaticRef(ty) => ty.global_path(),
+            CodegenTy::LazyStaticRef(ty) => ty.global_path_for_volo_gen(),
             CodegenTy::Bytes => "::pilota::Bytes".into(),
         }
     }

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -93,7 +93,7 @@ impl CodegenTy {
     }
 
     /// get the global path for ty.
-    pub fn global_path_for_volo_gen(&self) -> faststr::FastStr {
+    pub fn global_path(&self) -> faststr::FastStr {
         match self {
             CodegenTy::String => "::std::string::String".into(),
             CodegenTy::FastStr => "::pilota::FastStr".into(),
@@ -111,31 +111,27 @@ impl CodegenTy {
             CodegenTy::F32 => "f32".into(),
             CodegenTy::StaticRef(ty) => {
                 let ty = &**ty;
-                format!("&'static {}", ty.global_path_for_volo_gen()).into()
+                format!("&'static {}", ty.global_path()).into()
             }
             CodegenTy::Vec(ty) => {
                 let ty = &**ty;
-                format!("::std::vec::Vec<{}>", ty.global_path_for_volo_gen()).into()
+                format!("::std::vec::Vec<{}>", ty.global_path()).into()
             }
             CodegenTy::Array(ty, size) => {
                 let ty = &**ty;
-                format!("[{}; {}]", ty.global_path_for_volo_gen(), size).into()
+                format!("[{}; {}]", ty.global_path(), size).into()
             }
             CodegenTy::Set(ty) => {
                 let ty = &**ty;
-                format!(
-                    "::std::collections::HashSet<{}>",
-                    ty.global_path_for_volo_gen()
-                )
-                .into()
+                format!("::std::collections::HashSet<{}>", ty.global_path()).into()
             }
             CodegenTy::Map(k, v) => {
                 let k = &**k;
                 let v = &**v;
                 format!(
                     "::std::collections::HashMap<{}, {}>",
-                    k.global_path_for_volo_gen(),
-                    v.global_path_for_volo_gen()
+                    k.global_path(),
+                    v.global_path()
                 )
                 .into()
             }
@@ -146,9 +142,9 @@ impl CodegenTy {
             }),
             CodegenTy::Arc(ty) => {
                 let ty = &**ty;
-                format!("::std::sync::Arc<{}>", ty.global_path_for_volo_gen()).into()
+                format!("::std::sync::Arc<{}>", ty.global_path()).into()
             }
-            CodegenTy::LazyStaticRef(ty) => ty.global_path_for_volo_gen(),
+            CodegenTy::LazyStaticRef(ty) => ty.global_path(),
             CodegenTy::Bytes => "::pilota::Bytes".into(),
         }
     }

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Display, sync::Arc};
 
-use faststr::FastStr;
 pub use TyKind::*;
 
 use super::{context::tls::with_cx, rir::Path};
@@ -93,9 +92,8 @@ impl CodegenTy {
         }
     }
 
-    /// get the global path for ty, for adt type, it will return the path
-    /// warpped in volo_gen
-    pub fn global_path_for_volo_gen(&self) -> FastStr {
+    /// get the global path for ty.
+    pub fn global_path_for_volo_gen(&self) -> faststr::FastStr {
         match self {
             CodegenTy::String => "::std::string::String".into(),
             CodegenTy::FastStr => "::pilota::FastStr".into(),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

[volo-issue5](https://github.com/cloudwego/volo/issues/5)

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Because the service may  use the variables of the imported package, so we need to use global path other than cur_related_path in codegen_service_method.

1. build codegen context
2. pick a service def
3. call codegen_service_method_with_global_path