### PR TITLE
fix: evaluate def_location immediately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -161,26 +161,34 @@ where
 
     fn collect_def_ids(&self, input: &[DefId]) -> FxHashMap<DefId, DefLocation> {
         use crate::middle::ty::Visitor;
+        const MAX_RECURSION_DEPTH: usize = 64;
         struct PathCollector<'a> {
             map: &'a mut FxHashMap<DefId, DefLocation>,
             cx: &'a Context,
+            depth: usize,
         }
 
         impl crate::ty::Visitor for PathCollector<'_> {
             fn visit_path(&mut self, path: &crate::rir::Path) {
-                collect(self.cx, path.did, self.map)
+                collect(self.cx, path.did, self.map, self.depth)
             }
         }
 
-        fn collect(cx: &Context, def_id: DefId, map: &mut FxHashMap<DefId, DefLocation>) {
-            if let Some(_location) = map.get_mut(&def_id) {
+        fn collect(
+            cx: &Context,
+            def_id: DefId,
+            map: &mut FxHashMap<DefId, DefLocation>,
+            mut depth: usize,
+        ) {
+            if map.contains_key(&def_id) || depth > MAX_RECURSION_DEPTH {
                 return;
             }
+            depth += 1;
             if !matches!(&*cx.item(def_id).unwrap(), rir::Item::Mod(_)) {
                 let file_id = cx.node(def_id).unwrap().file_id;
 
                 if cx.input_files().contains(&file_id) {
-                    let type_graph = cx.type_graph();
+                    let type_graph = cx.workspace_graph();
                     let node = type_graph.node_map[&def_id];
                     for from in type_graph
                         .graph
@@ -188,24 +196,31 @@ where
                     {
                         let from_def_id = type_graph.id_map[&from];
                         let from_file_id = cx.node(from_def_id).unwrap().file_id;
-                        if !cx.input_files().contains(&from_file_id)
-                            || map
+
+                        if from_file_id != file_id {
+                            map.insert(def_id, DefLocation::Dynamic);
+                            break;
+                        } else {
+                            if !map.contains_key(&from_def_id) {
+                                collect(cx, from_def_id, map, depth);
+                            }
+                            if map
                                 .get(&from_def_id)
                                 .map(|v| match v {
                                     DefLocation::Fixed(_, _) => false,
                                     DefLocation::Dynamic => true,
                                 })
                                 .unwrap_or_default()
-                        {
-                            map.insert(def_id, DefLocation::Dynamic);
-                            return;
+                            {
+                                map.insert(def_id, DefLocation::Dynamic);
+                                break;
+                            }
                         }
                     }
-                    let file = cx.file(file_id).unwrap();
-                    map.insert(
-                        def_id,
-                        DefLocation::Fixed(CrateId { main_file: file_id }, file.package.clone()),
-                    );
+                    map.entry(def_id).or_insert_with(|| {
+                        let file = cx.db.file(file_id).unwrap();
+                        DefLocation::Fixed(CrateId { main_file: file_id }, file.package.clone())
+                    });
                 } else {
                     map.insert(def_id, DefLocation::Dynamic);
                 }
@@ -216,7 +231,7 @@ where
 
             node.related_nodes
                 .iter()
-                .for_each(|def_id| collect(cx, *def_id, map));
+                .for_each(|def_id| collect(cx, *def_id, map, depth));
 
             let item = node.expect_item();
 
@@ -224,32 +239,32 @@ where
                 rir::Item::Message(m) => m
                     .fields
                     .iter()
-                    .for_each(|f| PathCollector { cx, map }.visit(&f.ty)),
+                    .for_each(|f| PathCollector { cx, map, depth }.visit(&f.ty)),
                 rir::Item::Enum(e) => e
                     .variants
                     .iter()
                     .flat_map(|v| &v.fields)
-                    .for_each(|ty| PathCollector { cx, map }.visit(ty)),
+                    .for_each(|ty| PathCollector { cx, map, depth }.visit(ty)),
                 rir::Item::Service(s) => {
-                    s.extend.iter().for_each(|p| collect(cx, p.did, map));
+                    s.extend.iter().for_each(|p| collect(cx, p.did, map, depth));
                     s.methods
                         .iter()
                         .flat_map(|m| m.args.iter().map(|f| &f.ty).chain(std::iter::once(&m.ret)))
-                        .for_each(|ty| PathCollector { cx, map }.visit(ty));
+                        .for_each(|ty| PathCollector { cx, map, depth }.visit(ty));
                 }
-                rir::Item::NewType(n) => PathCollector { cx, map }.visit(&n.ty),
+                rir::Item::NewType(n) => PathCollector { cx, map, depth }.visit(&n.ty),
                 rir::Item::Const(c) => {
-                    PathCollector { cx, map }.visit(&c.ty);
+                    PathCollector { cx, map, depth }.visit(&c.ty);
                 }
                 rir::Item::Mod(m) => {
-                    m.items.iter().for_each(|i| collect(cx, *i, map));
+                    m.items.iter().for_each(|i| collect(cx, *i, map, depth));
                 }
             }
         }
         let mut map = FxHashMap::default();
 
         input.iter().for_each(|def_id| {
-            collect(&self.cg, *def_id, &mut map);
+            collect(&self.cg, *def_id, &mut map, 0);
         });
 
         map

--- a/pilota-build/src/db.rs
+++ b/pilota-build/src/db.rs
@@ -7,6 +7,7 @@ use crate::{
         rir::{self},
         ty::{AdtDef, AdtKind, CodegenTy, TyKind},
         type_graph::TypeGraph,
+        workspace_graph::WorkspaceGraph,
     },
     symbol::{DefId, FileId},
     tags::Tags,
@@ -49,6 +50,8 @@ pub trait RirDatabase {
     fn input_files(&self) -> Arc<Vec<FileId>>;
     #[salsa::input]
     fn args(&self) -> Arc<FxHashSet<DefId>>;
+    #[salsa::input]
+    fn workspace_graph(&self) -> Arc<WorkspaceGraph>;
 
     fn node(&self, def_id: DefId) -> Option<rir::Node>;
     fn file(&self, file_id: FileId) -> Option<Arc<rir::File>>;

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -33,6 +33,7 @@ use middle::{
     context::{tls::CONTEXT, CollectMode, ContextBuilder, Mode, WorkspaceInfo},
     rir::NodeKind,
     type_graph::TypeGraph,
+    workspace_graph::WorkspaceGraph,
 };
 pub use middle::{
     context::{Context, SourceType},
@@ -275,8 +276,10 @@ where
             }
         });
 
-        let type_graph = Arc::from(TypeGraph::from_items(items));
+        let type_graph = Arc::from(TypeGraph::from_items(items.clone()));
+        let workspace_graph = Arc::from(WorkspaceGraph::from_items(items));
         db.set_type_graph_with_durability(type_graph, Durability::HIGH);
+        db.set_workspace_graph_with_durability(workspace_graph, Durability::HIGH);
         db.set_nodes_with_durability(Arc::new(nodes), Durability::HIGH);
         db.set_tags_map_with_durability(Arc::new(tags), Durability::HIGH);
         db.set_args_with_durability(Arc::new(args), Durability::HIGH);

--- a/pilota-build/src/middle/mod.rs
+++ b/pilota-build/src/middle/mod.rs
@@ -4,3 +4,4 @@ pub mod resolver;
 pub mod rir;
 pub mod ty;
 pub mod type_graph;
+pub mod workspace_graph;

--- a/pilota-build/src/middle/type_graph.rs
+++ b/pilota-build/src/middle/type_graph.rs
@@ -13,18 +13,15 @@ use crate::symbol::DefId;
 pub struct TypeGraph {
     pub(crate) graph: Graph<DefId, ()>,
     pub(crate) node_map: FxHashMap<DefId, NodeIndex>,
-    pub(crate) id_map: FxHashMap<NodeIndex, DefId>,
 }
 
 impl TypeGraph {
     pub fn from_items(items: impl Iterator<Item = (DefId, Arc<Item>)> + Clone) -> Self {
         let mut graph: Graph<DefId, ()> = Graph::new();
         let mut node_map = FxHashMap::default();
-        let mut id_map = FxHashMap::default();
         items.clone().for_each(|(def_id, _)| {
             let node_index = graph.add_node(def_id);
             node_map.insert(def_id, node_index);
-            id_map.insert(node_index, def_id);
         });
 
         items.for_each(|(def_id, item)| {
@@ -50,11 +47,7 @@ impl TypeGraph {
                 _ => {}
             };
         });
-        Self {
-            graph,
-            node_map,
-            id_map,
-        }
+        Self { graph, node_map }
     }
 
     pub fn is_nested(&self, a: DefId, b: DefId) -> bool {

--- a/pilota-build/src/middle/workspace_graph.rs
+++ b/pilota-build/src/middle/workspace_graph.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use fxhash::FxHashMap;
+use petgraph::{graph::NodeIndex, Graph};
+
+use super::{
+    rir::Item,
+    ty::{self},
+};
+use crate::symbol::DefId;
+
+#[derive(Debug)]
+pub struct WorkspaceGraph {
+    pub(crate) graph: Graph<DefId, ()>,
+    pub(crate) node_map: FxHashMap<DefId, NodeIndex>,
+    pub(crate) id_map: FxHashMap<NodeIndex, DefId>,
+}
+
+impl WorkspaceGraph {
+    pub fn from_items(items: impl Iterator<Item = (DefId, Arc<Item>)> + Clone) -> Self {
+        let mut graph: Graph<DefId, ()> = Graph::new();
+        let mut node_map = FxHashMap::default();
+        let mut id_map = FxHashMap::default();
+        items.clone().for_each(|(def_id, _)| {
+            let node_index = graph.add_node(def_id);
+            node_map.insert(def_id, node_index);
+            id_map.insert(node_index, def_id);
+        });
+
+        fn visit(
+            graph: &mut Graph<DefId, ()>,
+            idx: NodeIndex,
+            node_map: &FxHashMap<DefId, NodeIndex>,
+            ty: &ty::Ty,
+        ) {
+            match &ty.kind {
+                ty::Path(p) => {
+                    graph.add_edge(idx, node_map[&p.did], ());
+                }
+                ty::Vec(ty) | ty::Set(ty) => {
+                    if let ty::Path(p) = &ty.kind {
+                        graph.add_edge(idx, node_map[&p.did], ());
+                    }
+                }
+                ty::Map(ty1, ty2) => {
+                    if let ty::Path(p) = &ty1.kind {
+                        graph.add_edge(idx, node_map[&p.did], ());
+                    }
+                    if let ty::Path(p) = &ty2.kind {
+                        graph.add_edge(idx, node_map[&p.did], ());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        items.for_each(|(def_id, item)| {
+            let idx = node_map[&def_id];
+            match &*item {
+                Item::Message(s) => s.fields.iter().for_each(|f| {
+                    visit(&mut graph, idx, &node_map, &f.ty);
+                }),
+                Item::Enum(e) => {
+                    e.variants.iter().flat_map(|v| &v.fields).for_each(|ty| {
+                        visit(&mut graph, idx, &node_map, ty);
+                    });
+                }
+                Item::NewType(t) => {
+                    visit(&mut graph, idx, &node_map, &t.ty);
+                }
+                _ => {}
+            };
+        });
+        Self {
+            graph,
+            node_map,
+            id_map,
+        }
+    }
+}


### PR DESCRIPTION
There are some cases where the def_location is not evaluated we should do it immediately to get information.