### PR TITLE
fix: missing i8 type

### DIFF
--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -601,6 +601,7 @@ impl Context {
                 format! { "::pilota::FastStr::from_static_str(\"{s}\")" }.into(),
                 true,
             ),
+            (Literal::Int(i), CodegenTy::I8) => (format! { "{i}i8" }.into(), true),
             (Literal::Int(i), CodegenTy::I16) => (format! { "{i}i16" }.into(), true),
             (Literal::Int(i), CodegenTy::I32) => (format! { "{i}i32" }.into(), true),
             (Literal::Int(i), CodegenTy::I64) => (format! { "{i}i64" }.into(), true),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
pilota build failed
```thrift
struct Number {
    1: optional i8 a = 0; 
}
```

``` 
 thread 'main' panicked at 'unexpected literal Int(0) with ty I8', .../rsproxy.cn-8f6827c7555bfaf8/pilota-build-0.7.7/src/middle/context.rs:678:18
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
code gen i8 type
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
