### PR TITLE
feat(pilota-build): add feature `ahash` for choosing hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +786,7 @@ dependencies = [
 name = "pilota"
 version = "0.9.0"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-recursion",
  "bytes",
@@ -1463,6 +1477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1667,4 +1687,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -390,7 +390,10 @@ impl ThriftBackend {
                 let read_set_end = helper.codegen_read_set_end();
                 let read_el = self.codegen_decode_ty(helper, ty);
                 format! {r#"{{let list_ident = {read_set_begin};
-                    let mut val = ::std::collections::HashSet::with_capacity(list_ident.size);
+                    let mut val = ::std::collections::HashSet::with_capacity_and_hasher(
+                        list_ident.size,
+                        ::pilota::Hasher::new(),
+                    );
                     for _ in 0..list_ident.size {{
                         val.insert({read_el});
                     }};
@@ -408,7 +411,10 @@ impl ThriftBackend {
                 format! {
                     r#"{{
                         let map_ident = {read_map_begin};
-                        let mut val = ::std::collections::HashMap::with_capacity(map_ident.size);
+                        let mut val = ::std::collections::HashMap::with_capacity_and_hasher(
+                            map_ident.size,
+                            ::pilota::Hasher::new(),
+                        );
                         for _ in 0..map_ident.size {{
                             val.insert({read_el_key}, {read_el_val});
                         }}

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -530,7 +530,10 @@ impl Context {
                 .join("");
             anyhow::Ok(
                 format! {r#"{{
-                    let mut map = ::std::collections::HashMap::with_capacity({len});
+                    let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                        {len},
+                        ::pilota::Hasher::new(),
+                    );
                     {kvs}
                     map
                 }}"#}

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -129,13 +129,17 @@ impl CodegenTy {
             }
             CodegenTy::Set(ty) => {
                 let ty = &**ty;
-                format!("::std::collections::HashSet<{}>", ty.global_path()).into()
+                format!(
+                    "::std::collections::HashSet<{}, ::pilota::Hasher>",
+                    ty.global_path()
+                )
+                .into()
             }
             CodegenTy::Map(k, v) => {
                 let k = &**k;
                 let v = &**v;
                 format!(
-                    "::std::collections::HashMap<{}, {}>",
+                    "::std::collections::HashMap<{}, {}, ::pilota::Hasher>",
                     k.global_path(),
                     v.global_path()
                 )
@@ -192,12 +196,12 @@ impl Display for CodegenTy {
             }
             CodegenTy::Set(ty) => {
                 let ty = &**ty;
-                write!(f, "::std::collections::HashSet<{ty}>")
+                write!(f, "::std::collections::HashSet<{ty}, ::pilota::Hasher>")
             }
             CodegenTy::Map(k, v) => {
                 let k = &**k;
                 let v = &**v;
-                write!(f, "::std::collections::HashMap<{k}, {v}>")
+                write!(f, "::std::collections::HashMap<{k}, {v}, ::pilota::Hasher>")
             }
             CodegenTy::Adt(def) => with_cx(|cx| {
                 let path = cx.cur_related_item_path(def.did);

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -48,6 +48,7 @@ fn test_with_builder<F: FnOnce(&Path, &Path)>(
                 .and_then(|s| s.to_str())
                 .unwrap()
         ));
+        println!("{path:?}");
 
         f(source.as_ref(), &path);
         diff_file(target, path);

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -177,7 +177,7 @@ pub mod nested_message {
             pub struct Tt3 {
                 pub a: ::std::option::Option<i32>,
 
-                pub m: ::std::collections::HashMap<i32, super::T2>,
+                pub m: ::std::collections::HashMap<i32, super::T2, ::pilota::Hasher>,
             }
             impl ::pilota::prost::Message for Tt3 {
                 #[inline]

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -91,16 +91,22 @@ pub mod const_val {
             }
         }
         ::pilota::lazy_static::lazy_static! {
-            pub static ref TEST_MAP_LIST: ::std::collections::HashMap<i32, ::std::vec::Vec<&'static str>> = {
-            let mut map = ::std::collections::HashMap::with_capacity(1);
+            pub static ref TEST_MAP_LIST: ::std::collections::HashMap<i32, ::std::vec::Vec<&'static str>, ::pilota::Hasher> = {
+            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                1,
+                ::pilota::Hasher::new(),
+            );
             map.insert(1i32, ::std::vec!["hello"]);
             map
         };
         }
         pub const TEST_LIST: [&'static str; 2] = ["hello", "world"];
         ::pilota::lazy_static::lazy_static! {
-            pub static ref TEST_MAP: ::std::collections::HashMap<Index, &'static str> = {
-            let mut map = ::std::collections::HashMap::with_capacity(2);
+            pub static ref TEST_MAP: ::std::collections::HashMap<Index, &'static str, ::pilota::Hasher> = {
+            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                2,
+                ::pilota::Hasher::new(),
+            );
             map.insert(Index::A, "hello");map.insert(Index::B, "world");
             map
         };

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -272,7 +272,10 @@ pub mod default_value {
                     test_b: Some(B::Read),
                     test_b2: Some(B::Write),
                     map: Some({
-                        let mut map = ::std::collections::HashMap::with_capacity(1);
+                        let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                            1,
+                            ::pilota::Hasher::new(),
+                        );
                         map.insert(
                             ::pilota::FastStr::from_static_str("hello"),
                             ::pilota::FastStr::from_static_str("world"),
@@ -298,7 +301,7 @@ pub mod default_value {
             pub test_b2: ::std::option::Option<B>,
 
             pub map: ::std::option::Option<
-                ::std::collections::HashMap<::pilota::FastStr, ::pilota::FastStr>,
+                ::std::collections::HashMap<::pilota::FastStr, ::pilota::FastStr, ::pilota::Hasher>,
             >,
 
             pub test_double: ::std::option::Option<f64>,
@@ -411,7 +414,10 @@ pub mod default_value {
                                 map = Some({
                                     let map_ident = protocol.read_map_begin()?;
                                     let mut val =
-                                        ::std::collections::HashMap::with_capacity(map_ident.size);
+                                        ::std::collections::HashMap::with_capacity_and_hasher(
+                                            map_ident.size,
+                                            ::pilota::Hasher::new(),
+                                        );
                                     for _ in 0..map_ident.size {
                                         val.insert(
                                             protocol.read_faststr()?,
@@ -463,7 +469,10 @@ pub mod default_value {
                 let string = string.unwrap_or_else(|| "test".to_string());
                 if map.is_none() {
                     map = Some({
-                        let mut map = ::std::collections::HashMap::with_capacity(1);
+                        let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                            1,
+                            ::pilota::Hasher::new(),
+                        );
                         map.insert(
                             ::pilota::FastStr::from_static_str("hello"),
                             ::pilota::FastStr::from_static_str("world"),
@@ -557,9 +566,11 @@ pub mod default_value {
                                 {
                                     map = Some({
                                         let map_ident = protocol.read_map_begin().await?;
-                                        let mut val = ::std::collections::HashMap::with_capacity(
-                                            map_ident.size,
-                                        );
+                                        let mut val =
+                                            ::std::collections::HashMap::with_capacity_and_hasher(
+                                                map_ident.size,
+                                                ::pilota::Hasher::new(),
+                                            );
                                         for _ in 0..map_ident.size {
                                             val.insert(
                                                 protocol.read_faststr().await?,
@@ -615,7 +626,10 @@ pub mod default_value {
                     let string = string.unwrap_or_else(|| "test".to_string());
                     if map.is_none() {
                         map = Some({
-                            let mut map = ::std::collections::HashMap::with_capacity(1);
+                            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                                1,
+                                ::pilota::Hasher::new(),
+                            );
                             map.insert(
                                 ::pilota::FastStr::from_static_str("hello"),
                                 ::pilota::FastStr::from_static_str("world"),

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -12,7 +12,10 @@ pub mod multi {
                     test_b: Some(B::Read),
                     test_b2: Some(B::Write),
                     map: Some({
-                        let mut map = ::std::collections::HashMap::with_capacity(1);
+                        let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                            1,
+                            ::pilota::Hasher::new(),
+                        );
                         map.insert(
                             ::pilota::FastStr::from_static_str("hello"),
                             ::pilota::FastStr::from_static_str("world"),
@@ -38,7 +41,7 @@ pub mod multi {
             pub test_b2: ::std::option::Option<B>,
 
             pub map: ::std::option::Option<
-                ::std::collections::HashMap<::pilota::FastStr, ::pilota::FastStr>,
+                ::std::collections::HashMap<::pilota::FastStr, ::pilota::FastStr, ::pilota::Hasher>,
             >,
 
             pub test_double: ::std::option::Option<f64>,
@@ -151,7 +154,10 @@ pub mod multi {
                                 map = Some({
                                     let map_ident = protocol.read_map_begin()?;
                                     let mut val =
-                                        ::std::collections::HashMap::with_capacity(map_ident.size);
+                                        ::std::collections::HashMap::with_capacity_and_hasher(
+                                            map_ident.size,
+                                            ::pilota::Hasher::new(),
+                                        );
                                     for _ in 0..map_ident.size {
                                         val.insert(
                                             protocol.read_faststr()?,
@@ -203,7 +209,10 @@ pub mod multi {
                 let string = string.unwrap_or_else(|| "test".to_string());
                 if map.is_none() {
                     map = Some({
-                        let mut map = ::std::collections::HashMap::with_capacity(1);
+                        let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                            1,
+                            ::pilota::Hasher::new(),
+                        );
                         map.insert(
                             ::pilota::FastStr::from_static_str("hello"),
                             ::pilota::FastStr::from_static_str("world"),
@@ -297,9 +306,11 @@ pub mod multi {
                                 {
                                     map = Some({
                                         let map_ident = protocol.read_map_begin().await?;
-                                        let mut val = ::std::collections::HashMap::with_capacity(
-                                            map_ident.size,
-                                        );
+                                        let mut val =
+                                            ::std::collections::HashMap::with_capacity_and_hasher(
+                                                map_ident.size,
+                                                ::pilota::Hasher::new(),
+                                            );
                                         for _ in 0..map_ident.size {
                                             val.insert(
                                                 protocol.read_faststr().await?,
@@ -355,7 +366,10 @@ pub mod multi {
                     let string = string.unwrap_or_else(|| "test".to_string());
                     if map.is_none() {
                         map = Some({
-                            let mut map = ::std::collections::HashMap::with_capacity(1);
+                            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                                1,
+                                ::pilota::Hasher::new(),
+                            );
                             map.insert(
                                 ::pilota::FastStr::from_static_str("hello"),
                                 ::pilota::FastStr::from_static_str("world"),

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -286,11 +286,12 @@ pub mod normal {
         pub struct ObjReq {
             pub msg: Message,
 
-            pub msg_map: ::std::collections::HashMap<Message, SubMessage>,
+            pub msg_map: ::std::collections::HashMap<Message, SubMessage, ::pilota::Hasher>,
 
             pub sub_msgs: ::std::vec::Vec<SubMessage>,
 
-            pub msg_set: ::std::option::Option<::std::collections::HashSet<Message>>,
+            pub msg_set:
+                ::std::option::Option<::std::collections::HashSet<Message, ::pilota::Hasher>>,
 
             pub flag_msg: ::pilota::FastStr,
 
@@ -386,7 +387,10 @@ pub mod normal {
                                 msg_map = Some({
                                     let map_ident = protocol.read_map_begin()?;
                                     let mut val =
-                                        ::std::collections::HashMap::with_capacity(map_ident.size);
+                                        ::std::collections::HashMap::with_capacity_and_hasher(
+                                            map_ident.size,
+                                            ::pilota::Hasher::new(),
+                                        );
                                     for _ in 0..map_ident.size {
                                         val.insert(
                                             ::pilota::thrift::Message::decode(protocol)?,
@@ -416,7 +420,10 @@ pub mod normal {
                                 msg_set = Some({
                                     let list_ident = protocol.read_set_begin()?;
                                     let mut val =
-                                        ::std::collections::HashSet::with_capacity(list_ident.size);
+                                        ::std::collections::HashSet::with_capacity_and_hasher(
+                                            list_ident.size,
+                                            ::pilota::Hasher::new(),
+                                        );
                                     for _ in 0..list_ident.size {
                                         val.insert(::pilota::thrift::Message::decode(protocol)?);
                                     }
@@ -533,7 +540,10 @@ pub mod normal {
                 },Some(2) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
                     msg_map = Some({
                         let map_ident = protocol.read_map_begin().await?;
-                        let mut val = ::std::collections::HashMap::with_capacity(map_ident.size);
+                        let mut val = ::std::collections::HashMap::with_capacity_and_hasher(
+                            map_ident.size,
+                            ::pilota::Hasher::new(),
+                        );
                         for _ in 0..map_ident.size {
                             val.insert(<Message as ::pilota::thrift::Message>::decode_async(protocol).await?, <SubMessage as ::pilota::thrift::Message>::decode_async(protocol).await?);
                         }
@@ -554,7 +564,10 @@ pub mod normal {
 
                 },Some(4) if field_ident.field_type == ::pilota::thrift::TType::Set  => {
                     msg_set = Some({let list_ident = protocol.read_set_begin().await?;
-                    let mut val = ::std::collections::HashSet::with_capacity(list_ident.size);
+                    let mut val = ::std::collections::HashSet::with_capacity_and_hasher(
+                        list_ident.size,
+                        ::pilota::Hasher::new(),
+                    );
                     for _ in 0..list_ident.size {
                         val.insert(<Message as ::pilota::thrift::Message>::decode_async(protocol).await?);
                     };

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -584,7 +584,11 @@ pub mod wrapper_arc {
 
             pub name2: ::std::vec::Vec<::std::vec::Vec<::std::sync::Arc<A>>>,
 
-            pub name3: ::std::collections::HashMap<i32, ::std::vec::Vec<::std::sync::Arc<A>>>,
+            pub name3: ::std::collections::HashMap<
+                i32,
+                ::std::vec::Vec<::std::sync::Arc<A>>,
+                ::pilota::Hasher,
+            >,
         }
         impl ::pilota::thrift::Message for Test {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -701,7 +705,10 @@ pub mod wrapper_arc {
                                 name3 = Some({
                                     let map_ident = protocol.read_map_begin()?;
                                     let mut val =
-                                        ::std::collections::HashMap::with_capacity(map_ident.size);
+                                        ::std::collections::HashMap::with_capacity_and_hasher(
+                                            map_ident.size,
+                                            ::pilota::Hasher::new(),
+                                        );
                                     for _ in 0..map_ident.size {
                                         val.insert(protocol.read_i32()?, unsafe {
                                             let list_ident = protocol.read_list_begin()?;
@@ -827,7 +834,10 @@ pub mod wrapper_arc {
                 },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
                     name3 = Some({
                         let map_ident = protocol.read_map_begin().await?;
-                        let mut val = ::std::collections::HashMap::with_capacity(map_ident.size);
+                        let mut val = ::std::collections::HashMap::with_capacity_and_hasher(
+                            map_ident.size,
+                            ::pilota::Hasher::new(),
+                        );
                         for _ in 0..map_ident.size {
                             val.insert(protocol.read_i32().await?, {
                             let list_ident = protocol.read_list_begin().await?;

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -1697,8 +1697,11 @@ pub mod unknown_fields {
             }
         }
         ::pilota::lazy_static::lazy_static! {
-            pub static ref TEST_MAP_LIST: ::std::collections::HashMap<i32, ::std::vec::Vec<&'static str>> = {
-            let mut map = ::std::collections::HashMap::with_capacity(1);
+            pub static ref TEST_MAP_LIST: ::std::collections::HashMap<i32, ::std::vec::Vec<&'static str>, ::pilota::Hasher> = {
+            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                1,
+                ::pilota::Hasher::new(),
+            );
             map.insert(1i32, ::std::vec!["hello"]);
             map
         };
@@ -3674,8 +3677,11 @@ pub mod unknown_fields {
             }
         }
         ::pilota::lazy_static::lazy_static! {
-            pub static ref TEST_MAP: ::std::collections::HashMap<Index, &'static str> = {
-            let mut map = ::std::collections::HashMap::with_capacity(2);
+            pub static ref TEST_MAP: ::std::collections::HashMap<Index, &'static str, ::pilota::Hasher> = {
+            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
+                2,
+                ::pilota::Hasher::new(),
+            );
             map.insert(Index::A, "hello");map.insert(Index::B, "world");
             map
         };

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -18,6 +18,7 @@ keywords = ["serialization", "thrift", "protobuf"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+ahash = { version = "0.8", optional = true }
 paste = "1"
 bytes = { version = "1", features = ["serde"] }
 async-recursion = "1"
@@ -39,6 +40,11 @@ smallvec = "1"
 [dev-dependencies]
 criterion = "0.5"
 rand = "0.8"
+
+[features]
+default = ["ahash"]
+
+ahash = ["dep:ahash"]
 
 [[bench]]
 name = "faststr"

--- a/pilota/src/lib.rs
+++ b/pilota/src/lib.rs
@@ -23,3 +23,8 @@ pub enum EnumConvertError<Num> {
     #[error("invalid value `{0}` for enum `{1}`")]
     InvalidNum(Num, &'static str),
 }
+
+#[cfg(feature = "ahash")]
+pub type Hasher = ahash::random_state::RandomState;
+#[cfg(not(feature = "ahash"))]
+pub type Hasher = std::collections::hash_map::RandomState;

--- a/pilota/src/thrift/mod.rs
+++ b/pilota/src/thrift/mod.rs
@@ -19,7 +19,7 @@ pub use error::*;
 use faststr::FastStr;
 
 pub use self::{binary::TAsyncBinaryProtocol, compact::TAsyncCompactProtocol};
-use crate::{assert_remaining, thrift::rw_ext::IOError};
+use crate::{assert_remaining, thrift::rw_ext::IOError, Hasher};
 
 const MAXIMUM_SKIP_DEPTH: i8 = 64;
 
@@ -329,7 +329,7 @@ pub trait TLengthProtocolExt: TLengthProtocol + Sized {
         &mut self,
         id: Option<i16>,
         el_ttype: TType,
-        els: &HashSet<T>,
+        els: &HashSet<T, Hasher>,
         el_len: F,
     ) -> usize
     where
@@ -341,7 +341,7 @@ pub trait TLengthProtocolExt: TLengthProtocol + Sized {
     }
 
     #[inline]
-    fn set_len<T, F>(&mut self, el_ttype: TType, els: &HashSet<T>, el_len: F) -> usize
+    fn set_len<T, F>(&mut self, el_ttype: TType, els: &HashSet<T, Hasher>, el_len: F) -> usize
     where
         F: Fn(&mut Self, &T) -> usize,
     {
@@ -363,7 +363,7 @@ pub trait TLengthProtocolExt: TLengthProtocol + Sized {
         id: Option<i16>,
         key_ttype: TType,
         val_ttype: TType,
-        els: &HashMap<K, V>,
+        els: &HashMap<K, V, Hasher>,
         key_len: FK,
         val_len: FV,
     ) -> usize
@@ -381,7 +381,7 @@ pub trait TLengthProtocolExt: TLengthProtocol + Sized {
         &mut self,
         key_ttype: TType,
         val_ttype: TType,
-        els: &HashMap<K, V>,
+        els: &HashMap<K, V, Hasher>,
         key_len: FK,
         val_len: FV,
     ) -> usize
@@ -545,7 +545,7 @@ pub trait TOutputProtocolExt: TOutputProtocol + Sized {
         &mut self,
         id: i16,
         el_ttype: TType,
-        els: &HashSet<T>,
+        els: &HashSet<T, Hasher>,
         encode: F,
     ) -> Result<(), EncodeError>
     where
@@ -560,7 +560,7 @@ pub trait TOutputProtocolExt: TOutputProtocol + Sized {
     fn write_set<T, F>(
         &mut self,
         el_ttype: TType,
-        els: &HashSet<T>,
+        els: &HashSet<T, Hasher>,
         encode: F,
     ) -> Result<(), EncodeError>
     where
@@ -599,7 +599,7 @@ pub trait TOutputProtocolExt: TOutputProtocol + Sized {
         id: i16,
         key_ttype: TType,
         val_ttype: TType,
-        els: &HashMap<K, V>,
+        els: &HashMap<K, V, Hasher>,
         key_encode: FK,
         val_encode: FV,
     ) -> Result<(), EncodeError>
@@ -617,7 +617,7 @@ pub trait TOutputProtocolExt: TOutputProtocol + Sized {
         &mut self,
         key_ttype: TType,
         val_ttype: TType,
-        els: &HashMap<K, V>,
+        els: &HashMap<K, V, Hasher>,
         key_encode: FK,
         val_encode: FV,
     ) -> Result<(), EncodeError>


### PR DESCRIPTION
## Motivation

Since the `ahash::random_state::RandomState` is faster than the default `Hasher` of `HashMap` and `HashSet`, replacing the `HashMap<K, V>` to `HashMap<K, V, ahash::RandomState>` can improve the performance of `pilota`.
