### PR TITLE
feat: add env configuration for resolve depth

### DIFF
--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -12,7 +12,7 @@ use crate::{
     fmt::fmt_file,
     middle::context::{CrateId, DefLocation},
     rir::{self, ItemPath},
-    Codegen, CodegenBackend, Context, DefId,
+    Codegen, CodegenBackend, Context, DefId, MAX_RESOLVE_DEPTH,
 };
 
 #[derive(Clone)]
@@ -161,7 +161,6 @@ where
 
     fn collect_def_ids(&self, input: &[DefId]) -> FxHashMap<DefId, DefLocation> {
         use crate::middle::ty::Visitor;
-        const MAX_RECURSION_DEPTH: usize = 64;
         struct PathCollector<'a> {
             map: &'a mut FxHashMap<DefId, DefLocation>,
             cx: &'a Context,
@@ -180,7 +179,7 @@ where
             map: &mut FxHashMap<DefId, DefLocation>,
             mut depth: usize,
         ) {
-            if map.contains_key(&def_id) || depth > MAX_RECURSION_DEPTH {
+            if map.contains_key(&def_id) || depth > *MAX_RESOLVE_DEPTH {
                 return;
             }
             depth += 1;

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -50,6 +50,13 @@ use salsa::Durability;
 pub use symbol::{DefId, IdentName};
 pub use tags::TagId;
 
+lazy_static::lazy_static! {
+    pub(crate) static ref MAX_RESOLVE_DEPTH: usize = std::env::var("MAX_RESOLVE_DEPTH")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(256);
+}
+
 pub trait MakeBackend: Sized {
     type Target: CodegenBackend;
     fn make_backend(self, context: Context) -> Self::Target;

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -22,7 +22,7 @@ use crate::{
     symbol::{DefId, FileId, IdentName, Symbol},
     tags::{EnumMode, TagId, Tags},
     ty::{AdtDef, AdtKind, CodegenTy, Visitor},
-    Plugin,
+    Plugin, MAX_RESOLVE_DEPTH,
 };
 
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
@@ -272,7 +272,6 @@ impl ContextBuilder {
         &self,
         input: &[DefId],
     ) -> FxHashMap<DefId, DefLocation> {
-        const MAX_RECURSION_DEPTH: usize = 64;
         struct PathCollector<'a> {
             map: &'a mut FxHashMap<DefId, DefLocation>,
             cx: &'a ContextBuilder,
@@ -291,7 +290,7 @@ impl ContextBuilder {
             map: &mut FxHashMap<DefId, DefLocation>,
             mut depth: usize,
         ) {
-            if map.contains_key(&def_id) || depth > MAX_RECURSION_DEPTH {
+            if map.contains_key(&def_id) || depth > *MAX_RESOLVE_DEPTH {
                 return;
             }
             depth += 1;


### PR DESCRIPTION
## Motivation
`MAX_RESOLVE_DEPTH` is used to prevent stack overflow when evaluting the `DefLocation` in worksapce mode. Sometimes, the default value will be small for users and cause panic in the process of code generation.

## Solution
Open the environment variables `MAX_RESOLVE_DEPTH` for user configuration.
