### PR TITLE
fix: generate i8 for thrift byte

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "criterion",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -422,7 +422,7 @@ impl ThriftLower {
         let kind = match &ty.0 {
             thrift_parser::Ty::String => ir::TyKind::String,
             thrift_parser::Ty::Void => ir::TyKind::Void,
-            thrift_parser::Ty::Byte => ir::TyKind::U8,
+            thrift_parser::Ty::Byte => ir::TyKind::I8,
             thrift_parser::Ty::Bool => ir::TyKind::Bool,
             thrift_parser::Ty::Binary => ir::TyKind::Bytes,
             thrift_parser::Ty::I8 => ir::TyKind::I8,

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -92,12 +92,15 @@ pub mod default_value {
             fn default() -> Self {
                 C {
                     off: Some(::pilota::FastStr::from_static_str("off")),
+                    test_byte: Some(0i8),
                 }
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub struct C {
             pub off: ::std::option::Option<::pilota::FastStr>,
+
+            pub test_byte: ::std::option::Option<i8>,
         }
         impl ::pilota::thrift::Message for C {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -112,6 +115,9 @@ pub mod default_value {
                 if let Some(value) = self.off.as_ref() {
                     protocol.write_faststr_field(1, (value).clone())?;
                 }
+                if let Some(value) = self.test_byte.as_ref() {
+                    protocol.write_i8_field(2, *value)?;
+                }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
                 Ok(())
@@ -124,6 +130,7 @@ pub mod default_value {
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
 
                 let mut off = Some(::pilota::FastStr::from_static_str("off"));
+                let mut test_byte = Some(0i8);
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -143,6 +150,9 @@ pub mod default_value {
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
                                 off = Some(protocol.read_faststr()?);
+                            }
+                            Some(2) if field_ident.field_type == ::pilota::thrift::TType::I8 => {
+                                test_byte = Some(protocol.read_i8()?);
                             }
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
@@ -167,7 +177,7 @@ pub mod default_value {
                 };
                 protocol.read_struct_end()?;
 
-                let data = Self { off };
+                let data = Self { off, test_byte };
                 Ok(data)
             }
 
@@ -183,6 +193,7 @@ pub mod default_value {
             > {
                 ::std::boxed::Box::pin(async move {
                     let mut off = Some(::pilota::FastStr::from_static_str("off"));
+                    let mut test_byte = Some(0i8);
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -201,6 +212,11 @@ pub mod default_value {
                                         == ::pilota::thrift::TType::Binary =>
                                 {
                                     off = Some(protocol.read_faststr().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type == ::pilota::thrift::TType::I8 =>
+                                {
+                                    test_byte = Some(protocol.read_i8().await?);
                                 }
                                 _ => {
                                     protocol.skip(field_ident.field_type).await?;
@@ -226,7 +242,7 @@ pub mod default_value {
                     };
                     protocol.read_struct_end().await?;
 
-                    let data = Self { off };
+                    let data = Self { off, test_byte };
                     Ok(data)
                 })
             }
@@ -239,6 +255,10 @@ pub mod default_value {
                         .off
                         .as_ref()
                         .map_or(0, |value| protocol.faststr_field_len(Some(1), value))
+                    + self
+                        .test_byte
+                        .as_ref()
+                        .map_or(0, |value| protocol.i8_field_len(Some(2), *value))
                     + protocol.field_stop_len()
                     + protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/default_value.thrift
+++ b/pilota-build/test_data/thrift/default_value.thrift
@@ -19,4 +19,5 @@ struct A {
 
 struct C {
     1: string off = "off",
+    2: optional byte test_byte = 0,
 }

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -513,12 +513,15 @@ pub mod multi {
             fn default() -> Self {
                 C {
                     off: Some(::pilota::FastStr::from_static_str("off")),
+                    test_byte: Some(0i8),
                 }
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub struct C {
             pub off: ::std::option::Option<::pilota::FastStr>,
+
+            pub test_byte: ::std::option::Option<i8>,
         }
         impl ::pilota::thrift::Message for C {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -533,6 +536,9 @@ pub mod multi {
                 if let Some(value) = self.off.as_ref() {
                     protocol.write_faststr_field(1, (value).clone())?;
                 }
+                if let Some(value) = self.test_byte.as_ref() {
+                    protocol.write_i8_field(2, *value)?;
+                }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
                 Ok(())
@@ -545,6 +551,7 @@ pub mod multi {
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
 
                 let mut off = Some(::pilota::FastStr::from_static_str("off"));
+                let mut test_byte = Some(0i8);
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -564,6 +571,9 @@ pub mod multi {
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
                                 off = Some(protocol.read_faststr()?);
+                            }
+                            Some(2) if field_ident.field_type == ::pilota::thrift::TType::I8 => {
+                                test_byte = Some(protocol.read_i8()?);
                             }
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
@@ -588,7 +598,7 @@ pub mod multi {
                 };
                 protocol.read_struct_end()?;
 
-                let data = Self { off };
+                let data = Self { off, test_byte };
                 Ok(data)
             }
 
@@ -604,6 +614,7 @@ pub mod multi {
             > {
                 ::std::boxed::Box::pin(async move {
                     let mut off = Some(::pilota::FastStr::from_static_str("off"));
+                    let mut test_byte = Some(0i8);
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -622,6 +633,11 @@ pub mod multi {
                                         == ::pilota::thrift::TType::Binary =>
                                 {
                                     off = Some(protocol.read_faststr().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type == ::pilota::thrift::TType::I8 =>
+                                {
+                                    test_byte = Some(protocol.read_i8().await?);
                                 }
                                 _ => {
                                     protocol.skip(field_ident.field_type).await?;
@@ -647,7 +663,7 @@ pub mod multi {
                     };
                     protocol.read_struct_end().await?;
 
-                    let data = Self { off };
+                    let data = Self { off, test_byte };
                     Ok(data)
                 })
             }
@@ -660,6 +676,10 @@ pub mod multi {
                         .off
                         .as_ref()
                         .map_or(0, |value| protocol.faststr_field_len(Some(1), value))
+                    + self
+                        .test_byte
+                        .as_ref()
+                        .map_or(0, |value| protocol.i8_field_len(Some(2), *value))
                     + protocol.field_stop_len()
                     + protocol.struct_end_len()
             }
@@ -673,6 +693,7 @@ pub mod multi {
                 A {
                     c: Some(super::default_value::C {
                         off: Some(::pilota::FastStr::from_static_str("off")),
+                        test_byte: Default::default(),
                     }),
                 }
             }
@@ -705,9 +726,7 @@ pub mod multi {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
 
-                let mut c = Some(super::default_value::C {
-                    off: Some(::pilota::FastStr::from_static_str("off")),
-                });
+                let mut c = None;
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -751,6 +770,13 @@ pub mod multi {
                 };
                 protocol.read_struct_end()?;
 
+                if c.is_none() {
+                    c = Some(super::default_value::C {
+                        off: Some(::pilota::FastStr::from_static_str("off")),
+                        test_byte: Default::default(),
+                    });
+                }
+
                 let data = Self { c };
                 Ok(data)
             }
@@ -766,9 +792,7 @@ pub mod multi {
                 >,
             > {
                 ::std::boxed::Box::pin(async move {
-                    let mut c = Some(super::default_value::C {
-                        off: Some(::pilota::FastStr::from_static_str("off")),
-                    });
+                    let mut c = None;
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -812,6 +836,13 @@ pub mod multi {
                 }
             };
                     protocol.read_struct_end().await?;
+
+                    if c.is_none() {
+                        c = Some(super::default_value::C {
+                            off: Some(::pilota::FastStr::from_static_str("off")),
+                            test_byte: Default::default(),
+                        });
+                    }
 
                     let data = Self { c };
                     Ok(data)


### PR DESCRIPTION
https://thrift.apache.org/docs/types

Notice: maybe a break change for those who already used byte in the idl.