### PR TITLE
perf: rewrite skip function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,6 +731,7 @@ dependencies = [
  "proptest",
  "rand",
  "serde",
+ "smallvec",
  "thiserror",
  "tokio",
 ]

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -96,17 +96,21 @@ pub mod serde {
                 protocol.read_struct_end()?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field a is required".to_string(),
-                    ));
-                };
+                            "field a is required".to_string()
+                    )
+                )
+            };
                 let Some(b) = b else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field b is required".to_string(),
-                    ));
-                };
+                            "field b is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { a, b };
                 Ok(data)
@@ -165,17 +169,21 @@ pub mod serde {
                 protocol.read_struct_end().await?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field a is required".to_string(),
-                    ));
-                };
+                            "field a is required".to_string()
+                    )
+                )
+            };
                 let Some(b) = b else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field b is required".to_string(),
-                    ));
-                };
+                            "field b is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { a, b };
                 Ok(data)

--- a/pilota-build/test_data/thrift/binary_bytes.rs
+++ b/pilota-build/test_data/thrift/binary_bytes.rs
@@ -86,17 +86,21 @@ pub mod binary_bytes {
                 protocol.read_struct_end()?;
 
                 let Some(bytes) = bytes else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field bytes is required".to_string(),
-                    ));
-                };
+                            "field bytes is required".to_string()
+                    )
+                )
+            };
                 let Some(vec) = vec else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field vec is required".to_string(),
-                    ));
-                };
+                            "field vec is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { bytes, vec };
                 Ok(data)
@@ -157,17 +161,21 @@ pub mod binary_bytes {
                 protocol.read_struct_end().await?;
 
                 let Some(bytes) = bytes else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field bytes is required".to_string(),
-                    ));
-                };
+                            "field bytes is required".to_string()
+                    )
+                )
+            };
                 let Some(vec) = vec else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field vec is required".to_string(),
-                    ));
-                };
+                            "field vec is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { bytes, vec };
                 Ok(data)

--- a/pilota-build/test_data/thrift/decode_error.rs
+++ b/pilota-build/test_data/thrift/decode_error.rs
@@ -77,11 +77,13 @@ pub mod decode_error {
                 protocol.read_struct_end()?;
 
                 let Some(b) = b else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field b is required".to_string(),
-                    ));
-                };
+                            "field b is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { b };
                 Ok(data)
@@ -136,11 +138,13 @@ pub mod decode_error {
                 protocol.read_struct_end().await?;
 
                 let Some(b) = b else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field b is required".to_string(),
-                    ));
-                };
+                            "field b is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { b };
                 Ok(data)
@@ -230,11 +234,13 @@ pub mod decode_error {
                 protocol.read_struct_end()?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field a is required".to_string(),
-                    ));
-                };
+                            "field a is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { a };
                 Ok(data)
@@ -289,11 +295,13 @@ pub mod decode_error {
                 protocol.read_struct_end().await?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field a is required".to_string(),
-                    ));
-                };
+                            "field a is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { a };
                 Ok(data)
@@ -383,11 +391,13 @@ pub mod decode_error {
                 protocol.read_struct_end()?;
 
                 let Some(c) = c else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field c is required".to_string(),
-                    ));
-                };
+                            "field c is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { c };
                 Ok(data)
@@ -442,11 +452,13 @@ pub mod decode_error {
                 protocol.read_struct_end().await?;
 
                 let Some(c) = c else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field c is required".to_string(),
-                    ));
-                };
+                            "field c is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { c };
                 Ok(data)

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -472,29 +472,37 @@ pub mod normal {
                 protocol.read_struct_end()?;
 
                 let Some(msg) = msg else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field msg is required".to_string(),
-                    ));
-                };
+                            "field msg is required".to_string()
+                    )
+                )
+            };
                 let Some(msg_map) = msg_map else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field msg_map is required".to_string(),
-                    ));
-                };
+                            "field msg_map is required".to_string()
+                    )
+                )
+            };
                 let Some(sub_msgs) = sub_msgs else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field sub_msgs is required".to_string(),
-                    ));
-                };
+                            "field sub_msgs is required".to_string()
+                    )
+                )
+            };
                 let Some(flag_msg) = flag_msg else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field flag_msg is required".to_string(),
-                    ));
-                };
+                            "field flag_msg is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     msg,
@@ -618,29 +626,37 @@ pub mod normal {
                 protocol.read_struct_end().await?;
 
                 let Some(msg) = msg else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field msg is required".to_string(),
-                    ));
-                };
+                            "field msg is required".to_string()
+                    )
+                )
+            };
                 let Some(msg_map) = msg_map else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field msg_map is required".to_string(),
-                    ));
-                };
+                            "field msg_map is required".to_string()
+                    )
+                )
+            };
                 let Some(sub_msgs) = sub_msgs else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field sub_msgs is required".to_string(),
-                    ));
-                };
+                            "field sub_msgs is required".to_string()
+                    )
+                )
+            };
                 let Some(flag_msg) = flag_msg else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field flag_msg is required".to_string(),
-                    ));
-                };
+                            "field flag_msg is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     msg,
@@ -913,11 +929,13 @@ pub mod normal {
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -976,11 +994,13 @@ pub mod normal {
                 protocol.read_struct_end().await?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -1598,11 +1618,13 @@ pub mod normal {
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -1661,11 +1683,13 @@ pub mod normal {
                 protocol.read_struct_end().await?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -84,11 +84,13 @@ pub mod pilota_name {
                 protocol.read_struct_end()?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field id is required".to_string(),
-                    ));
-                };
+                            "field id is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { id };
                 Ok(data)
@@ -143,11 +145,13 @@ pub mod pilota_name {
                 protocol.read_struct_end().await?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field id is required".to_string(),
-                    ));
-                };
+                            "field id is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { id };
                 Ok(data)
@@ -242,11 +246,13 @@ pub mod pilota_name {
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -305,11 +311,13 @@ pub mod pilota_name {
                 protocol.read_struct_end().await?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -552,17 +560,21 @@ pub mod pilota_name {
                 protocol.read_struct_end()?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field id is required".to_string(),
-                    ));
-                };
+                            "field id is required".to_string()
+                    )
+                )
+            };
                 let Some(hello) = hello else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field hello is required".to_string(),
-                    ));
-                };
+                            "field hello is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { id, hello };
                 Ok(data)
@@ -623,17 +635,21 @@ pub mod pilota_name {
                 protocol.read_struct_end().await?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field id is required".to_string(),
-                    ));
-                };
+                            "field id is required".to_string()
+                    )
+                )
+            };
                 let Some(hello) = hello else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field hello is required".to_string(),
-                    ));
-                };
+                            "field hello is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { id, hello };
                 Ok(data)
@@ -729,11 +745,13 @@ pub mod pilota_name {
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -792,11 +810,13 @@ pub mod pilota_name {
                 protocol.read_struct_end().await?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -157,11 +157,13 @@ pub mod self_kw {
                 protocol.read_struct_end()?;
 
                 let Some(r#type) = r#type else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field r#type is required".to_string(),
-                    ));
-                };
+                            "field r#type is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { r#type };
                 Ok(data)
@@ -216,11 +218,13 @@ pub mod self_kw {
                 protocol.read_struct_end().await?;
 
                 let Some(r#type) = r#type else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field r#type is required".to_string(),
-                    ));
-                };
+                            "field r#type is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { r#type };
                 Ok(data)

--- a/pilota-build/test_data/thrift/string.rs
+++ b/pilota-build/test_data/thrift/string.rs
@@ -86,17 +86,21 @@ pub mod string {
                 protocol.read_struct_end()?;
 
                 let Some(faststr) = faststr else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field faststr is required".to_string(),
-                    ));
-                };
+                            "field faststr is required".to_string()
+                    )
+                )
+            };
                 let Some(string) = string else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field string is required".to_string(),
-                    ));
-                };
+                            "field string is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { faststr, string };
                 Ok(data)
@@ -157,17 +161,21 @@ pub mod string {
                 protocol.read_struct_end().await?;
 
                 let Some(faststr) = faststr else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field faststr is required".to_string(),
-                    ));
-                };
+                            "field faststr is required".to_string()
+                    )
+                )
+            };
                 let Some(string) = string else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field string is required".to_string(),
-                    ));
-                };
+                            "field string is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { faststr, string };
                 Ok(data)

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -340,11 +340,13 @@ pub mod wrapper_arc {
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -403,11 +405,13 @@ pub mod wrapper_arc {
                 protocol.read_struct_end().await?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -746,23 +750,29 @@ pub mod wrapper_arc {
                 protocol.read_struct_end()?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field id is required".to_string(),
-                    ));
-                };
+                            "field id is required".to_string()
+                    )
+                )
+            };
                 let Some(name2) = name2 else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field name2 is required".to_string(),
-                    ));
-                };
+                            "field name2 is required".to_string()
+                    )
+                )
+            };
                 let Some(name3) = name3 else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field name3 is required".to_string(),
-                    ));
-                };
+                            "field name3 is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { id, name2, name3 };
                 Ok(data)
@@ -868,23 +878,29 @@ pub mod wrapper_arc {
                 protocol.read_struct_end().await?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field id is required".to_string(),
-                    ));
-                };
+                            "field id is required".to_string()
+                    )
+                )
+            };
                 let Some(name2) = name2 else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field name2 is required".to_string(),
-                    ));
-                };
+                            "field name2 is required".to_string()
+                    )
+                )
+            };
                 let Some(name3) = name3 else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field name3 is required".to_string(),
-                    ));
-                };
+                            "field name3 is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { id, name2, name3 };
                 Ok(data)
@@ -1007,11 +1023,13 @@ pub mod wrapper_arc {
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -1071,11 +1089,13 @@ pub mod wrapper_arc {
                 protocol.read_struct_end().await?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -402,17 +402,21 @@ pub mod unknown_fields {
                 protocol.read_struct_end()?;
 
                 let Some(bytes) = bytes else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field bytes is required".to_string(),
-                    ));
-                };
+                            "field bytes is required".to_string()
+                    )
+                )
+            };
                 let Some(vec) = vec else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field vec is required".to_string(),
-                    ));
-                };
+                            "field vec is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     bytes,
@@ -477,17 +481,21 @@ pub mod unknown_fields {
                 protocol.read_struct_end().await?;
 
                 let Some(bytes) = bytes else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field bytes is required".to_string(),
-                    ));
-                };
+                            "field bytes is required".to_string()
+                    )
+                )
+            };
                 let Some(vec) = vec else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field vec is required".to_string(),
-                    ));
-                };
+                            "field vec is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     bytes,
@@ -588,11 +596,13 @@ pub mod unknown_fields {
                 protocol.read_struct_end()?;
 
                 let Some(td) = td else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field td is required".to_string(),
-                    ));
-                };
+                            "field td is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     td,
@@ -648,11 +658,13 @@ pub mod unknown_fields {
                 protocol.read_struct_end().await?;
 
                 let Some(td) = td else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field td is required".to_string(),
-                    ));
-                };
+                            "field td is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     td,
@@ -940,23 +952,29 @@ pub mod unknown_fields {
                 protocol.read_struct_end()?;
 
                 let Some(faststr) = faststr else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field faststr is required".to_string(),
-                    ));
-                };
+                            "field faststr is required".to_string()
+                    )
+                )
+            };
                 let Some(string) = string else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field string is required".to_string(),
-                    ));
-                };
+                            "field string is required".to_string()
+                    )
+                )
+            };
                 let Some(list) = list else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field list is required".to_string(),
-                    ));
-                };
+                            "field list is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     faststr,
@@ -1042,23 +1060,29 @@ pub mod unknown_fields {
                 protocol.read_struct_end().await?;
 
                 let Some(faststr) = faststr else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field faststr is required".to_string(),
-                    ));
-                };
+                            "field faststr is required".to_string()
+                    )
+                )
+            };
                 let Some(string) = string else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field string is required".to_string(),
-                    ));
-                };
+                            "field string is required".to_string()
+                    )
+                )
+            };
                 let Some(list) = list else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field list is required".to_string(),
-                    ));
-                };
+                            "field list is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     faststr,
@@ -1607,11 +1631,13 @@ pub mod unknown_fields {
                 protocol.read_struct_end()?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field a is required".to_string(),
-                    ));
-                };
+                            "field a is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { a, _unknown_fields };
                 Ok(data)
@@ -1666,11 +1692,13 @@ pub mod unknown_fields {
                 protocol.read_struct_end().await?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field a is required".to_string(),
-                    ));
-                };
+                            "field a is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self {
                     a,
@@ -2705,11 +2733,13 @@ pub mod unknown_fields {
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -2768,11 +2798,13 @@ pub mod unknown_fields {
                 protocol.read_struct_end().await?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -3072,11 +3104,13 @@ pub mod unknown_fields {
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)
@@ -3135,11 +3169,13 @@ pub mod unknown_fields {
                 protocol.read_struct_end().await?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::DecodeError::new(
+                return Err(
+                    ::pilota::thrift::DecodeError::new(
                         ::pilota::thrift::DecodeErrorKind::InvalidData,
-                        "field req is required".to_string(),
-                    ));
-                };
+                            "field req is required".to_string()
+                    )
+                )
+            };
 
                 let data = Self { req };
                 Ok(data)

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -36,6 +36,7 @@ integer-encoding = { version = "3", features = [
 ] }
 proptest = "1"
 serde = { version = "1", features = ["derive"] }
+smallvec = "1"
 
 [dev-dependencies]
 criterion = "0.5"
@@ -47,4 +48,8 @@ harness = false
 
 [[bench]]
 name = "thrift_binary"
+harness = false
+
+[[bench]]
+name = "skip"
 harness = false

--- a/pilota/benches/skip.rs
+++ b/pilota/benches/skip.rs
@@ -1,0 +1,137 @@
+use std::collections::{HashMap, HashSet};
+
+use bytes::{Bytes, BytesMut};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use faststr::FastStr;
+use pilota::thrift::{
+    binary_unsafe::TBinaryUnsafeInputProtocol, DecodeError, TInputProtocol, TOutputProtocol,
+    TOutputProtocolExt, TStructIdentifier, TType,
+};
+
+use rand::Rng;
+
+fn skip_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Thrift Binary Skip Bench");
+
+    let buf = generate_list_i32();
+    group.bench_function("binary_unsafe skip list<i32>", |b| {
+        b.iter(|| {
+            black_box({
+                let b = buf.clone();
+                let b_len = b.len();
+                match black_box(skip_binary_unsafe(b, TType::List)) {
+                    Ok(size) => assert_eq!(size, b_len),
+                    Err(_) => panic!("skip decode error"),
+                }
+            });
+        });
+    });
+
+    let buf = generate_struct();
+    group.bench_function("binary_unsafe skip struct", |b| {
+        b.iter(|| {
+            black_box({
+                let b = buf.clone();
+                let b_len = b.len();
+                match black_box(skip_binary_unsafe(b, TType::Struct)) {
+                    Ok(size) => assert_eq!(size, b_len),
+                    Err(_) => panic!("skip decode error"),
+                }
+            });
+        });
+    });
+
+    group.finish();
+}
+
+fn generate_list_i32() -> Bytes {
+    let mut rng = rand::thread_rng();
+    let vec_size: usize = 100;
+    let v: Vec<i32> = (0..vec_size).map(|_| rng.gen()).collect();
+
+    let mut buf = BytesMut::new();
+
+    let mut p = pilota::thrift::binary::TBinaryProtocol::new(&mut buf, true);
+    p.write_list(TType::I32, &v, |protocol, e| {
+        protocol.write_i32(e.clone())?;
+        Ok(())
+    })
+    .unwrap();
+    drop(p);
+    buf.freeze()
+}
+
+fn generate_struct() -> Bytes {
+    let mut buf = BytesMut::new();
+
+    let mut p = pilota::thrift::binary::TBinaryProtocol::new(&mut buf, true);
+    p.write_struct_begin(&TStructIdentifier { name: "test" })
+        .unwrap();
+    p.write_i8_field(1, 8).unwrap();
+    p.write_i64_field(2, 64).unwrap();
+    p.write_uuid_field(3, [1; 16]).unwrap();
+    p.write_i32_field(4, 32).unwrap();
+    p.write_faststr_field(5, FastStr::new("string")).unwrap();
+    p.write_bytes_field(6, Bytes::from("stringbytes")).unwrap();
+    p.write_double_field(7, 0.42).unwrap();
+    p.write_i16_field(8, 16).unwrap();
+    p.write_bool_field(9, false).unwrap();
+    p.write_map_field(
+        101,
+        TType::Binary,
+        TType::I32,
+        &HashMap::from([("key1", 1), ("key2", 2), ("key3", 3)]),
+        |protocol, key| {
+            protocol.write_string(*key)?;
+            Ok(())
+        },
+        |protocol, val| {
+            protocol.write_i32(*val)?;
+            Ok(())
+        },
+    )
+    .unwrap();
+    p.write_set_field(
+        201,
+        TType::Binary,
+        &HashSet::from(["set1", "set2", "set3"]),
+        |protocol, key| {
+            protocol.write_string(*key)?;
+            Ok(())
+        },
+    )
+    .unwrap();
+    p.write_list_field(
+        301,
+        TType::Binary,
+        &["set1", "set2", "set3"],
+        |protocol, key| {
+            protocol.write_string(*key)?;
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    let struct_buf = p.buf_mut().clone();
+    p.write_field_begin(TType::Struct, 401).unwrap();
+    p.write_bytes_without_len(struct_buf.freeze()).unwrap();
+    p.write_field_stop().unwrap();
+    p.write_struct_end().unwrap();
+    p.write_field_end().unwrap();
+
+    p.write_field_stop().unwrap();
+    p.write_struct_end().unwrap();
+    drop(p);
+    buf.freeze()
+}
+
+#[inline(never)]
+fn skip_binary_unsafe(mut b: Bytes, ttype: TType) -> Result<usize, DecodeError> {
+    unsafe {
+        let mut p = TBinaryUnsafeInputProtocol::new(&mut b);
+        p.skip_till_depth(ttype, 100)
+    }
+}
+
+criterion_group!(benches, skip_bench);
+criterion_main!(benches);

--- a/pilota/src/thrift/mod.rs
+++ b/pilota/src/thrift/mod.rs
@@ -921,6 +921,26 @@ impl TryFrom<u8> for TType {
     }
 }
 
+const BINARY_BASIC_TYPE_FIXED_SIZE: [usize; 17] = [
+    0,  // TType::Stop
+    0,  // TType::Void
+    1,  // TType::Bool
+    1,  // TType::I8
+    8,  // TType::Double
+    0,  // NAN
+    2,  // TType::I16
+    0,  // NAN
+    4,  // TType::I32
+    0,  // NAN
+    8,  // TType::I64
+    0,  // TType::Binary
+    0,  // TType::Struct
+    0,  // TType::Map
+    0,  // TType::List
+    0,  // TType::Set
+    16, // TType::Uuid
+];
+
 /// Thrift message types.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]


### PR DESCRIPTION
Rewrite skip function using loops and fast skipping for fixed-length types

## Motivation

Improving the performance of the skip function.

## Solution

Using loops and fast skipping for fixed-length types.

cargo bench result(the old version is baseline):
```
 Thrift Binary Skip Bench/binary_unsafe skip list<i32>
                        time:   [32.492 ns 32.665 ns 32.859 ns]
                        change: [-93.907% -93.787% -93.682%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

Thrift Binary Skip Bench/binary_unsafe skip struct
                        time:   [342.44 ns 346.33 ns 350.27 ns]
                        change: [-6.1207% -4.4530% -2.6464%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
```
