### PR TITLE
fix(pilota-build): panic in workspace mode when using main branch in toml

### DIFF
--- a/pilota-build/src/codegen/toml.rs
+++ b/pilota-build/src/codegen/toml.rs
@@ -16,6 +16,8 @@ pub fn merge_tomls(a: &mut toml::Value, b: toml::Value) {
                 a.insert(k, v);
             }
         }),
+        // maybe depend on specific version for testing, don't do anything
+        (toml::Value::Table(_), toml::Value::String(_)) => {}
         pair => panic!("can not merge {pair:?}"),
     }
 }


### PR DESCRIPTION
If users uses specified version in toml, then just simply use it.