### PR TITLE
fix: generate struct in common crate rather than its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "criterion",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.9.8"
+version = "0.9.9"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/middle/type_graph.rs
+++ b/pilota-build/src/middle/type_graph.rs
@@ -11,16 +11,20 @@ use crate::symbol::DefId;
 
 #[derive(Debug)]
 pub struct TypeGraph {
-    graph: Graph<DefId, ()>,
-    node_map: FxHashMap<DefId, NodeIndex>,
+    pub(crate) graph: Graph<DefId, ()>,
+    pub(crate) node_map: FxHashMap<DefId, NodeIndex>,
+    pub(crate) id_map: FxHashMap<NodeIndex, DefId>,
 }
 
 impl TypeGraph {
     pub fn from_items(items: impl Iterator<Item = (DefId, Arc<Item>)> + Clone) -> Self {
         let mut graph: Graph<DefId, ()> = Graph::new();
         let mut node_map = FxHashMap::default();
+        let mut id_map = FxHashMap::default();
         items.clone().for_each(|(def_id, _)| {
-            node_map.insert(def_id, graph.add_node(def_id));
+            let node_index = graph.add_node(def_id);
+            node_map.insert(def_id, node_index);
+            id_map.insert(node_index, def_id);
         });
 
         items.for_each(|(def_id, item)| {
@@ -46,7 +50,11 @@ impl TypeGraph {
                 _ => {}
             };
         });
-        Self { graph, node_map }
+        Self {
+            graph,
+            node_map,
+            id_map,
+        }
     }
 
     pub fn is_nested(&self, a: DefId, b: DefId) -> bool {


### PR DESCRIPTION
Prevent the common crate from depending on other crates to escape the cyclic dependencies.