### PR TITLE
improve: use rustc-hash instead of fxhash for more active support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
 name = "pilota-build"
 version = "0.10.2"
 dependencies = [
+ "ahash",
  "anyhow",
  "criterion",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "nom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,21 +124,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -172,9 +166,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -183,15 +177,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -199,18 +193,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.14"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.14"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -282,6 +276,12 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "dashmap"
@@ -368,15 +368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,9 +386,13 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -428,9 +423,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "home"
@@ -517,9 +512,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -555,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -800,7 +795,6 @@ dependencies = [
  "derivative",
  "diffy",
  "faststr",
- "fxhash",
  "heck 0.4.1",
  "itertools 0.12.0",
  "lazy_static",
@@ -817,6 +811,7 @@ dependencies = [
  "quote",
  "rand",
  "rayon",
+ "rustc-hash",
  "salsa",
  "scoped-tls",
  "serde",
@@ -878,9 +873,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -893,7 +888,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "rand",
@@ -997,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -1007,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1035,13 +1030,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.4",
  "regex-syntax 0.8.2",
 ]
 
@@ -1056,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1091,11 +1086,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1246,9 +1241,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "syn"
@@ -1494,9 +1489,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1504,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -1519,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1529,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1542,15 +1537,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1733,9 +1728,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.33"
+version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -18,28 +18,29 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 pilota-thrift-parser = { path = "../pilota-thrift-parser", version = "0.10" }
+pilota = { path = "../pilota", version = "0.10" }
 
-toml = "0.8"
-heck = "0.4"
-syn = "2"
-normpath = "1"
-serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
-fxhash = "0.2"
-proc-macro2 = "1"
-salsa = { version = "0.17.0-pre.2" }
-scoped-tls = "1"
-quote = "1"
-rayon = "1"
-lazy_static = "1"
-tracing = "0.1"
+anyhow = "1"
 dashmap = "5"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-phf = { version = "0.11", features = ["macros"] }
+heck = "0.4"
 itertools = "0.12"
+lazy_static = "1"
+normpath = "1"
 paste = "1"
 petgraph = "0.6"
-anyhow = "1"
+phf = { version = "0.11", features = ["macros"] }
+proc-macro2 = "1"
+quote = "1"
+rayon = "1"
+rustc-hash = "1"
+salsa = { version = "0.17.0-pre.2" }
+scoped-tls = "1"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+syn = "2"
+toml = "0.8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # The official rust-protobuf parser currently has some bug.
 # We will switch to the official one when https://github.com/stepancheg/rust-protobuf/pull/646 is fixed.

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -18,8 +18,8 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 pilota-thrift-parser = { path = "../pilota-thrift-parser", version = "0.10" }
-pilota = { path = "../pilota", version = "0.10" }
 
+ahash = "0.8"
 anyhow = "1"
 dashmap = "5"
 heck = "0.4"

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -458,7 +458,7 @@ where
         ws.write_crates()
     }
 
-    pub fn write_items<'a>(&self, stream: &mut String, items: impl Iterator<Item = CodegenItem>)
+    pub fn write_items(&self, stream: &mut String, items: impl Iterator<Item = CodegenItem>)
     where
         B: Send,
     {

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -5,11 +5,11 @@ use std::{
     sync::Arc,
 };
 
+use ahash::AHashMap;
 use dashmap::DashMap;
 use faststr::FastStr;
 use itertools::Itertools;
 use normpath::PathExt;
-use pilota::AHashMap;
 use pkg_tree::PkgNode;
 use quote::quote;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -7,9 +7,9 @@ use std::{
 
 use dashmap::DashMap;
 use faststr::FastStr;
-use fxhash::FxHashMap;
 use itertools::Itertools;
 use normpath::PathExt;
+use pilota::AHashMap;
 use pkg_tree::PkgNode;
 use quote::quote;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
@@ -136,7 +136,7 @@ where
         &self,
         stream: &mut String,
         item: CodegenItem,
-        dup: &mut FxHashMap<FastStr, Vec<DefId>>,
+        dup: &mut AHashMap<FastStr, Vec<DefId>>,
     ) {
         CUR_ITEM.set(&item.def_id, || match item.kind {
             CodegenKind::Direct => {
@@ -191,7 +191,7 @@ where
         })
     }
 
-    fn duplicate(&self, dup: &mut FxHashMap<FastStr, Vec<DefId>>, def_id: DefId) -> bool {
+    fn duplicate(&self, dup: &mut AHashMap<FastStr, Vec<DefId>>, def_id: DefId) -> bool {
         let name = self.rust_name(def_id);
         if !self.dedups.contains(&name.0) {
             return false;
@@ -483,7 +483,7 @@ where
             let span = tracing::span!(tracing::Level::TRACE, "write_mod", path = ?p);
 
             let _enter = span.enter();
-            let mut dup = FxHashMap::default();
+            let mut dup = AHashMap::default();
             for def_id in def_ids.iter() {
                 this.write_item(&mut stream, *def_id, &mut dup)
             }

--- a/pilota-build/src/codegen/pkg_tree.rs
+++ b/pilota-build/src/codegen/pkg_tree.rs
@@ -27,11 +27,7 @@ fn from_pkgs(base_path: &[FastStr], pkgs: &[&[FastStr]]) -> Arc<[PkgNode]> {
         .into_group_map_by(|p| p.first().unwrap());
 
     Arc::from_iter(groups.into_iter().map(|(k, v)| {
-        let path = base_path
-            .iter()
-            .chain(Some(k).into_iter())
-            .cloned()
-            .collect::<Vec<_>>();
+        let path = base_path.iter().chain(Some(k)).cloned().collect::<Vec<_>>();
 
         let pkgs = v
             .into_iter()

--- a/pilota-build/src/codegen/thrift/decode_helper.rs
+++ b/pilota-build/src/codegen/thrift/decode_helper.rs
@@ -95,12 +95,11 @@ impl DecodeHelper {
     pub fn codegen_field_begin_len(&self, keep: bool) -> FastStr {
         if self.is_async {
             Default::default()
+        } else if keep {
+            "__pilota_offset += protocol.field_begin_len(field_ident.field_type, field_ident.id);"
+                .into()
         } else {
-            if keep {
-                "__pilota_offset += protocol.field_begin_len(field_ident.field_type, field_ident.id);".into()
-            } else {
-                "protocol.field_begin_len(field_ident.field_type, field_ident.id);".into()
-            }
+            "protocol.field_begin_len(field_ident.field_type, field_ident.id);".into()
         }
     }
 }

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -347,7 +347,7 @@ impl ThriftBackend {
         })
     }
 
-    fn codegen_entry_enum(&self, _def_id: DefId, _stream: &mut String, _e: &rir::Enum) {
+    fn codegen_entry_enum(&self, _def_id: DefId, _stream: &mut str, _e: &rir::Enum) {
         // TODO
     }
 
@@ -713,13 +713,10 @@ impl CodegenBackend for ThriftBackend {
                             if e.variants.first().filter(|v| variant_is_void(v)).is_some() {
                                 format!("Ok({name}::Ok(()))").into()
                             } else {
-                                format!(
-                                    r#"Err(::pilota::thrift::DecodeError::new(
-                                        ::pilota::thrift::DecodeErrorKind::InvalidData,
-                                        "received empty union from remote Message")
-                                    )"#
-                                )
-                                .into()
+                                r#"Err(::pilota::thrift::DecodeError::new(
+                                    ::pilota::thrift::DecodeErrorKind::InvalidData,
+                                    "received empty union from remote Message")
+                                )"#.into()
                             };
 
                         format! {

--- a/pilota-build/src/codegen/toml.rs
+++ b/pilota-build/src/codegen/toml.rs
@@ -6,7 +6,7 @@ pub fn merge_tomls(a: &mut toml::Value, b: toml::Value) {
         (toml::Value::String(a), toml::Value::String(b)) => *a = b,
         (toml::Value::Array(a), toml::Value::Array(b)) => {
             a.extend(b);
-            a.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+            a.sort_by_key(|a| a.to_string());
             a.dedup_by(|a, b| a.to_string() == b.to_string());
         }
         (toml::Value::Table(a), toml::Value::Table(b)) => b.into_iter().for_each(|(k, v)| {
@@ -16,6 +16,6 @@ pub fn merge_tomls(a: &mut toml::Value, b: toml::Value) {
                 a.insert(k, v);
             }
         }),
-        pair @ _ => panic!("can not merge {pair:?}"),
+        pair => panic!("can not merge {pair:?}"),
     }
 }

--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -2,9 +2,9 @@ use std::{borrow::Cow, path::PathBuf, process::Command, sync::Arc};
 
 use anyhow::bail;
 use faststr::FastStr;
-use fxhash::FxHashMap;
 use itertools::Itertools;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use rustc_hash::FxHashMap;
 
 use super::CodegenItem;
 use crate::{

--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -117,7 +117,7 @@ where
             .as_table()
             .unwrap()
             .keys()
-            .map(|s| FastStr::new(s))
+            .map(FastStr::new)
             .collect_vec();
 
         std::fs::write(

--- a/pilota-build/src/db.rs
+++ b/pilota-build/src/db.rs
@@ -1,6 +1,6 @@
 use std::{fmt, path::PathBuf, sync::Arc};
 
-use fxhash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     middle::{

--- a/pilota-build/src/dedup.rs
+++ b/pilota-build/src/dedup.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 
 use crate::{
     rir::{Arg, EnumVariant, Field, Item, Method, Node},

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -3,11 +3,11 @@ use std::{collections::HashMap, ops::Deref, path::PathBuf, sync::Arc};
 use anyhow::Context as _;
 use dashmap::DashMap;
 use faststr::FastStr;
-use fxhash::{FxHashMap, FxHashSet};
 use heck::ToShoutySnakeCase;
 use itertools::Itertools;
 use normpath::PathExt;
 use quote::format_ident;
+use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::ParallelDatabase;
 
 use self::tls::with_cur_item;

--- a/pilota-build/src/middle/resolver.rs
+++ b/pilota-build/src/middle/resolver.rs
@@ -96,7 +96,7 @@ impl PathResolver for DefaultPathResolver {
 
         let _length = path.len();
 
-        for (_idx, k) in path.into_iter().enumerate() {
+        for k in path.into_iter() {
             segs.push(match k {
                 Kind::Super => "super".into(),
                 Kind::Ident(ident) => ident.to_string(),

--- a/pilota-build/src/middle/type_graph.rs
+++ b/pilota-build/src/middle/type_graph.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use fxhash::FxHashMap;
 use petgraph::{algo::has_path_connecting, graph::NodeIndex, Graph};
+use rustc_hash::FxHashMap;
 
 use super::{
     rir::Item,

--- a/pilota-build/src/middle/workspace_graph.rs
+++ b/pilota-build/src/middle/workspace_graph.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use fxhash::FxHashMap;
 use petgraph::{graph::NodeIndex, Graph};
+use rustc_hash::FxHashMap;
 
 use super::{
     rir::Item,

--- a/pilota-build/src/parser/mod.rs
+++ b/pilota-build/src/parser/mod.rs
@@ -8,7 +8,7 @@ use crate::{ir::File, symbol::FileId};
 pub(crate) mod protobuf;
 pub(crate) mod thrift;
 
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 pub use thrift::ThriftParser;
 
 pub use self::protobuf::ProtobufParser;

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -1,13 +1,14 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use faststr::FastStr;
-use fxhash::{FxHashMap, FxHashSet};
 use itertools::Itertools;
 use normpath::PathExt;
+use pilota::AHashMap;
 use protobuf::descriptor::{
     field_descriptor_proto::{Label, Type},
     DescriptorProto, EnumDescriptorProto, ServiceDescriptorProto,
 };
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::Parser;
 use crate::{
@@ -66,7 +67,7 @@ impl Lower {
         &self,
         type_: Option<protobuf::EnumOrUnknown<protobuf::descriptor::field_descriptor_proto::Type>>,
         type_name: Option<&str>,
-        nested_messages: &FxHashMap<String, &DescriptorProto>,
+        nested_messages: &AHashMap<FastStr, &DescriptorProto>,
         message_name: Option<&str>,
     ) -> ir::Ty {
         if let Some(name) = type_name {
@@ -197,8 +198,8 @@ impl Lower {
         let nested_messages = message
             .nested_type
             .iter()
-            .map(|m| (format!("{}.{}", fq_message_name, m.name()), m))
-            .collect::<FxHashMap<_, _>>();
+            .map(|m| (format!("{}.{}", fq_message_name, m.name()).into(), m))
+            .collect::<AHashMap<FastStr, _>>();
 
         let mut fields = Vec::default();
         let mut oneof_fields = FxHashMap::default();

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
+use ahash::AHashMap;
 use faststr::FastStr;
 use itertools::Itertools;
 use normpath::PathExt;
-use pilota::AHashMap;
 use protobuf::descriptor::{
     field_descriptor_proto::{Label, Type},
     DescriptorProto, EnumDescriptorProto, ServiceDescriptorProto,

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -1,12 +1,12 @@
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use faststr::FastStr;
-use fxhash::FxHashMap;
 use heck::ToUpperCamelCase;
 use itertools::Itertools;
 use normpath::PathExt;
 use pilota_thrift_parser as thrift_parser;
 use pilota_thrift_parser::parser::Parser as _;
+use rustc_hash::FxHashMap;
 use salsa::ParallelDatabase;
 use thrift_parser::Annotations;
 

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -125,10 +125,8 @@ pub fn walk_codegen_uint<P: Plugin + ?Sized>(p: &mut P, cx: &Context, items: &[D
     items.iter().for_each(|def_id| {
         CUR_ITEM.set(def_id, || {
             let node = cx.node(*def_id).unwrap();
-
-            match &node.kind {
-                NodeKind::Item(item) => p.on_item(cx, *def_id, item.clone()),
-                _ => {}
+            if let NodeKind::Item(item) = &node.kind {
+                p.on_item(cx, *def_id, item.clone())
             }
         });
     });

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashSet, ops::DerefMut, sync::Arc};
 
 use faststr::FastStr;
-use fxhash::FxHashMap;
 use itertools::Itertools;
 use quote::quote;
+use rustc_hash::FxHashMap;
 
 use crate::{
     db::RirDatabase,

--- a/pilota-build/src/plugin/workspace.rs
+++ b/pilota-build/src/plugin/workspace.rs
@@ -15,10 +15,8 @@ impl Plugin for _WorkspacePlugin {
             v.iter().for_each(|(def_id, _)| {
                 CUR_ITEM.set(def_id, || {
                     let node = cx.node(*def_id).unwrap();
-
-                    match &node.kind {
-                        NodeKind::Item(item) => self.on_item(cx, *def_id, item.clone()),
-                        _ => {}
+                    if let NodeKind::Item(item) = &node.kind {
+                        self.on_item(cx, *def_id, item.clone());
                     }
                 });
             })
@@ -31,15 +29,12 @@ impl Plugin for _WorkspacePlugin {
         def_id: crate::DefId,
         item: std::sync::Arc<crate::rir::Item>,
     ) {
-        match &*item {
-            Item::Service(s) => {
-                if let Some(loc) = cx.location_map.get(&def_id) {
-                    if let Some(mut gen) = cx.plugin_gen.get_mut(loc) {
-                        gen.push_str(&format!("pub struct {};", s.name.sym));
-                    }
-                };
-            }
-            _ => {}
+        if let Item::Service(s) = &*item {
+            if let Some(loc) = cx.location_map.get(&def_id) {
+                if let Some(mut gen) = cx.plugin_gen.get_mut(loc) {
+                    gen.push_str(&format!("pub struct {};", s.name.sym));
+                }
+            };
         }
     }
 }

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -165,11 +165,10 @@ impl ir::visit::Visitor for CollectDef<'_> {
             ir::ItemKind::Use(_) => None,
         } {
             let prev_parent = self.parent.replace(ModuleId::Node(did));
-            match &item.kind {
-                ir::ItemKind::Enum(e) => e.variants.iter().for_each(|e| {
+            if let ir::ItemKind::Enum(e) = &item.kind {
+                e.variants.iter().for_each(|e| {
                     self.def_sym(Namespace::Value, (*e.name).clone());
-                }),
-                _ => {}
+                })
             }
             ir::visit::walk_item(self, item);
             self.parent = prev_parent;
@@ -454,9 +453,9 @@ impl Resolver {
         assert!(status.r#mod.len() <= 1);
 
         match ns {
-            Namespace::Value => status.value.get(0),
-            Namespace::Ty => status.ty.get(0),
-            Namespace::Mod => status.r#mod.get(0),
+            Namespace::Value => status.value.first(),
+            Namespace::Ty => status.ty.first(),
+            Namespace::Mod => status.r#mod.first(),
         }
         .copied()
     }

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -1,7 +1,8 @@
 use std::{ptr::NonNull, sync::Arc};
 
-use fxhash::{FxHashMap, FxHashSet};
 use itertools::Itertools;
+use pilota::AHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     errors,
@@ -178,9 +179,9 @@ impl ir::visit::Visitor for CollectDef<'_> {
 
 #[derive(Default, Debug)]
 pub struct SymbolTable {
-    pub(crate) value: FxHashMap<Symbol, DefId>,
-    pub(crate) ty: FxHashMap<Symbol, DefId>,
-    pub(crate) mods: FxHashMap<Symbol, DefId>,
+    pub(crate) value: AHashMap<Symbol, DefId>,
+    pub(crate) ty: AHashMap<Symbol, DefId>,
+    pub(crate) mods: AHashMap<Symbol, DefId>,
 }
 
 pub struct Resolver {

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -1,7 +1,7 @@
 use std::{ptr::NonNull, sync::Arc};
 
+use ahash::AHashMap;
 use itertools::Itertools;
-use pilota::AHashMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Pilota thrift Parser."
 documentation = "https://docs.rs/pilota"

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -7,7 +7,7 @@ use nom::{
     IResult,
 };
 
-use super::super::{
+use crate::{
     descriptor::{Annotation, Annotations, Literal},
     parser::*,
 };

--- a/pilota/src/prost/encoding.rs
+++ b/pilota/src/prost/encoding.rs
@@ -1559,6 +1559,7 @@ macro_rules! map {
         ///
         /// This is necessary because enumeration values can have a default value other
         /// than 0 in proto2.
+        #[allow(clippy::too_many_arguments)]
         pub fn encode_with_default<K, V, B, KE, KL, VE, VL>(
             key_encode: KE,
             key_encoded_len: KL,

--- a/pilota/src/thrift/binary.rs
+++ b/pilota/src/thrift/binary.rs
@@ -696,7 +696,7 @@ impl TInputProtocol for TBinaryProtocol<&mut Bytes> {
     fn read_faststr(&mut self) -> Result<FastStr, DecodeError> {
         let len = self.trans.read_i32()? as usize;
         let bytes = self.trans.split_to(len);
-        unsafe { return Ok(FastStr::from_bytes_unchecked(bytes)) };
+        unsafe { Ok(FastStr::from_bytes_unchecked(bytes)) }
     }
 
     #[inline]

--- a/pilota/src/thrift/binary_le.rs
+++ b/pilota/src/thrift/binary_le.rs
@@ -909,7 +909,7 @@ impl TInputProtocol for TBinaryProtocol<&mut Bytes> {
     fn read_faststr(&mut self) -> Result<FastStr, DecodeError> {
         let len = self.trans.read_i32_le()? as usize;
         let bytes = self.trans.split_to(len);
-        unsafe { return Ok(FastStr::from_bytes_unchecked(bytes)) };
+        unsafe { Ok(FastStr::from_bytes_unchecked(bytes)) }
     }
 
     #[inline]

--- a/pilota/src/thrift/binary_unsafe.rs
+++ b/pilota/src/thrift/binary_unsafe.rs
@@ -272,11 +272,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut BytesMut> {
     #[inline]
     fn write_bytes_without_len(&mut self, b: Bytes) -> Result<(), EncodeError> {
         unsafe {
-            ptr::copy_nonoverlapping(
-                b.as_ptr(),
-                self.buf.as_mut_ptr().offset(self.index as isize),
-                b.len(),
-            );
+            ptr::copy_nonoverlapping(b.as_ptr(), self.buf.as_mut_ptr().add(self.index), b.len());
             self.index += b.len();
         }
         Ok(())
@@ -374,11 +370,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut BytesMut> {
     fn write_string(&mut self, s: &str) -> Result<(), EncodeError> {
         self.write_i32(s.len() as i32)?;
         unsafe {
-            ptr::copy_nonoverlapping(
-                s.as_ptr(),
-                self.buf.as_mut_ptr().offset(self.index as isize),
-                s.len(),
-            );
+            ptr::copy_nonoverlapping(s.as_ptr(), self.buf.as_mut_ptr().add(self.index), s.len());
             self.index += s.len();
         }
         Ok(())
@@ -388,11 +380,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut BytesMut> {
     fn write_faststr(&mut self, s: FastStr) -> Result<(), EncodeError> {
         self.write_i32(s.len() as i32)?;
         unsafe {
-            ptr::copy_nonoverlapping(
-                s.as_ptr(),
-                self.buf.as_mut_ptr().offset(self.index as isize),
-                s.len(),
-            );
+            ptr::copy_nonoverlapping(s.as_ptr(), self.buf.as_mut_ptr().add(self.index), s.len());
             self.index += s.len();
         }
         Ok(())
@@ -443,11 +431,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut BytesMut> {
     fn write_bytes_vec(&mut self, b: &[u8]) -> Result<(), EncodeError> {
         self.write_i32(b.len() as i32)?;
         unsafe {
-            ptr::copy_nonoverlapping(
-                b.as_ptr(),
-                self.buf.as_mut_ptr().offset(self.index as isize),
-                b.len(),
-            );
+            ptr::copy_nonoverlapping(b.as_ptr(), self.buf.as_mut_ptr().add(self.index), b.len());
             self.index += b.len();
         }
         Ok(())
@@ -539,18 +523,14 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
             self.buf = unsafe {
                 let l = self.trans.bytes_mut().len();
                 slice::from_raw_parts_mut(
-                    self.trans.bytes_mut().as_mut_ptr().offset(l as isize),
+                    self.trans.bytes_mut().as_mut_ptr().add(l),
                     self.trans.bytes_mut().capacity() - l,
                 )
             };
             return Ok(());
         }
         unsafe {
-            ptr::copy_nonoverlapping(
-                b.as_ptr(),
-                self.buf.as_mut_ptr().offset(self.index as isize),
-                b.len(),
-            );
+            ptr::copy_nonoverlapping(b.as_ptr(), self.buf.as_mut_ptr().add(self.index), b.len());
             self.index += b.len();
         }
         Ok(())
@@ -648,11 +628,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
     fn write_string(&mut self, s: &str) -> Result<(), EncodeError> {
         self.write_i32(s.len() as i32)?;
         unsafe {
-            ptr::copy_nonoverlapping(
-                s.as_ptr(),
-                self.buf.as_mut_ptr().offset(self.index as isize),
-                s.len(),
-            );
+            ptr::copy_nonoverlapping(s.as_ptr(), self.buf.as_mut_ptr().add(self.index), s.len());
             self.index += s.len();
         }
         Ok(())
@@ -671,18 +647,14 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
             self.buf = unsafe {
                 let l = self.trans.bytes_mut().len();
                 slice::from_raw_parts_mut(
-                    self.trans.bytes_mut().as_mut_ptr().offset(l as isize),
+                    self.trans.bytes_mut().as_mut_ptr().add(l),
                     self.trans.bytes_mut().capacity() - l,
                 )
             };
             return Ok(());
         }
         unsafe {
-            ptr::copy_nonoverlapping(
-                s.as_ptr(),
-                self.buf.as_mut_ptr().offset(self.index as isize),
-                s.len(),
-            );
+            ptr::copy_nonoverlapping(s.as_ptr(), self.buf.as_mut_ptr().add(self.index), s.len());
             self.index += s.len();
         }
         Ok(())
@@ -733,11 +705,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
     fn write_bytes_vec(&mut self, b: &[u8]) -> Result<(), EncodeError> {
         self.write_i32(b.len() as i32)?;
         unsafe {
-            ptr::copy_nonoverlapping(
-                b.as_ptr(),
-                self.buf.as_mut_ptr().offset(self.index as isize),
-                b.len(),
-            );
+            ptr::copy_nonoverlapping(b.as_ptr(), self.buf.as_mut_ptr().add(self.index), b.len());
             self.index += b.len();
         }
         Ok(())
@@ -1104,7 +1072,7 @@ impl<'a> TInputProtocol for TBinaryUnsafeInputProtocol<'a> {
             self.index = 0;
             let bytes = self.trans.split_to(len);
             self.buf = slice::from_raw_parts(self.trans.as_ptr(), self.trans.len());
-            return Ok(FastStr::from_bytes_unchecked(bytes));
+            Ok(FastStr::from_bytes_unchecked(bytes))
         }
     }
 
@@ -1166,7 +1134,7 @@ impl<'a> TInputProtocol for TBinaryUnsafeInputProtocol<'a> {
 
     #[inline]
     fn buf(&mut self) -> &mut Self::Buf {
-        &mut self.trans
+        self.trans
     }
 
     #[inline]

--- a/pilota/src/thrift/compact.rs
+++ b/pilota/src/thrift/compact.rs
@@ -1110,17 +1110,17 @@ where
 
     #[inline]
     async fn read_i16(&mut self) -> Result<i16, DecodeError> {
-        Ok(self.read_varint_async::<i16>().await?)
+        self.read_varint_async::<i16>().await
     }
 
     #[inline]
     async fn read_i32(&mut self) -> Result<i32, DecodeError> {
-        Ok(self.read_varint_async::<i32>().await?)
+        self.read_varint_async::<i32>().await
     }
 
     #[inline]
     async fn read_i64(&mut self) -> Result<i64, DecodeError> {
-        Ok(self.read_varint_async::<i64>().await?)
+        self.read_varint_async::<i64>().await
     }
 
     #[inline]
@@ -1645,7 +1645,7 @@ impl TInputProtocol for TCompactInputProtocol<&mut Bytes> {
     fn read_faststr(&mut self) -> Result<FastStr, DecodeError> {
         let size = self.read_varint::<u32>()? as usize;
         let bytes = self.trans.split_to(size);
-        unsafe { return Ok(FastStr::from_bytes_unchecked(bytes)) }
+        unsafe { Ok(FastStr::from_bytes_unchecked(bytes)) }
     }
 
     #[inline]


### PR DESCRIPTION
## Motivation

FxHash is a speedy hash algorithm for use within rustc, and it performs great in hashing integer keys where we use it for. We found that rustc-hash is more active than fxhash crate, so we decided to replace fxhash with rustc-hash.

## Solution

Replace fxhash with rustc-hash, and judge the usage of fxhash suitable or not, if not, replace it with ahashmap.
