### PR TITLE
fix: generate keywords that are not supported in r# with suffix _

### DIFF
--- a/pilota-build/src/symbol.rs
+++ b/pilota-build/src/symbol.rs
@@ -101,14 +101,21 @@ where
 
 impl std::fmt::Display for Symbol {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if &**self == "Self" {
-            return write!(f, "Self_");
+        if self.is_path_segment_keyword() {
+            return write!(f, "{}_", &**self);
         }
         if KEYWORDS_SET.contains(self) {
             write!(f, "r#{}", &**self)
         } else {
             write!(f, "{}", &**self)
         }
+    }
+}
+
+impl Symbol {
+    // https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/symbol.rs#L2395-L2398
+    fn is_path_segment_keyword(&self) -> bool {
+        ["super", "self", "Self", "crate"].contains(&&**self)
     }
 }
 

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -93,6 +93,8 @@ pub mod self_kw {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
             pub r#type: ::pilota::FastStr,
+
+            pub self_: ::pilota::FastStr,
         }
         impl ::pilota::thrift::Message for A {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -105,6 +107,7 @@ pub mod self_kw {
 
                 protocol.write_struct_begin(&struct_ident)?;
                 protocol.write_faststr_field(1, (&self.r#type).clone())?;
+                protocol.write_faststr_field(2, (&self.self_).clone())?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
                 Ok(())
@@ -117,6 +120,7 @@ pub mod self_kw {
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
 
                 let mut r#type = None;
+                let mut self_ = None;
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -136,6 +140,11 @@ pub mod self_kw {
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
                                 r#type = Some(protocol.read_faststr()?);
+                            }
+                            Some(2)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                self_ = Some(protocol.read_faststr()?);
                             }
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
@@ -163,8 +172,14 @@ pub mod self_kw {
                         "field r#type is required".to_string(),
                     ));
                 };
+                let Some(self_) = self_ else {
+                    return Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field self_ is required".to_string(),
+                    ));
+                };
 
-                let data = Self { r#type };
+                let data = Self { r#type, self_ };
                 Ok(data)
             }
 
@@ -180,6 +195,7 @@ pub mod self_kw {
             > {
                 ::std::boxed::Box::pin(async move {
                     let mut r#type = None;
+                    let mut self_ = None;
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -198,6 +214,12 @@ pub mod self_kw {
                                         == ::pilota::thrift::TType::Binary =>
                                 {
                                     r#type = Some(protocol.read_faststr().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    self_ = Some(protocol.read_faststr().await?);
                                 }
                                 _ => {
                                     protocol.skip(field_ident.field_type).await?;
@@ -226,8 +248,14 @@ pub mod self_kw {
                             "field r#type is required".to_string(),
                         ));
                     };
+                    let Some(self_) = self_ else {
+                        return Err(::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            "field self_ is required".to_string(),
+                        ));
+                    };
 
-                    let data = Self { r#type };
+                    let data = Self { r#type, self_ };
                     Ok(data)
                 })
             }
@@ -237,6 +265,7 @@ pub mod self_kw {
                 use ::pilota::thrift::TLengthProtocolExt;
                 protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "A" })
                     + protocol.faststr_field_len(Some(1), &self.r#type)
+                    + protocol.faststr_field_len(Some(2), &self.self_)
                     + protocol.field_stop_len()
                     + protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/self_kw.thrift
+++ b/pilota-build/test_data/thrift/self_kw.thrift
@@ -5,4 +5,5 @@ enum Index {
 
 struct A {
     1: required string type,
+    2: required string self,
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
Here are some keywords that are not supported in r#, which are listed in [here](https://github.com/rust-lang/rust/blob/master/compiler/rustc_span/src/symbol.rs#L2395-L2398). When user use these keywords in thrift IDL, the generated code will not compile.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Use another naming style to generate. Eg: `self` will be generated to `self_` rather than `r#self`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
