### PR TITLE
support workspace user gen code outside

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 mod serde;
+mod workspace;
 
 pub use self::serde::SerdePlugin;
 
@@ -303,6 +304,10 @@ impl<T> Plugin for Box<T>
 where
     T: Plugin + ?Sized,
 {
+    fn on_codegen_uint(&mut self, cx: &Context, items: &[DefId]) {
+        self.deref_mut().on_codegen_uint(cx, items)
+    }
+
     fn on_item(&mut self, cx: &Context, def_id: DefId, item: Arc<Item>) {
         self.deref_mut().on_item(cx, def_id, item)
     }

--- a/pilota-build/src/plugin/workspace.rs
+++ b/pilota-build/src/plugin/workspace.rs
@@ -1,0 +1,45 @@
+use crate::{
+    db::RirDatabase,
+    middle::context::tls::CUR_ITEM,
+    rir::{Item, NodeKind},
+    Plugin,
+};
+
+#[derive(Clone, Copy)]
+pub struct _WorkspacePlugin;
+
+impl Plugin for _WorkspacePlugin {
+    fn on_codegen_uint(&mut self, cx: &crate::Context, _items: &[crate::DefId]) {
+        cx.entry_map.iter().for_each(|(k, v)| {
+            cx.plugin_gen.insert(k.clone(), "".to_string());
+            v.iter().for_each(|(def_id, _)| {
+                CUR_ITEM.set(def_id, || {
+                    let node = cx.node(*def_id).unwrap();
+
+                    match &node.kind {
+                        NodeKind::Item(item) => self.on_item(cx, *def_id, item.clone()),
+                        _ => {}
+                    }
+                });
+            })
+        });
+    }
+
+    fn on_item(
+        &mut self,
+        cx: &crate::Context,
+        def_id: crate::DefId,
+        item: std::sync::Arc<crate::rir::Item>,
+    ) {
+        match &*item {
+            Item::Service(s) => {
+                if let Some(loc) = cx.location_map.get(&def_id) {
+                    if let Some(mut gen) = cx.plugin_gen.get_mut(loc) {
+                        gen.push_str(&format!("pub struct {};", s.name.sym));
+                    }
+                };
+            }
+            _ => {}
+        }
+    }
+}

--- a/pilota-thrift-parser/src/descriptor/mod.rs
+++ b/pilota-thrift-parser/src/descriptor/mod.rs
@@ -93,7 +93,7 @@ impl Eq for File {}
 
 impl PartialOrd for File {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.path.partial_cmp(&other.path)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
In workspace mode, user can write plugin to generate code in lib.rs rather than gen.rs, example code can be seen in pilota-build/src/plugin/workspace.rs.
