### PR TITLE
fixed warnings in gen codes

### DIFF
--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -1,8 +1,10 @@
-use std::{fmt::Display, sync::Arc};
+use std::fmt::Display;
+pub use std::sync::Arc;
 
 pub use TyKind::*;
 
-use super::{context::tls::with_cx, rir::Path};
+use super::context::tls::with_cx;
+pub use super::rir::Path;
 use crate::{db::RirDatabase, symbol::DefId, tags::TagId};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Ignore warnings in workspace gen codes. And fixed hidden_glob_reexports in pilota-build.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added `#![allow(warnings, clippy::all)]` in workspace gen codes. And pub use Arc & Path.