### PR TITLE
fix(pilota_build): idl enum should implement the From<NewType> trait for inner type

### DIFF
--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -250,7 +250,15 @@ where
                 fn from(value: {repr}) -> Self {{
                     Self(value)
                 }}
-            }}"#
+            }}
+
+            impl ::std::convert::From<{name}> for {repr} {{
+                fn from(value: {name}) -> {repr} {{
+                    value.0
+                }}
+            }}
+
+            "#
         });
 
         self.backend.codegen_enum_impl(def_id, stream, e);
@@ -406,6 +414,7 @@ where
                     Self(v)
                 }}
             }}
+            
             "#
         });
         self.backend.codegen_newtype_impl(def_id, stream, t);

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -214,6 +214,13 @@ pub mod serde {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<C> for i32 {
+            fn from(value: C) -> i32 {
+                value.0
+            }
+        }
+
         impl ::pilota::thrift::Message for C {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -105,6 +105,13 @@ pub mod nested_message {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<Label> for i32 {
+            fn from(value: Label) -> i32 {
+                value.0
+            }
+        }
+
         #[derive(Debug, Default, Clone, PartialEq)]
         pub struct T2 {
             pub t3: t2::Tt3,

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -22,6 +22,13 @@ pub mod const_val {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<Index> for i32 {
+            fn from(value: Index) -> i32 {
+                value.0
+            }
+        }
+
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -22,6 +22,13 @@ pub mod default_value {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<B> for i32 {
+            fn from(value: B) -> i32 {
+                value.0
+            }
+        }
+
         impl ::pilota::thrift::Message for B {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -22,6 +22,13 @@ pub mod enum_test {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<Index> for i32 {
+            fn from(value: Index) -> i32 {
+                value.0
+            }
+        }
+
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -435,6 +435,13 @@ pub mod multi {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<B> for i32 {
+            fn from(value: B) -> i32 {
+                value.0
+            }
+        }
+
         impl ::pilota::thrift::Message for B {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -941,6 +941,13 @@ pub mod pilota_name {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<Index> for i32 {
+            fn from(value: Index) -> i32 {
+                value.0
+            }
+        }
+
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -22,6 +22,13 @@ pub mod self_kw {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<Index> for i32 {
+            fn from(value: Index) -> i32 {
+                value.0
+            }
+        }
+
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -2591,6 +2591,13 @@ pub mod unknown_fields {
                 Self(value)
             }
         }
+
+        impl ::std::convert::From<Index> for i32 {
+            fn from(value: Index) -> i32 {
+                value.0
+            }
+        }
+
         impl ::pilota::thrift::Message for Index {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
                 &self,


### PR DESCRIPTION
## Motivation

The generated new type for idl enum type would encounter the encoding error for the lack of implementation of into inner trait.

## Solution

Implement the From<NewType> trait for Inner type when generate the idl enum type.
