### PR TITLE
fix: don't override include_dirs for protobuf config

### DIFF
--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -479,7 +479,7 @@ impl Parser for ProtobufParser {
     }
 
     fn include_dirs(&mut self, dirs: Vec<std::path::PathBuf>) {
-        self.include_dirs = dirs.clone();
+        self.include_dirs.extend(dirs.clone());
         self.inner.includes(dirs);
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
Compilation will fail when there are multiple different include_dirs configurations.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Extend include_dirs instead of override.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
