### PR TITLE
feat: use ahashmap instead of hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]

--- a/pilota-build/benches/unknown.rs
+++ b/pilota-build/benches/unknown.rs
@@ -151,7 +151,7 @@ fn prepare_obj_req(size: usize) -> crate::normal::normal::ObjReq {
         uid: None,
     };
 
-    let mut msg_map = std::collections::HashMap::new();
+    let mut msg_map = pilota::AHashMap::default();
     msg_map.insert(
         crate::normal::normal::Message {
             value: None,
@@ -163,7 +163,7 @@ fn prepare_obj_req(size: usize) -> crate::normal::normal::ObjReq {
         },
     );
 
-    let mut msg_set = std::collections::HashSet::new();
+    let mut msg_set = pilota::AHashSet::default();
     msg_set.insert(msg.clone());
 
     req.msg = msg; // 2 * size

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -390,10 +390,7 @@ impl ThriftBackend {
                 let read_set_end = helper.codegen_read_set_end();
                 let read_el = self.codegen_decode_ty(helper, ty);
                 format! {r#"{{let list_ident = {read_set_begin};
-                    let mut val = ::std::collections::HashSet::with_capacity_and_hasher(
-                        list_ident.size,
-                        ::pilota::Hasher::new(),
-                    );
+                    let mut val = ::pilota::AHashSet::with_capacity(list_ident.size);
                     for _ in 0..list_ident.size {{
                         val.insert({read_el});
                     }};
@@ -411,10 +408,7 @@ impl ThriftBackend {
                 format! {
                     r#"{{
                         let map_ident = {read_map_begin};
-                        let mut val = ::std::collections::HashMap::with_capacity_and_hasher(
-                            map_ident.size,
-                            ::pilota::Hasher::new(),
-                        );
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
                         for _ in 0..map_ident.size {{
                             val.insert({read_el_key}, {read_el_val});
                         }}

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -530,10 +530,7 @@ impl Context {
                 .join("");
             anyhow::Ok(
                 format! {r#"{{
-                    let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                        {len},
-                        ::pilota::Hasher::new(),
-                    );
+                    let mut map = ::pilota::AHashMap::with_capacity({len});
                     {kvs}
                     map
                 }}"#}

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -129,17 +129,13 @@ impl CodegenTy {
             }
             CodegenTy::Set(ty) => {
                 let ty = &**ty;
-                format!(
-                    "::std::collections::HashSet<{}, ::pilota::Hasher>",
-                    ty.global_path()
-                )
-                .into()
+                format!("::pilota::AHashSet<{}>", ty.global_path()).into()
             }
             CodegenTy::Map(k, v) => {
                 let k = &**k;
                 let v = &**v;
                 format!(
-                    "::std::collections::HashMap<{}, {}, ::pilota::Hasher>",
+                    "::pilota::AHashMap<{}, {}>",
                     k.global_path(),
                     v.global_path()
                 )
@@ -196,12 +192,12 @@ impl Display for CodegenTy {
             }
             CodegenTy::Set(ty) => {
                 let ty = &**ty;
-                write!(f, "::std::collections::HashSet<{ty}, ::pilota::Hasher>")
+                write!(f, "::pilota::AHashSet<{ty}>")
             }
             CodegenTy::Map(k, v) => {
                 let k = &**k;
                 let v = &**v;
-                write!(f, "::std::collections::HashMap<{k}, {v}, ::pilota::Hasher>")
+                write!(f, "::pilota::AHashMap<{k}, {v}>")
             }
             CodegenTy::Adt(def) => with_cx(|cx| {
                 let path = cx.cur_related_item_path(def.did);

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -177,7 +177,7 @@ pub mod nested_message {
             pub struct Tt3 {
                 pub a: ::std::option::Option<i32>,
 
-                pub m: ::std::collections::HashMap<i32, super::T2, ::pilota::Hasher>,
+                pub m: ::pilota::AHashMap<i32, super::T2>,
             }
             impl ::pilota::prost::Message for Tt3 {
                 #[inline]

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -91,22 +91,16 @@ pub mod const_val {
             }
         }
         ::pilota::lazy_static::lazy_static! {
-            pub static ref TEST_MAP_LIST: ::std::collections::HashMap<i32, ::std::vec::Vec<&'static str>, ::pilota::Hasher> = {
-            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                1,
-                ::pilota::Hasher::new(),
-            );
+            pub static ref TEST_MAP_LIST: ::pilota::AHashMap<i32, ::std::vec::Vec<&'static str>> = {
+            let mut map = ::pilota::AHashMap::with_capacity(1);
             map.insert(1i32, ::std::vec!["hello"]);
             map
         };
         }
         pub const TEST_LIST: [&'static str; 2] = ["hello", "world"];
         ::pilota::lazy_static::lazy_static! {
-            pub static ref TEST_MAP: ::std::collections::HashMap<Index, &'static str, ::pilota::Hasher> = {
-            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                2,
-                ::pilota::Hasher::new(),
-            );
+            pub static ref TEST_MAP: ::pilota::AHashMap<Index, &'static str> = {
+            let mut map = ::pilota::AHashMap::with_capacity(2);
             map.insert(Index::A, "hello");map.insert(Index::B, "world");
             map
         };

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -272,10 +272,7 @@ pub mod default_value {
                     test_b: Some(B::Read),
                     test_b2: Some(B::Write),
                     map: Some({
-                        let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                            1,
-                            ::pilota::Hasher::new(),
-                        );
+                        let mut map = ::pilota::AHashMap::with_capacity(1);
                         map.insert(
                             ::pilota::FastStr::from_static_str("hello"),
                             ::pilota::FastStr::from_static_str("world"),
@@ -300,9 +297,8 @@ pub mod default_value {
 
             pub test_b2: ::std::option::Option<B>,
 
-            pub map: ::std::option::Option<
-                ::std::collections::HashMap<::pilota::FastStr, ::pilota::FastStr, ::pilota::Hasher>,
-            >,
+            pub map:
+                ::std::option::Option<::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>>,
 
             pub test_double: ::std::option::Option<f64>,
 
@@ -413,11 +409,7 @@ pub mod default_value {
                             Some(6) if field_ident.field_type == ::pilota::thrift::TType::Map => {
                                 map = Some({
                                     let map_ident = protocol.read_map_begin()?;
-                                    let mut val =
-                                        ::std::collections::HashMap::with_capacity_and_hasher(
-                                            map_ident.size,
-                                            ::pilota::Hasher::new(),
-                                        );
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
                                     for _ in 0..map_ident.size {
                                         val.insert(
                                             protocol.read_faststr()?,
@@ -469,10 +461,7 @@ pub mod default_value {
                 let string = string.unwrap_or_else(|| "test".to_string());
                 if map.is_none() {
                     map = Some({
-                        let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                            1,
-                            ::pilota::Hasher::new(),
-                        );
+                        let mut map = ::pilota::AHashMap::with_capacity(1);
                         map.insert(
                             ::pilota::FastStr::from_static_str("hello"),
                             ::pilota::FastStr::from_static_str("world"),
@@ -567,10 +556,7 @@ pub mod default_value {
                                     map = Some({
                                         let map_ident = protocol.read_map_begin().await?;
                                         let mut val =
-                                            ::std::collections::HashMap::with_capacity_and_hasher(
-                                                map_ident.size,
-                                                ::pilota::Hasher::new(),
-                                            );
+                                            ::pilota::AHashMap::with_capacity(map_ident.size);
                                         for _ in 0..map_ident.size {
                                             val.insert(
                                                 protocol.read_faststr().await?,
@@ -626,10 +612,7 @@ pub mod default_value {
                     let string = string.unwrap_or_else(|| "test".to_string());
                     if map.is_none() {
                         map = Some({
-                            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                                1,
-                                ::pilota::Hasher::new(),
-                            );
+                            let mut map = ::pilota::AHashMap::with_capacity(1);
                             map.insert(
                                 ::pilota::FastStr::from_static_str("hello"),
                                 ::pilota::FastStr::from_static_str("world"),

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -12,10 +12,7 @@ pub mod multi {
                     test_b: Some(B::Read),
                     test_b2: Some(B::Write),
                     map: Some({
-                        let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                            1,
-                            ::pilota::Hasher::new(),
-                        );
+                        let mut map = ::pilota::AHashMap::with_capacity(1);
                         map.insert(
                             ::pilota::FastStr::from_static_str("hello"),
                             ::pilota::FastStr::from_static_str("world"),
@@ -40,9 +37,8 @@ pub mod multi {
 
             pub test_b2: ::std::option::Option<B>,
 
-            pub map: ::std::option::Option<
-                ::std::collections::HashMap<::pilota::FastStr, ::pilota::FastStr, ::pilota::Hasher>,
-            >,
+            pub map:
+                ::std::option::Option<::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>>,
 
             pub test_double: ::std::option::Option<f64>,
 
@@ -153,11 +149,7 @@ pub mod multi {
                             Some(6) if field_ident.field_type == ::pilota::thrift::TType::Map => {
                                 map = Some({
                                     let map_ident = protocol.read_map_begin()?;
-                                    let mut val =
-                                        ::std::collections::HashMap::with_capacity_and_hasher(
-                                            map_ident.size,
-                                            ::pilota::Hasher::new(),
-                                        );
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
                                     for _ in 0..map_ident.size {
                                         val.insert(
                                             protocol.read_faststr()?,
@@ -209,10 +201,7 @@ pub mod multi {
                 let string = string.unwrap_or_else(|| "test".to_string());
                 if map.is_none() {
                     map = Some({
-                        let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                            1,
-                            ::pilota::Hasher::new(),
-                        );
+                        let mut map = ::pilota::AHashMap::with_capacity(1);
                         map.insert(
                             ::pilota::FastStr::from_static_str("hello"),
                             ::pilota::FastStr::from_static_str("world"),
@@ -307,10 +296,7 @@ pub mod multi {
                                     map = Some({
                                         let map_ident = protocol.read_map_begin().await?;
                                         let mut val =
-                                            ::std::collections::HashMap::with_capacity_and_hasher(
-                                                map_ident.size,
-                                                ::pilota::Hasher::new(),
-                                            );
+                                            ::pilota::AHashMap::with_capacity(map_ident.size);
                                         for _ in 0..map_ident.size {
                                             val.insert(
                                                 protocol.read_faststr().await?,
@@ -366,10 +352,7 @@ pub mod multi {
                     let string = string.unwrap_or_else(|| "test".to_string());
                     if map.is_none() {
                         map = Some({
-                            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                                1,
-                                ::pilota::Hasher::new(),
-                            );
+                            let mut map = ::pilota::AHashMap::with_capacity(1);
                             map.insert(
                                 ::pilota::FastStr::from_static_str("hello"),
                                 ::pilota::FastStr::from_static_str("world"),

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -286,12 +286,11 @@ pub mod normal {
         pub struct ObjReq {
             pub msg: Message,
 
-            pub msg_map: ::std::collections::HashMap<Message, SubMessage, ::pilota::Hasher>,
+            pub msg_map: ::pilota::AHashMap<Message, SubMessage>,
 
             pub sub_msgs: ::std::vec::Vec<SubMessage>,
 
-            pub msg_set:
-                ::std::option::Option<::std::collections::HashSet<Message, ::pilota::Hasher>>,
+            pub msg_set: ::std::option::Option<::pilota::AHashSet<Message>>,
 
             pub flag_msg: ::pilota::FastStr,
 
@@ -386,11 +385,7 @@ pub mod normal {
                             Some(2) if field_ident.field_type == ::pilota::thrift::TType::Map => {
                                 msg_map = Some({
                                     let map_ident = protocol.read_map_begin()?;
-                                    let mut val =
-                                        ::std::collections::HashMap::with_capacity_and_hasher(
-                                            map_ident.size,
-                                            ::pilota::Hasher::new(),
-                                        );
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
                                     for _ in 0..map_ident.size {
                                         val.insert(
                                             ::pilota::thrift::Message::decode(protocol)?,
@@ -420,10 +415,7 @@ pub mod normal {
                                 msg_set = Some({
                                     let list_ident = protocol.read_set_begin()?;
                                     let mut val =
-                                        ::std::collections::HashSet::with_capacity_and_hasher(
-                                            list_ident.size,
-                                            ::pilota::Hasher::new(),
-                                        );
+                                        ::pilota::AHashSet::with_capacity(list_ident.size);
                                     for _ in 0..list_ident.size {
                                         val.insert(::pilota::thrift::Message::decode(protocol)?);
                                     }
@@ -540,10 +532,7 @@ pub mod normal {
                 },Some(2) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
                     msg_map = Some({
                         let map_ident = protocol.read_map_begin().await?;
-                        let mut val = ::std::collections::HashMap::with_capacity_and_hasher(
-                            map_ident.size,
-                            ::pilota::Hasher::new(),
-                        );
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
                         for _ in 0..map_ident.size {
                             val.insert(<Message as ::pilota::thrift::Message>::decode_async(protocol).await?, <SubMessage as ::pilota::thrift::Message>::decode_async(protocol).await?);
                         }
@@ -564,10 +553,7 @@ pub mod normal {
 
                 },Some(4) if field_ident.field_type == ::pilota::thrift::TType::Set  => {
                     msg_set = Some({let list_ident = protocol.read_set_begin().await?;
-                    let mut val = ::std::collections::HashSet::with_capacity_and_hasher(
-                        list_ident.size,
-                        ::pilota::Hasher::new(),
-                    );
+                    let mut val = ::pilota::AHashSet::with_capacity(list_ident.size);
                     for _ in 0..list_ident.size {
                         val.insert(<Message as ::pilota::thrift::Message>::decode_async(protocol).await?);
                     };

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -584,11 +584,7 @@ pub mod wrapper_arc {
 
             pub name2: ::std::vec::Vec<::std::vec::Vec<::std::sync::Arc<A>>>,
 
-            pub name3: ::std::collections::HashMap<
-                i32,
-                ::std::vec::Vec<::std::sync::Arc<A>>,
-                ::pilota::Hasher,
-            >,
+            pub name3: ::pilota::AHashMap<i32, ::std::vec::Vec<::std::sync::Arc<A>>>,
         }
         impl ::pilota::thrift::Message for Test {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -704,11 +700,7 @@ pub mod wrapper_arc {
                             Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map => {
                                 name3 = Some({
                                     let map_ident = protocol.read_map_begin()?;
-                                    let mut val =
-                                        ::std::collections::HashMap::with_capacity_and_hasher(
-                                            map_ident.size,
-                                            ::pilota::Hasher::new(),
-                                        );
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
                                     for _ in 0..map_ident.size {
                                         val.insert(protocol.read_i32()?, unsafe {
                                             let list_ident = protocol.read_list_begin()?;
@@ -834,10 +826,7 @@ pub mod wrapper_arc {
                 },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
                     name3 = Some({
                         let map_ident = protocol.read_map_begin().await?;
-                        let mut val = ::std::collections::HashMap::with_capacity_and_hasher(
-                            map_ident.size,
-                            ::pilota::Hasher::new(),
-                        );
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
                         for _ in 0..map_ident.size {
                             val.insert(protocol.read_i32().await?, {
                             let list_ident = protocol.read_list_begin().await?;

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -1697,11 +1697,8 @@ pub mod unknown_fields {
             }
         }
         ::pilota::lazy_static::lazy_static! {
-            pub static ref TEST_MAP_LIST: ::std::collections::HashMap<i32, ::std::vec::Vec<&'static str>, ::pilota::Hasher> = {
-            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                1,
-                ::pilota::Hasher::new(),
-            );
+            pub static ref TEST_MAP_LIST: ::pilota::AHashMap<i32, ::std::vec::Vec<&'static str>> = {
+            let mut map = ::pilota::AHashMap::with_capacity(1);
             map.insert(1i32, ::std::vec!["hello"]);
             map
         };
@@ -3677,11 +3674,8 @@ pub mod unknown_fields {
             }
         }
         ::pilota::lazy_static::lazy_static! {
-            pub static ref TEST_MAP: ::std::collections::HashMap<Index, &'static str, ::pilota::Hasher> = {
-            let mut map = ::std::collections::HashMap::with_capacity_and_hasher(
-                2,
-                ::pilota::Hasher::new(),
-            );
+            pub static ref TEST_MAP: ::pilota::AHashMap<Index, &'static str> = {
+            let mut map = ::pilota::AHashMap::with_capacity(2);
             map.insert(Index::A, "hello");map.insert(Index::B, "world");
             map
         };

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["serialization", "thrift", "protobuf"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ahash = { version = "0.8", optional = true }
+ahash = { version = "0.8", features = ["serde"] }
 paste = "1"
 bytes = { version = "1", features = ["serde"] }
 async-recursion = "1"
@@ -29,10 +29,7 @@ derivative = "2"
 anyhow = "1"
 thiserror = "1"
 faststr = { version = "0.2", features = ["serde"] }
-integer-encoding = { version = "4", features = [
-    "tokio",
-    "tokio_async",
-] }
+integer-encoding = { version = "4", features = ["tokio", "tokio_async"] }
 proptest = "1"
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
@@ -40,11 +37,6 @@ smallvec = "1"
 [dev-dependencies]
 criterion = "0.5"
 rand = "0.8"
-
-[features]
-default = ["ahash"]
-
-ahash = ["dep:ahash"]
 
 [[bench]]
 name = "faststr"

--- a/pilota/benches/skip.rs
+++ b/pilota/benches/skip.rs
@@ -1,5 +1,4 @@
-use std::collections::{HashMap, HashSet};
-
+use ahash::{AHashMap, AHashSet};
 use bytes::{Bytes, BytesMut};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use faststr::FastStr;
@@ -79,7 +78,7 @@ fn generate_struct() -> Bytes {
         101,
         TType::Binary,
         TType::I32,
-        &HashMap::from([("key1", 1), ("key2", 2), ("key3", 3)]),
+        &AHashMap::from([("key1", 1), ("key2", 2), ("key3", 3)]),
         |protocol, key| {
             protocol.write_string(*key)?;
             Ok(())
@@ -93,7 +92,7 @@ fn generate_struct() -> Bytes {
     p.write_set_field(
         201,
         TType::Binary,
-        &HashSet::from(["set1", "set2", "set3"]),
+        &AHashSet::from(["set1", "set2", "set3"]),
         |protocol, key| {
             protocol.write_string(*key)?;
             Ok(())

--- a/pilota/src/lib.rs
+++ b/pilota/src/lib.rs
@@ -7,6 +7,7 @@ pub mod prost;
 pub mod thrift;
 
 // reexport
+pub use ahash::{AHashMap, AHashSet};
 pub use async_recursion;
 pub use bytes::*;
 pub use derivative;
@@ -23,8 +24,3 @@ pub enum EnumConvertError<Num> {
     #[error("invalid value `{0}` for enum `{1}`")]
     InvalidNum(Num, &'static str),
 }
-
-#[cfg(feature = "ahash")]
-pub type Hasher = ahash::random_state::RandomState;
-#[cfg(not(feature = "ahash"))]
-pub type Hasher = std::collections::hash_map::RandomState;

--- a/pilota/src/prost/encoding.rs
+++ b/pilota/src/prost/encoding.rs
@@ -1672,8 +1672,8 @@ macro_rules! map {
 }
 
 pub mod hash_map {
-    use std::collections::HashMap;
-    map!(HashMap);
+    use crate::AHashMap;
+    map!(AHashMap);
 }
 
 pub mod btree_map {

--- a/pilota/src/thrift/mod.rs
+++ b/pilota/src/thrift/mod.rs
@@ -7,19 +7,14 @@ pub mod rw_ext;
 pub mod unknown;
 pub mod varint_ext;
 
-use std::{
-    collections::{HashMap, HashSet},
-    future::Future,
-    ops::Deref,
-    sync::Arc,
-};
+use std::{future::Future, ops::Deref, sync::Arc};
 
 use bytes::{Buf, BufMut, Bytes};
 pub use error::*;
 use faststr::FastStr;
 
 pub use self::{binary::TAsyncBinaryProtocol, compact::TAsyncCompactProtocol};
-use crate::{assert_remaining, thrift::rw_ext::IOError, Hasher};
+use crate::{assert_remaining, thrift::rw_ext::IOError, AHashMap, AHashSet};
 
 const MAXIMUM_SKIP_DEPTH: i8 = 64;
 
@@ -329,7 +324,7 @@ pub trait TLengthProtocolExt: TLengthProtocol + Sized {
         &mut self,
         id: Option<i16>,
         el_ttype: TType,
-        els: &HashSet<T, Hasher>,
+        els: &AHashSet<T>,
         el_len: F,
     ) -> usize
     where
@@ -341,7 +336,7 @@ pub trait TLengthProtocolExt: TLengthProtocol + Sized {
     }
 
     #[inline]
-    fn set_len<T, F>(&mut self, el_ttype: TType, els: &HashSet<T, Hasher>, el_len: F) -> usize
+    fn set_len<T, F>(&mut self, el_ttype: TType, els: &AHashSet<T>, el_len: F) -> usize
     where
         F: Fn(&mut Self, &T) -> usize,
     {
@@ -363,7 +358,7 @@ pub trait TLengthProtocolExt: TLengthProtocol + Sized {
         id: Option<i16>,
         key_ttype: TType,
         val_ttype: TType,
-        els: &HashMap<K, V, Hasher>,
+        els: &AHashMap<K, V>,
         key_len: FK,
         val_len: FV,
     ) -> usize
@@ -381,7 +376,7 @@ pub trait TLengthProtocolExt: TLengthProtocol + Sized {
         &mut self,
         key_ttype: TType,
         val_ttype: TType,
-        els: &HashMap<K, V, Hasher>,
+        els: &AHashMap<K, V>,
         key_len: FK,
         val_len: FV,
     ) -> usize
@@ -545,7 +540,7 @@ pub trait TOutputProtocolExt: TOutputProtocol + Sized {
         &mut self,
         id: i16,
         el_ttype: TType,
-        els: &HashSet<T, Hasher>,
+        els: &AHashSet<T>,
         encode: F,
     ) -> Result<(), EncodeError>
     where
@@ -560,7 +555,7 @@ pub trait TOutputProtocolExt: TOutputProtocol + Sized {
     fn write_set<T, F>(
         &mut self,
         el_ttype: TType,
-        els: &HashSet<T, Hasher>,
+        els: &AHashSet<T>,
         encode: F,
     ) -> Result<(), EncodeError>
     where
@@ -599,7 +594,7 @@ pub trait TOutputProtocolExt: TOutputProtocol + Sized {
         id: i16,
         key_ttype: TType,
         val_ttype: TType,
-        els: &HashMap<K, V, Hasher>,
+        els: &AHashMap<K, V>,
         key_encode: FK,
         val_encode: FV,
     ) -> Result<(), EncodeError>
@@ -617,7 +612,7 @@ pub trait TOutputProtocolExt: TOutputProtocol + Sized {
         &mut self,
         key_ttype: TType,
         val_ttype: TType,
-        els: &HashMap<K, V, Hasher>,
+        els: &AHashMap<K, V>,
         key_encode: FK,
         val_encode: FV,
     ) -> Result<(), EncodeError>


### PR DESCRIPTION
## Motivation

The default hashmap does not have convenient methods when the RandomState is not default, this PR changes the default generated code to use AHashMap instead.
