### PR TITLE
feat: generate enum default as newtype

### DIFF
--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     rir::EnumVariant,
     symbol::{DefId, EnumRepr, Symbol},
-    tags::{thrift::EntryMessage, EnumMode},
+    tags::thrift::EntryMessage,
     ty::TyKind,
 };
 
@@ -503,17 +503,7 @@ impl CodegenBackend for ThriftBackend {
         let keep = self.keep_unknown_fields.contains(&def_id);
         let name = self.rust_name(def_id);
         let is_entry_message = self.node_contains_tag::<EntryMessage>(def_id);
-        let v = match self
-            .cx
-            .node_tags(def_id)
-            .unwrap()
-            .get::<EnumMode>()
-            .copied()
-            .unwrap_or(EnumMode::Enum)
-        {
-            EnumMode::NewType => "self.inner()",
-            EnumMode::Enum => "*self as i32",
-        };
+        let v = "self.inner()";
         match e.repr {
             Some(EnumRepr::I32) => stream.push_str(&self.codegen_impl_message_with_helper(
                 def_id,

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -40,10 +40,7 @@ pub use middle::{
     rir, ty,
 };
 use parser::{protobuf::ProtobufParser, thrift::ThriftParser, ParseResult, Parser};
-use plugin::{
-    AutoDerivePlugin, BoxedPlugin, EnumNumPlugin, ImplDefaultPlugin, PredicateResult,
-    WithAttrsPlugin,
-};
+use plugin::{AutoDerivePlugin, BoxedPlugin, ImplDefaultPlugin, PredicateResult, WithAttrsPlugin};
 pub use plugin::{BoxClonePlugin, ClonePlugin, Plugin};
 use resolve::{ResolveResult, Resolver};
 use salsa::Durability;
@@ -105,7 +102,6 @@ impl Builder<MkThriftBackend, ThriftParser> {
             plugins: vec![
                 Box::new(WithAttrsPlugin(Arc::from(["#[derive(Debug)]".into()]))),
                 Box::new(ImplDefaultPlugin),
-                Box::new(EnumNumPlugin),
             ],
             touches: Vec::default(),
             ignore_unused: true,
@@ -127,7 +123,6 @@ impl Builder<MkProtobufBackend, ProtobufParser> {
             plugins: vec![
                 Box::new(WithAttrsPlugin(Arc::from(["#[derive(Debug)]".into()]))),
                 Box::new(ImplDefaultPlugin),
-                Box::new(EnumNumPlugin),
             ],
             touches: Vec::default(),
             ignore_unused: true,

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -478,7 +478,7 @@ impl ThriftLower {
         }
 
         annotations.iter().for_each(
-            |annotation| with_tags!(annotation -> crate::tags::PilotaName | crate::tags::RustType | crate::tags::RustWrapperArc | crate::tags::SerdeAttribute | crate::tags::EnumMode),
+            |annotation| with_tags!(annotation -> crate::tags::PilotaName | crate::tags::RustType | crate::tags::RustWrapperArc | crate::tags::SerdeAttribute),
         );
 
         tags

--- a/pilota-build/src/plugin/serde.rs
+++ b/pilota-build/src/plugin/serde.rs
@@ -1,4 +1,4 @@
-use crate::tags::{EnumMode, SerdeAttribute};
+use crate::tags::SerdeAttribute;
 
 #[derive(Clone, Copy)]
 pub struct SerdePlugin;
@@ -28,17 +28,18 @@ impl crate::Plugin for SerdePlugin {
                         adj.add_attrs(&[attr.into()]);
                     }
                 });
-
-                if cx.node_tags(def_id).unwrap().get::<EnumMode>().copied()
-                    == Some(EnumMode::NewType)
-                {
-                    cx.with_adjust_mut(def_id, |adj| {
-                        adj.add_attrs(&["#[serde(transparent)]".into()]);
-                    })
-                }
             }
             _ => {}
         };
+
+        if let crate::rir::Item::Enum(e) = &*item {
+            if e.repr.is_some() {
+                cx.with_adjust_mut(def_id, |adj| {
+                    adj.add_attrs(&["#[serde(transparent)]".into()]);
+                })
+            }
+        }
+
         crate::plugin::walk_item(self, cx, def_id, item)
     }
 

--- a/pilota-build/src/tags.rs
+++ b/pilota-build/src/tags.rs
@@ -134,27 +134,6 @@ impl Annotation for PilotaName {
 #[derive(Debug)]
 pub struct RustType(pub FastStr);
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-pub enum EnumMode {
-    NewType,
-    Enum,
-}
-
-impl FromStr for EnumMode {
-    type Err = std::convert::Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "new_type" => Self::NewType,
-            _ => Self::Enum,
-        })
-    }
-}
-
-impl Annotation for EnumMode {
-    const KEY: &'static str = "pilota.enum_mode";
-}
-
 impl PartialEq<str> for RustType {
     fn eq(&self, other: &str) -> bool {
         self.0 == other

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -191,42 +191,29 @@ pub mod serde {
                     + protocol.struct_end_len()
             }
         }
-        impl ::std::convert::From<C> for i32 {
-            fn from(e: C) -> Self {
-                e as _
-            }
-        }
-
-        impl ::std::convert::TryFrom<i32> for C {
-            type Error = ::pilota::EnumConvertError<i32>;
-
-            #[allow(non_upper_case_globals)]
-            fn try_from(v: i32) -> ::std::result::Result<Self, ::pilota::EnumConvertError<i32>> {
-                const D: i32 = C::D as i32;
-                const E: i32 = C::E as i32;
-                match v {
-                    D => ::std::result::Result::Ok(C::D),
-                    E => ::std::result::Result::Ok(C::E),
-
-                    _ => ::std::result::Result::Err(::pilota::EnumConvertError::InvalidNum(v, "C")),
-                }
-            }
-        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize)]
         #[serde(untagged)]
-        #[derive(Clone, PartialEq)]
-        #[repr(i32)]
-        #[derive(Copy)]
-        pub enum C {
-            #[derivative(Default)]
-            #[serde(rename = "DD")]
-            D = 0,
+        #[serde(transparent)]
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct C(i32);
 
-            E = 1,
+        impl C {
+            pub const D: Self = Self(0);
+            pub const E: Self = Self(1);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
         }
 
+        impl ::std::convert::From<i32> for C {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
         impl ::pilota::thrift::Message for C {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
@@ -234,7 +221,7 @@ pub mod serde {
             ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_i32(*self as i32)?;
+                protocol.write_i32(self.inner())?;
                 Ok(())
             }
 
@@ -276,7 +263,7 @@ pub mod serde {
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
-                protocol.i32_len(*self as i32)
+                protocol.i32_len(self.inner())
             }
         }
         #[derive(

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -84,44 +84,26 @@ pub mod nested_message {
     }
 
     pub mod tt1 {
-
-        impl ::std::convert::From<Label> for i32 {
-            fn from(e: Label) -> Self {
-                e as _
-            }
-        }
-
-        impl ::std::convert::TryFrom<i32> for Label {
-            type Error = ::pilota::EnumConvertError<i32>;
-
-            #[allow(non_upper_case_globals)]
-            fn try_from(v: i32) -> ::std::result::Result<Self, ::pilota::EnumConvertError<i32>> {
-                const LabelOptional: i32 = Label::LabelOptional as i32;
-                const LabelRequired: i32 = Label::LabelRequired as i32;
-                const LabelRepeated: i32 = Label::LabelRepeated as i32;
-                match v {
-                    LabelOptional => ::std::result::Result::Ok(Label::LabelOptional),
-                    LabelRequired => ::std::result::Result::Ok(Label::LabelRequired),
-                    LabelRepeated => ::std::result::Result::Ok(Label::LabelRepeated),
-
-                    _ => ::std::result::Result::Err(::pilota::EnumConvertError::InvalidNum(
-                        v, "Label",
-                    )),
-                }
-            }
-        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
-        #[repr(i32)]
-        #[derive(Copy)]
-        pub enum Label {
-            #[derivative(Default)]
-            LabelOptional = 1,
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Label(i32);
 
-            LabelRequired = 2,
+        impl Label {
+            pub const LABEL_OPTIONAL: Self = Self(1);
+            pub const LABEL_REQUIRED: Self = Self(2);
+            pub const LABEL_REPEATED: Self = Self(3);
 
-            LabelRepeated = 3,
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
+        }
+
+        impl ::std::convert::From<i32> for Label {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
         }
         #[derive(Debug, Default, Clone, PartialEq)]
         pub struct T2 {

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -100,7 +100,6 @@ pub mod oneof {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum Test {
             #[derivative(Default)]
             A(::pilota::FastStr),
@@ -172,7 +171,6 @@ pub mod oneof {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum Type {
             #[derivative(Default)]
             S(::pilota::FastStr),

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -2,42 +2,26 @@ pub mod const_val {
     #![allow(warnings, clippy::all)]
 
     pub mod const_val {
-
-        impl ::std::convert::From<Index> for i32 {
-            fn from(e: Index) -> Self {
-                e as _
-            }
-        }
-
-        impl ::std::convert::TryFrom<i32> for Index {
-            type Error = ::pilota::EnumConvertError<i32>;
-
-            #[allow(non_upper_case_globals)]
-            fn try_from(v: i32) -> ::std::result::Result<Self, ::pilota::EnumConvertError<i32>> {
-                const A: i32 = Index::A as i32;
-                const B: i32 = Index::B as i32;
-                match v {
-                    A => ::std::result::Result::Ok(Index::A),
-                    B => ::std::result::Result::Ok(Index::B),
-
-                    _ => ::std::result::Result::Err(::pilota::EnumConvertError::InvalidNum(
-                        v, "Index",
-                    )),
-                }
-            }
-        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
-        #[repr(i32)]
-        #[derive(Copy)]
-        pub enum Index {
-            #[derivative(Default)]
-            A = 0,
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Index(i32);
 
-            B = 1,
+        impl Index {
+            pub const A: Self = Self(0);
+            pub const B: Self = Self(1);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
         }
 
+        impl ::std::convert::From<i32> for Index {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
@@ -45,7 +29,7 @@ pub mod const_val {
             ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_i32(*self as i32)?;
+                protocol.write_i32(self.inner())?;
                 Ok(())
             }
 
@@ -87,7 +71,7 @@ pub mod const_val {
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
-                protocol.i32_len(*self as i32)
+                protocol.i32_len(self.inner())
             }
         }
         ::pilota::lazy_static::lazy_static! {

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -2,40 +2,26 @@ pub mod default_value {
     #![allow(warnings, clippy::all)]
 
     pub mod default_value {
-
-        impl ::std::convert::From<B> for i32 {
-            fn from(e: B) -> Self {
-                e as _
-            }
-        }
-
-        impl ::std::convert::TryFrom<i32> for B {
-            type Error = ::pilota::EnumConvertError<i32>;
-
-            #[allow(non_upper_case_globals)]
-            fn try_from(v: i32) -> ::std::result::Result<Self, ::pilota::EnumConvertError<i32>> {
-                const Read: i32 = B::Read as i32;
-                const Write: i32 = B::Write as i32;
-                match v {
-                    Read => ::std::result::Result::Ok(B::Read),
-                    Write => ::std::result::Result::Ok(B::Write),
-
-                    _ => ::std::result::Result::Err(::pilota::EnumConvertError::InvalidNum(v, "B")),
-                }
-            }
-        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
-        #[repr(i32)]
-        #[derive(Copy)]
-        pub enum B {
-            #[derivative(Default)]
-            Read = 1,
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct B(i32);
 
-            Write = 2,
+        impl B {
+            pub const READ: Self = Self(1);
+            pub const WRITE: Self = Self(2);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
         }
 
+        impl ::std::convert::From<i32> for B {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
         impl ::pilota::thrift::Message for B {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
@@ -43,7 +29,7 @@ pub mod default_value {
             ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_i32(*self as i32)?;
+                protocol.write_i32(self.inner())?;
                 Ok(())
             }
 
@@ -85,7 +71,7 @@ pub mod default_value {
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
-                protocol.i32_len(*self as i32)
+                protocol.i32_len(self.inner())
             }
         }
         impl Default for C {
@@ -263,8 +249,8 @@ pub mod default_value {
                     faststr: ::pilota::FastStr::from_static_str("hello world"),
                     string: "test".to_string(),
                     a: Some(false),
-                    test_b: Some(B::Read),
-                    test_b2: Some(B::Write),
+                    test_b: Some(B::READ),
+                    test_b2: Some(B::WRITE),
                     map: Some({
                         let mut map = ::pilota::AHashMap::with_capacity(1);
                         map.insert(
@@ -316,10 +302,10 @@ pub mod default_value {
                     protocol.write_bool_field(3, *value)?;
                 }
                 if let Some(value) = self.test_b.as_ref() {
-                    protocol.write_i32_field(4, (*value).into())?;
+                    protocol.write_i32_field(4, (value).inner())?;
                 }
                 if let Some(value) = self.test_b2.as_ref() {
-                    protocol.write_i32_field(5, (*value).into())?;
+                    protocol.write_i32_field(5, (value).inner())?;
                 }
                 if let Some(value) = self.map.as_ref() {
                     protocol.write_map_field(
@@ -360,8 +346,8 @@ pub mod default_value {
                 let mut faststr = ::pilota::FastStr::from_static_str("hello world");
                 let mut string = None;
                 let mut a = Some(false);
-                let mut test_b = Some(B::Read);
-                let mut test_b2 = Some(B::Write);
+                let mut test_b = Some(B::READ);
+                let mut test_b2 = Some(B::WRITE);
                 let mut map = None;
                 let mut test_double = Some(1f64);
                 let mut test_double2 = Some(1.2f64);
@@ -489,8 +475,8 @@ pub mod default_value {
                     let mut faststr = ::pilota::FastStr::from_static_str("hello world");
                     let mut string = None;
                     let mut a = Some(false);
-                    let mut test_b = Some(B::Read);
-                    let mut test_b2 = Some(B::Write);
+                    let mut test_b = Some(B::READ);
+                    let mut test_b2 = Some(B::WRITE);
                     let mut map = None;
                     let mut test_double = Some(1f64);
                     let mut test_double2 = Some(1.2f64);
@@ -637,11 +623,11 @@ pub mod default_value {
                     + self
                         .test_b
                         .as_ref()
-                        .map_or(0, |value| protocol.i32_field_len(Some(4), (*value).into()))
+                        .map_or(0, |value| protocol.i32_field_len(Some(4), (value).inner()))
                     + self
                         .test_b2
                         .as_ref()
-                        .map_or(0, |value| protocol.i32_field_len(Some(5), (*value).into()))
+                        .map_or(0, |value| protocol.i32_field_len(Some(5), (value).inner()))
                     + self.map.as_ref().map_or(0, |value| {
                         protocol.map_field_len(
                             Some(6),

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -2,42 +2,26 @@ pub mod enum_test {
     #![allow(warnings, clippy::all)]
 
     pub mod enum_test {
-
-        impl ::std::convert::From<Index> for i32 {
-            fn from(e: Index) -> Self {
-                e as _
-            }
-        }
-
-        impl ::std::convert::TryFrom<i32> for Index {
-            type Error = ::pilota::EnumConvertError<i32>;
-
-            #[allow(non_upper_case_globals)]
-            fn try_from(v: i32) -> ::std::result::Result<Self, ::pilota::EnumConvertError<i32>> {
-                const A: i32 = Index::A as i32;
-                const B: i32 = Index::B as i32;
-                match v {
-                    A => ::std::result::Result::Ok(Index::A),
-                    B => ::std::result::Result::Ok(Index::B),
-
-                    _ => ::std::result::Result::Err(::pilota::EnumConvertError::InvalidNum(
-                        v, "Index",
-                    )),
-                }
-            }
-        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
-        #[repr(i32)]
-        #[derive(Copy)]
-        pub enum Index {
-            #[derivative(Default)]
-            A = 1,
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Index(i32);
 
-            B = 16,
+        impl Index {
+            pub const A: Self = Self(1);
+            pub const B: Self = Self(16);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
         }
 
+        impl ::std::convert::From<i32> for Index {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
@@ -45,7 +29,7 @@ pub mod enum_test {
             ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_i32(*self as i32)?;
+                protocol.write_i32(self.inner())?;
                 Ok(())
             }
 
@@ -87,7 +71,7 @@ pub mod enum_test {
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
-                protocol.i32_len(*self as i32)
+                protocol.i32_len(self.inner())
             }
         }
     }

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -1055,7 +1055,6 @@ pub mod normal {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestTest123ResultSend {
             #[derivative(Default)]
             Ok(()),
@@ -1599,7 +1598,6 @@ pub mod normal {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestTestExceptionException {
             #[derivative(Default)]
             StException(StException),
@@ -1741,7 +1739,6 @@ pub mod normal {
         #[derive(Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestTestExceptionResultSend {
             #[derivative(Default)]
             Ok(ObjReq),
@@ -1919,7 +1916,6 @@ pub mod normal {
         #[derive(Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestTestExceptionResultRecv {
             #[derivative(Default)]
             Ok(ObjReq),
@@ -2097,7 +2093,6 @@ pub mod normal {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestTest123ResultRecv {
             #[derivative(Default)]
             Ok(()),

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -309,7 +309,6 @@ pub mod pilota_name {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestServiceTestResultSend {
             #[derivative(Default)]
             Ok(Test1),
@@ -785,7 +784,6 @@ pub mod pilota_name {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestServiceTestResultRecv {
             #[derivative(Default)]
             Ok(Test1),
@@ -923,41 +921,26 @@ pub mod pilota_name {
                     + protocol.struct_end_len()
             }
         }
-        impl ::std::convert::From<Index> for i32 {
-            fn from(e: Index) -> Self {
-                e as _
-            }
-        }
-
-        impl ::std::convert::TryFrom<i32> for Index {
-            type Error = ::pilota::EnumConvertError<i32>;
-
-            #[allow(non_upper_case_globals)]
-            fn try_from(v: i32) -> ::std::result::Result<Self, ::pilota::EnumConvertError<i32>> {
-                const AA: i32 = Index::AA as i32;
-                const B: i32 = Index::B as i32;
-                match v {
-                    AA => ::std::result::Result::Ok(Index::AA),
-                    B => ::std::result::Result::Ok(Index::B),
-
-                    _ => ::std::result::Result::Err(::pilota::EnumConvertError::InvalidNum(
-                        v, "Index",
-                    )),
-                }
-            }
-        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
-        #[repr(i32)]
-        #[derive(Copy)]
-        pub enum Index {
-            #[derivative(Default)]
-            AA = 0,
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Index(i32);
 
-            B = 1,
+        impl Index {
+            pub const AA: Self = Self(0);
+            pub const B: Self = Self(1);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
         }
 
+        impl ::std::convert::From<i32> for Index {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
@@ -965,7 +948,7 @@ pub mod pilota_name {
             ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_i32(*self as i32)?;
+                protocol.write_i32(self.inner())?;
                 Ok(())
             }
 
@@ -1007,7 +990,7 @@ pub mod pilota_name {
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
-                protocol.i32_len(*self as i32)
+                protocol.i32_len(self.inner())
             }
         }
     }

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -2,42 +2,26 @@ pub mod self_kw {
     #![allow(warnings, clippy::all)]
 
     pub mod self_kw {
-
-        impl ::std::convert::From<Index> for i32 {
-            fn from(e: Index) -> Self {
-                e as _
-            }
-        }
-
-        impl ::std::convert::TryFrom<i32> for Index {
-            type Error = ::pilota::EnumConvertError<i32>;
-
-            #[allow(non_upper_case_globals)]
-            fn try_from(v: i32) -> ::std::result::Result<Self, ::pilota::EnumConvertError<i32>> {
-                const A: i32 = Index::A as i32;
-                const Self_: i32 = Index::Self_ as i32;
-                match v {
-                    A => ::std::result::Result::Ok(Index::A),
-                    Self_ => ::std::result::Result::Ok(Index::Self_),
-
-                    _ => ::std::result::Result::Err(::pilota::EnumConvertError::InvalidNum(
-                        v, "Index",
-                    )),
-                }
-            }
-        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
-        #[repr(i32)]
-        #[derive(Copy)]
-        pub enum Index {
-            #[derivative(Default)]
-            A = 0,
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Index(i32);
 
-            Self_ = 1,
+        impl Index {
+            pub const A: Self = Self(0);
+            pub const SELF: Self = Self(1);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
         }
 
+        impl ::std::convert::From<i32> for Index {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
@@ -45,7 +29,7 @@ pub mod self_kw {
             ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_i32(*self as i32)?;
+                protocol.write_i32(self.inner())?;
                 Ok(())
             }
 
@@ -87,7 +71,7 @@ pub mod self_kw {
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
-                protocol.i32_len(*self as i32)
+                protocol.i32_len(self.inner())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/union.rs
+++ b/pilota-build/test_data/thrift/union.rs
@@ -5,7 +5,6 @@ pub mod union {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum Union {
             #[derivative(Default)]
             A(::pilota::FastStr),
@@ -167,7 +166,6 @@ pub mod union {
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
-
         pub enum Empty {}
 
         impl ::pilota::thrift::Message for Empty {

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -5,7 +5,6 @@ pub mod void {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestTest123ResultRecv {
             #[derivative(Default)]
             Ok(()),
@@ -346,7 +345,6 @@ pub mod void {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestTest123ResultSend {
             #[derivative(Default)]
             Ok(()),

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -125,7 +125,6 @@ pub mod wrapper_arc {
         #[derive(Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestServiceTestResultRecv {
             #[derivative(Default)]
             Ok(Test),
@@ -415,7 +414,6 @@ pub mod wrapper_arc {
         #[derive(Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(Clone, PartialEq)]
-
         pub enum TestServiceTestResultSend {
             #[derivative(Default)]
             Ok(::std::sync::Arc<Test>),

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -1958,7 +1958,6 @@ pub mod unknown_fields {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-
         pub enum TestUnion {
             #[derivative(Default)]
             A(A),
@@ -2153,7 +2152,6 @@ pub mod unknown_fields {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-
         pub enum TestTestExceptionException {
             #[derivative(Default)]
             StException(StException),
@@ -2295,7 +2293,6 @@ pub mod unknown_fields {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-
         pub enum TestTestExceptionResultRecv {
             #[derivative(Default)]
             Ok(ObjReq),
@@ -2473,7 +2470,6 @@ pub mod unknown_fields {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-
         pub enum TestTest123ResultRecv {
             #[derivative(Default)]
             Ok(()),
@@ -2573,41 +2569,28 @@ pub mod unknown_fields {
                     + protocol.struct_end_len()
             }
         }
-        impl ::std::convert::From<Index> for i32 {
-            fn from(e: Index) -> Self {
-                e as _
-            }
-        }
-
-        impl ::std::convert::TryFrom<i32> for Index {
-            type Error = ::pilota::EnumConvertError<i32>;
-
-            #[allow(non_upper_case_globals)]
-            fn try_from(v: i32) -> ::std::result::Result<Self, ::pilota::EnumConvertError<i32>> {
-                const A: i32 = Index::A as i32;
-                const B: i32 = Index::B as i32;
-                match v {
-                    A => ::std::result::Result::Ok(Index::A),
-                    B => ::std::result::Result::Ok(Index::B),
-
-                    _ => ::std::result::Result::Err(::pilota::EnumConvertError::InvalidNum(
-                        v, "Index",
-                    )),
-                }
-            }
-        }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-        #[repr(i32)]
-        #[derive(Copy)]
-        pub enum Index {
-            #[derivative(Default)]
-            A = 0,
+        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize)]
+        #[serde(transparent)]
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Index(i32);
 
-            B = 1,
+        impl Index {
+            pub const A: Self = Self(0);
+            pub const B: Self = Self(1);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
         }
 
+        impl ::std::convert::From<i32> for Index {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,
@@ -2615,7 +2598,7 @@ pub mod unknown_fields {
             ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
-                protocol.write_i32(*self as i32)?;
+                protocol.write_i32(self.inner())?;
                 Ok(())
             }
 
@@ -2657,7 +2640,7 @@ pub mod unknown_fields {
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TLengthProtocolExt;
-                protocol.i32_len(*self as i32)
+                protocol.i32_len(self.inner())
             }
         }
         #[derive(
@@ -2980,7 +2963,6 @@ pub mod unknown_fields {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-
         pub enum TestTest123ResultSend {
             #[derivative(Default)]
             Ok(()),
@@ -3371,7 +3353,6 @@ pub mod unknown_fields {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-
         pub enum TestTestExceptionResultSend {
             #[derivative(Default)]
             Ok(ObjReq),
@@ -3561,7 +3542,6 @@ pub mod unknown_fields {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-
         pub enum TestTest123ResultRecv {
             #[derivative(Default)]
             Ok(()),
@@ -3664,7 +3644,6 @@ pub mod unknown_fields {
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
         #[derivative(Default)]
         #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
-
         pub enum TestTest123ResultSend {
             #[derivative(Default)]
             Ok(()),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
Previously, thrift/protobuf enum type is generated to rust enum type by default, and we provided an annotation `pilota.enum_mode="new_type"` for users to change the rust generated type to a wrapper of i32. Over time, we found that it is more correct to make the newtype the default behaviour, as when users add a new variant in the enum definition, it will not cause the old idl generated code to fail to decode. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Deprecate annotation `pilota.enum_mode="new_type"` and make it as default behaviour. 

```thrift
enum Index {
    A = 0x01,
    B = 0x10,
}
```

Generated:

```rust
pub struct Index(i32);

impl Index {
    pub const A: Self = Self(1);
    pub const B: Self = Self(16);

    pub fn inner(&self) -> i32 {
        self.0
    }
}

impl ::std::convert::From<i32> for Index {
    fn from(value: i32) -> Self {
        Self(value)
    }
}
```
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
