### PR TITLE
fix: use absolute path for generated Ok and Err

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.3"
+version = "0.11.4"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/codegen/protobuf/mod.rs
+++ b/pilota-build/src/codegen/protobuf/mod.rs
@@ -536,7 +536,7 @@ impl CodegenBackend for ProtobufBackend {
                         {merge}
                         _ => unreachable!(concat!("invalid ", stringify!({name}), " tag: {{}}"), tag),
                     }};
-                    Ok(())
+                    ::core::result::Result::Ok(())
                 }}
             }}"#
         });

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -277,7 +277,7 @@ impl ThriftBackend {
             .map(|s| {
                 format!(
                     r#"let Some({s}) = {s} else {{
-                return Err(
+                return ::std::result::Result::Err(
                     ::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "field {s} is required".to_string()
@@ -314,11 +314,11 @@ impl ThriftBackend {
             let mut __pilota_decoding_field_id = None;
 
             {read_struct_begin};
-            if let Err(mut err) = {read_fields} {{
+            if let ::std::result::Result::Err(mut err) = {read_fields} {{
                 if let Some(field_id) = __pilota_decoding_field_id {{
                     err.prepend_msg(&format!("{format_msg}, caused by: ", field_id));
                 }}
-                return Err(err);
+                return ::std::result::Result::Err(err);
             }};
             {read_struct_end};
 
@@ -329,7 +329,7 @@ impl ThriftBackend {
             let data = Self {{
                 {fields}
             }};
-            Ok(data)
+            ::std::result::Result::Ok(data)
             "#
         }
     }
@@ -481,7 +481,7 @@ impl CodegenBackend for ThriftBackend {
                 {encode_fields}
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
                 "#
             },
             format! {
@@ -510,7 +510,7 @@ impl CodegenBackend for ThriftBackend {
                 name.clone(),
                 format! {
                     r#"protocol.write_i32({v})?;
-                    Ok(())
+                    ::std::result::Result::Ok(())
                     "#
                 },
                 format!("protocol.i32_len({v})"),
@@ -519,7 +519,7 @@ impl CodegenBackend for ThriftBackend {
                     let err_msg_tmpl = format!("invalid enum value for {}, value: {{}}", name);
                     format! {
                         r#"let value = {read_i32};
-                        Ok(::std::convert::TryFrom::try_from(value).map_err(|err|
+                        ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(|err|
                             ::pilota::thrift::new_protocol_exception(
                                 ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                                 format!("{err_msg_tmpl}", value)
@@ -604,7 +604,7 @@ impl CodegenBackend for ThriftBackend {
                         }}
                         protocol.write_field_stop()?;
                         protocol.write_struct_end()?;
-                        Ok(())"#
+                        ::std::result::Result::Ok(())"#
                     },
                         format! {
                             r#"protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {{
@@ -665,7 +665,7 @@ impl CodegenBackend for ThriftBackend {
                                         {decode_len}
                                         ret = Some({name}::{variant_name}(field_ident));
                                     }} else {{
-                                        return Err(::pilota::thrift::new_protocol_exception(
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                                             "received multiple fields for union from remote Message"
                                         ));
@@ -684,7 +684,7 @@ impl CodegenBackend for ThriftBackend {
                                     ret = Some({name}::_UnknownFields(__pilota_linked_bytes));
                                 }}
                             }} else {{
-                                return Err(::pilota::thrift::new_protocol_exception(
+                                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                                     ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                                     "received multiple fields for union from remote Message"
                                 ));
@@ -696,9 +696,9 @@ impl CodegenBackend for ThriftBackend {
 
                         let handle_none_ret: FastStr =
                             if e.variants.first().filter(|v| variant_is_void(v)).is_some() {
-                                format!("Ok({name}::Ok(()))").into()
+                                format!("::std::result::Result::Ok({name}::Ok(()))").into()
                             } else {
-                                r#"Err(::pilota::thrift::new_protocol_exception(
+                                r#"::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                                     ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                                     "received empty union from remote Message")
                                 )"#.into()
@@ -727,7 +727,7 @@ impl CodegenBackend for ThriftBackend {
                             {read_field_end};
                             {read_struct_end};
                             if let Some(ret) = ret {{
-                                Ok(ret)
+                                ::std::result::Result::Ok(ret)
                             }} else {{
                                 {handle_none_ret}
                             }}"#
@@ -750,12 +750,12 @@ impl CodegenBackend for ThriftBackend {
             name.clone(),
             format! {
                 r#"{encode}
-                Ok(())"#
+                ::std::result::Result::Ok(())"#
             },
             format!("{encode_size}"),
             |helper| {
                 let decode = self.codegen_decode_ty(helper, &t.ty);
-                format!("Ok({name}({decode}))")
+                format!("::std::result::Result::Ok({name}({decode}))")
             },
         ));
     }

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -67,7 +67,7 @@ impl ThriftBackend {
                 format! {
                     r#"protocol.write_list({el_ttype}, &{ident}, |protocol, val| {{
                         {write_el}
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     }})?;"#
                 }
                 .into()
@@ -79,7 +79,7 @@ impl ThriftBackend {
                 format! {
                     r#"protocol.write_set({el_ttype}, &{ident}, |protocol, val| {{
                         {write_el}
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     }})?;"#
                 }
                 .into()
@@ -93,10 +93,10 @@ impl ThriftBackend {
                 format! {
                     r#"protocol.write_map({key_ttype}, {val_ttype}, &{ident}, |protocol, key| {{
                         {write_key}
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     }}, |protocol, val| {{
                         {write_val}
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     }})?;"#
                 }
                 .into()
@@ -141,7 +141,7 @@ impl ThriftBackend {
                 format! {
                     r#"protocol.write_list_field({id}, {el_ttype}, &{ident}, |protocol, val| {{
                         {write_el}
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     }})?;"#
                 }
                 .into()
@@ -153,7 +153,7 @@ impl ThriftBackend {
                 format! {
                     r#"protocol.write_set_field({id}, {el_ttype}, &{ident}, |protocol, val| {{
                         {write_el}
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     }})?;"#
                 }
                 .into()
@@ -167,10 +167,10 @@ impl ThriftBackend {
                 format! {
                     r#"protocol.write_map_field({id}, {key_ttype}, {val_ttype}, &{ident}, |protocol, key| {{
                         {write_key}
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     }}, |protocol, val| {{
                         {write_val}
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     }})?;"#
                 }
                 .into()

--- a/pilota-build/test_data/must_gen_items.rs
+++ b/pilota-build/test_data/must_gen_items.rs
@@ -21,7 +21,7 @@ pub mod must_gen_items {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -35,7 +35,7 @@ pub mod must_gen_items {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -65,12 +65,12 @@ pub mod must_gen_items {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { a };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -89,7 +89,7 @@ pub mod must_gen_items {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -120,12 +120,12 @@ pub mod must_gen_items {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { a };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -34,7 +34,7 @@ pub mod serde {
                 protocol.write_i32_field(2, *&self.b)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -49,7 +49,7 @@ pub mod serde {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -84,25 +84,25 @@ pub mod serde {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field a is required".to_string(),
                     ));
                 };
                 let Some(b) = b else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field b is required".to_string(),
                     ));
                 };
 
                 let data = Self { a, b };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -122,7 +122,7 @@ pub mod serde {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -159,25 +159,29 @@ pub mod serde {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(a) = a else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field a is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field a is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(b) = b else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field b is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field b is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { a, b };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -237,7 +241,7 @@ pub mod serde {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(self.inner())?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -246,12 +250,14 @@ pub mod serde {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 let value = protocol.read_i32()?;
-                Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                    ::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        format!("invalid enum value for C, value: {}", value),
-                    )
-                })?)
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for C, value: {}", value),
+                        )
+                    },
+                )?)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -266,12 +272,14 @@ pub mod serde {
             > {
                 ::std::boxed::Box::pin(async move {
                     let value = protocol.read_i32().await?;
-                    Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                        ::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            format!("invalid enum value for C, value: {}", value),
-                        )
-                    })?)
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for C, value: {}", value),
+                            )
+                        },
+                    )?)
                 })
             }
 
@@ -317,7 +325,7 @@ pub mod serde {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(*(&**self))?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -325,7 +333,7 @@ pub mod serde {
             ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
-                Ok(B(protocol.read_i32()?))
+                ::std::result::Result::Ok(B(protocol.read_i32()?))
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -338,7 +346,9 @@ pub mod serde {
                         + 'a,
                 >,
             > {
-                ::std::boxed::Box::pin(async move { Ok(B(protocol.read_i32().await?)) })
+                ::std::boxed::Box::pin(async move {
+                    ::std::result::Result::Ok(B(protocol.read_i32().await?))
+                })
             }
 
             fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -165,7 +165,7 @@ pub mod oneof {
                     },
                     _ => unreachable!(concat!("invalid ", stringify!(Test), " tag: {}"), tag),
                 };
-                Ok(())
+                ::core::result::Result::Ok(())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
@@ -236,7 +236,7 @@ pub mod oneof {
                     },
                     _ => unreachable!(concat!("invalid ", stringify!(Type), " tag: {}"), tag),
                 };
-                Ok(())
+                ::core::result::Result::Ok(())
             }
         }
     }

--- a/pilota-build/test_data/thrift/binary_bytes.rs
+++ b/pilota-build/test_data/thrift/binary_bytes.rs
@@ -22,7 +22,7 @@ pub mod binary_bytes {
                 protocol.write_bytes_vec_field(2, &self.vec)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -37,7 +37,7 @@ pub mod binary_bytes {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -74,25 +74,25 @@ pub mod binary_bytes {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(bytes) = bytes else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field bytes is required".to_string(),
                     ));
                 };
                 let Some(vec) = vec else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field vec is required".to_string(),
                     ));
                 };
 
                 let data = Self { bytes, vec };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -112,7 +112,7 @@ pub mod binary_bytes {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -150,25 +150,29 @@ pub mod binary_bytes {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(bytes) = bytes else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field bytes is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field bytes is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(vec) = vec else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field vec is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field vec is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { bytes, vec };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -45,7 +45,7 @@ pub mod const_val {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(self.inner())?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -54,12 +54,14 @@ pub mod const_val {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 let value = protocol.read_i32()?;
-                Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                    ::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        format!("invalid enum value for Index, value: {}", value),
-                    )
-                })?)
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Index, value: {}", value),
+                        )
+                    },
+                )?)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -74,12 +76,14 @@ pub mod const_val {
             > {
                 ::std::boxed::Box::pin(async move {
                     let value = protocol.read_i32().await?;
-                    Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                        ::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            format!("invalid enum value for Index, value: {}", value),
-                        )
-                    })?)
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Index, value: {}", value),
+                            )
+                        },
+                    )?)
                 })
             }
 

--- a/pilota-build/test_data/thrift/decode_error.rs
+++ b/pilota-build/test_data/thrift/decode_error.rs
@@ -19,7 +19,7 @@ pub mod decode_error {
                 protocol.write_struct_field(1, &self.b, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -33,7 +33,7 @@ pub mod decode_error {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -65,19 +65,19 @@ pub mod decode_error {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(b) = b else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field b is required".to_string(),
                     ));
                 };
 
                 let data = Self { b };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -96,7 +96,7 @@ pub mod decode_error {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -131,19 +131,21 @@ pub mod decode_error {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(b) = b else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field b is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field b is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { b };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -173,7 +175,7 @@ pub mod decode_error {
                 protocol.write_faststr_field(3, (&self.a).clone())?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -187,7 +189,7 @@ pub mod decode_error {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -219,19 +221,19 @@ pub mod decode_error {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field a is required".to_string(),
                     ));
                 };
 
                 let data = Self { a };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -250,7 +252,7 @@ pub mod decode_error {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -282,19 +284,21 @@ pub mod decode_error {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(a) = a else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field a is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field a is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { a };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -324,7 +328,7 @@ pub mod decode_error {
                 protocol.write_struct_field(2, &self.c, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -338,7 +342,7 @@ pub mod decode_error {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -370,19 +374,19 @@ pub mod decode_error {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(c) = c else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field c is required".to_string(),
                     ));
                 };
 
                 let data = Self { c };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -401,7 +405,7 @@ pub mod decode_error {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -436,19 +440,21 @@ pub mod decode_error {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(c) = c else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field c is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field c is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { c };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -45,7 +45,7 @@ pub mod default_value {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(self.inner())?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -54,12 +54,14 @@ pub mod default_value {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 let value = protocol.read_i32()?;
-                Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                    ::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        format!("invalid enum value for B, value: {}", value),
-                    )
-                })?)
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for B, value: {}", value),
+                        )
+                    },
+                )?)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -74,12 +76,14 @@ pub mod default_value {
             > {
                 ::std::boxed::Box::pin(async move {
                     let value = protocol.read_i32().await?;
-                    Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                        ::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            format!("invalid enum value for B, value: {}", value),
-                        )
-                    })?)
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for B, value: {}", value),
+                            )
+                        },
+                    )?)
                 })
             }
 
@@ -121,7 +125,7 @@ pub mod default_value {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -136,7 +140,7 @@ pub mod default_value {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -171,12 +175,12 @@ pub mod default_value {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { off, test_byte };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -196,7 +200,7 @@ pub mod default_value {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -233,12 +237,12 @@ pub mod default_value {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { off, test_byte };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -336,11 +340,11 @@ pub mod default_value {
                         &value,
                         |protocol, key| {
                             protocol.write_faststr((key).clone())?;
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         },
                         |protocol, val| {
                             protocol.write_faststr((val).clone())?;
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         },
                     )?;
                 }
@@ -355,7 +359,7 @@ pub mod default_value {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -378,7 +382,7 @@ pub mod default_value {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -456,7 +460,7 @@ pub mod default_value {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
@@ -484,7 +488,7 @@ pub mod default_value {
                     test_double2,
                     alias_str,
                 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -512,7 +516,7 @@ pub mod default_value {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -611,7 +615,7 @@ pub mod default_value {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
@@ -639,7 +643,7 @@ pub mod default_value {
                         test_double2,
                         alias_str,
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -45,7 +45,7 @@ pub mod enum_test {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(self.inner())?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -54,12 +54,14 @@ pub mod enum_test {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 let value = protocol.read_i32()?;
-                Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                    ::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        format!("invalid enum value for Index, value: {}", value),
-                    )
-                })?)
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Index, value: {}", value),
+                        )
+                    },
+                )?)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -74,12 +76,182 @@ pub mod enum_test {
             > {
                 ::std::boxed::Box::pin(async move {
                     let value = protocol.read_i32().await?;
-                    Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Index, value: {}", value),
+                            )
+                        },
+                    )?)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                protocol.i32_len(self.inner())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Ok(i32);
+
+        impl Ok {
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
+
+            pub fn to_string(&self) -> ::std::string::String {
+                match self {
+                    Self(val) => val.to_string(),
+                }
+            }
+        }
+
+        impl ::std::convert::From<i32> for Ok {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
+
+        impl ::std::convert::From<Ok> for i32 {
+            fn from(value: Ok) -> i32 {
+                value.0
+            }
+        }
+
+        impl ::pilota::thrift::Message for Ok {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                protocol.write_i32(self.inner())?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{thrift::TLengthProtocolExt, Buf};
+                let value = protocol.read_i32()?;
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
                         ::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            format!("invalid enum value for Index, value: {}", value),
+                            format!("invalid enum value for Ok, value: {}", value),
                         )
-                    })?)
+                    },
+                )?)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let value = protocol.read_i32().await?;
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Ok, value: {}", value),
+                            )
+                        },
+                    )?)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                protocol.i32_len(self.inner())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Err(i32);
+
+        impl Err {
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
+
+            pub fn to_string(&self) -> ::std::string::String {
+                match self {
+                    Self(val) => val.to_string(),
+                }
+            }
+        }
+
+        impl ::std::convert::From<i32> for Err {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
+
+        impl ::std::convert::From<Err> for i32 {
+            fn from(value: Err) -> i32 {
+                value.0
+            }
+        }
+
+        impl ::pilota::thrift::Message for Err {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                protocol.write_i32(self.inner())?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{thrift::TLengthProtocolExt, Buf};
+                let value = protocol.read_i32()?;
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Err, value: {}", value),
+                        )
+                    },
+                )?)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let value = protocol.read_i32().await?;
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Err, value: {}", value),
+                            )
+                        },
+                    )?)
                 })
             }
 

--- a/pilota-build/test_data/thrift/enum_test.thrift
+++ b/pilota-build/test_data/thrift/enum_test.thrift
@@ -2,3 +2,11 @@ enum Index {
     A = 0x01,
     B = 0x10,
 }
+
+enum Err {
+
+}
+
+enum Ok {
+    
+}

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -35,7 +35,7 @@ pub mod multi {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -50,7 +50,7 @@ pub mod multi {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -85,12 +85,12 @@ pub mod multi {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { off, test_byte };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -110,7 +110,7 @@ pub mod multi {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -147,12 +147,12 @@ pub mod multi {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { off, test_byte };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -216,7 +216,7 @@ pub mod multi {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(self.inner())?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -225,12 +225,14 @@ pub mod multi {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 let value = protocol.read_i32()?;
-                Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                    ::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        format!("invalid enum value for B, value: {}", value),
-                    )
-                })?)
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for B, value: {}", value),
+                        )
+                    },
+                )?)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -245,12 +247,14 @@ pub mod multi {
             > {
                 ::std::boxed::Box::pin(async move {
                     let value = protocol.read_i32().await?;
-                    Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                        ::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            format!("invalid enum value for B, value: {}", value),
-                        )
-                    })?)
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for B, value: {}", value),
+                            )
+                        },
+                    )?)
                 })
             }
 
@@ -338,11 +342,11 @@ pub mod multi {
                         &value,
                         |protocol, key| {
                             protocol.write_faststr((key).clone())?;
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         },
                         |protocol, val| {
                             protocol.write_faststr((val).clone())?;
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         },
                     )?;
                 }
@@ -357,7 +361,7 @@ pub mod multi {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -380,7 +384,7 @@ pub mod multi {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -458,7 +462,7 @@ pub mod multi {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
@@ -486,7 +490,7 @@ pub mod multi {
                     test_double2,
                     alias_str,
                 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -514,7 +518,7 @@ pub mod multi {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -613,7 +617,7 @@ pub mod multi {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
@@ -641,7 +645,7 @@ pub mod multi {
                         test_double2,
                         alias_str,
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -726,7 +730,7 @@ pub mod multi {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -740,7 +744,7 @@ pub mod multi {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -772,7 +776,7 @@ pub mod multi {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
@@ -784,7 +788,7 @@ pub mod multi {
                 }
 
                 let data = Self { c };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -803,7 +807,7 @@ pub mod multi {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                     loop {
 
 
@@ -835,7 +839,7 @@ pub mod multi {
                 if let Some(field_id) = __pilota_decoding_field_id {
                     err.prepend_msg(&format!("decode struct `A` field(#{}) failed, caused by: ", field_id));
                 }
-                return Err(err);
+                return ::std::result::Result::Err(err);
             };
                     protocol.read_struct_end().await?;
 
@@ -847,7 +851,7 @@ pub mod multi {
                     }
 
                     let data = Self { c };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -887,7 +891,7 @@ pub mod multi {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -902,7 +906,7 @@ pub mod multi {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -939,12 +943,12 @@ pub mod multi {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { a, c };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -964,7 +968,7 @@ pub mod multi {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                     loop {
 
 
@@ -999,12 +1003,12 @@ pub mod multi {
                 if let Some(field_id) = __pilota_decoding_field_id {
                     err.prepend_msg(&format!("decode struct `B` field(#{}) failed, caused by: ", field_id));
                 }
-                return Err(err);
+                return ::std::result::Result::Err(err);
             };
                     protocol.read_struct_end().await?;
 
                     let data = Self { a, c };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1048,13 +1052,13 @@ pub mod multi {
                         &value,
                         |protocol, val| {
                             protocol.write_faststr((val).clone())?;
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         },
                     )?;
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1068,7 +1072,7 @@ pub mod multi {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1107,12 +1111,12 @@ pub mod multi {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { c };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1131,7 +1135,7 @@ pub mod multi {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1171,12 +1175,12 @@ pub mod multi {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { c };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1220,7 +1224,7 @@ pub mod multi {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1235,7 +1239,7 @@ pub mod multi {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1276,12 +1280,12 @@ pub mod multi {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { a, a_b };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1301,7 +1305,7 @@ pub mod multi {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1345,12 +1349,12 @@ pub mod multi {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { a, a_b };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1389,7 +1393,7 @@ pub mod multi {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1403,7 +1407,7 @@ pub mod multi {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1437,12 +1441,12 @@ pub mod multi {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { b_a };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1461,7 +1465,7 @@ pub mod multi {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1496,12 +1500,12 @@ pub mod multi {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { b_a };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -21,7 +21,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -35,7 +35,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -65,12 +65,12 @@ pub mod normal {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { a };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -89,7 +89,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -120,12 +120,12 @@ pub mod normal {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { a };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -159,7 +159,7 @@ pub mod normal {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -171,7 +171,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -198,12 +198,12 @@ pub mod normal {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -220,7 +220,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -243,12 +243,12 @@ pub mod normal {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTest123ArgsSend` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -293,11 +293,11 @@ pub mod normal {
                     &&self.msg_map,
                     |protocol, key| {
                         protocol.write_struct(key)?;
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     },
                     |protocol, val| {
                         protocol.write_struct(val)?;
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     },
                 )?;
                 protocol.write_list_field(
@@ -306,7 +306,7 @@ pub mod normal {
                     &&self.sub_msgs,
                     |protocol, val| {
                         protocol.write_struct(val)?;
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     },
                 )?;
                 if let Some(value) = self.msg_set.as_ref() {
@@ -316,7 +316,7 @@ pub mod normal {
                         &value,
                         |protocol, val| {
                             protocol.write_struct(val)?;
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         },
                     )?;
                 }
@@ -326,7 +326,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -345,7 +345,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -428,30 +428,30 @@ pub mod normal {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(msg) = msg else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field msg is required".to_string(),
                     ));
                 };
                 let Some(msg_map) = msg_map else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field msg_map is required".to_string(),
                     ));
                 };
                 let Some(sub_msgs) = sub_msgs else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field sub_msgs is required".to_string(),
                     ));
                 };
                 let Some(flag_msg) = flag_msg else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field flag_msg is required".to_string(),
                     ));
@@ -465,7 +465,7 @@ pub mod normal {
                     flag_msg,
                     mock_cost,
                 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -489,7 +489,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                     loop {
 
 
@@ -558,33 +558,41 @@ pub mod normal {
                 if let Some(field_id) = __pilota_decoding_field_id {
                     err.prepend_msg(&format!("decode struct `ObjReq` field(#{}) failed, caused by: ", field_id));
                 }
-                return Err(err);
+                return ::std::result::Result::Err(err);
             };
                     protocol.read_struct_end().await?;
 
                     let Some(msg) = msg else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field msg is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field msg is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(msg_map) = msg_map else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field msg_map is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field msg_map is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(sub_msgs) = sub_msgs else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field sub_msgs is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field sub_msgs is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(flag_msg) = flag_msg else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field flag_msg is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field flag_msg is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self {
@@ -595,7 +603,7 @@ pub mod normal {
                         flag_msg,
                         mock_cost,
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -654,7 +662,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -668,7 +676,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -700,12 +708,12 @@ pub mod normal {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { a };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -724,7 +732,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -759,12 +767,12 @@ pub mod normal {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { a };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -799,7 +807,7 @@ pub mod normal {
                 protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -813,7 +821,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -842,19 +850,19 @@ pub mod normal {
                     if let Some(field_id) = __pilota_decoding_field_id {
                         err.prepend_msg(&format!("decode struct `TestTestExceptionArgsSend` field(#{}) failed, caused by: ", field_id));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field req is required".to_string(),
                     ));
                 };
 
                 let data = Self { req };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -873,7 +881,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -907,19 +915,21 @@ pub mod normal {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTestExceptionArgsSend` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(req) = req else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field req is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { req };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -950,7 +960,7 @@ pub mod normal {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -962,7 +972,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -989,12 +999,12 @@ pub mod normal {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1011,7 +1021,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1034,12 +1044,12 @@ pub mod normal {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTest123ArgsRecv` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1075,7 +1085,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1102,9 +1112,9 @@ pub mod normal {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Ok(TestTest123ResultSend::Ok(()))
+                    ::std::result::Result::Ok(TestTest123ResultSend::Ok(()))
                 }
             }
 
@@ -1136,9 +1146,9 @@ pub mod normal {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Ok(TestTest123ResultSend::Ok(()))
+                        ::std::result::Result::Ok(TestTest123ResultSend::Ok(()))
                     }
                 })
             }
@@ -1175,7 +1185,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1189,7 +1199,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1221,12 +1231,12 @@ pub mod normal {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { message };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1245,7 +1255,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1277,12 +1287,12 @@ pub mod normal {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { message };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1318,7 +1328,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1332,7 +1342,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1364,12 +1374,12 @@ pub mod normal {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { value };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1388,7 +1398,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1420,12 +1430,12 @@ pub mod normal {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { value };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1461,7 +1471,7 @@ pub mod normal {
                 protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1475,7 +1485,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1504,19 +1514,19 @@ pub mod normal {
                     if let Some(field_id) = __pilota_decoding_field_id {
                         err.prepend_msg(&format!("decode struct `TestTestExceptionArgsRecv` field(#{}) failed, caused by: ", field_id));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field req is required".to_string(),
                     ));
                 };
 
                 let data = Self { req };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1535,7 +1545,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1569,19 +1579,21 @@ pub mod normal {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTestExceptionArgsRecv` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(req) = req else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field req is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { req };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1620,7 +1632,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1645,10 +1657,12 @@ pub mod normal {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionException::StException(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -1659,9 +1673,9 @@ pub mod normal {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -1699,10 +1713,10 @@ pub mod normal {
                                     ret =
                                         Some(TestTestExceptionException::StException(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -1713,9 +1727,9 @@ pub mod normal {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -1766,7 +1780,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1791,10 +1805,12 @@ pub mod normal {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionResultSend::Ok(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         Some(1) => {
@@ -1803,10 +1819,12 @@ pub mod normal {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionResultSend::StException(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -1817,9 +1835,9 @@ pub mod normal {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -1856,10 +1874,10 @@ pub mod normal {
 
                                     ret = Some(TestTestExceptionResultSend::Ok(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             Some(1) => {
@@ -1873,10 +1891,10 @@ pub mod normal {
                                     ret =
                                         Some(TestTestExceptionResultSend::StException(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -1887,9 +1905,9 @@ pub mod normal {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -1943,7 +1961,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1968,10 +1986,12 @@ pub mod normal {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionResultRecv::Ok(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         Some(1) => {
@@ -1980,10 +2000,12 @@ pub mod normal {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionResultRecv::StException(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -1994,9 +2016,9 @@ pub mod normal {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -2033,10 +2055,10 @@ pub mod normal {
 
                                     ret = Some(TestTestExceptionResultRecv::Ok(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             Some(1) => {
@@ -2050,10 +2072,10 @@ pub mod normal {
                                     ret =
                                         Some(TestTestExceptionResultRecv::StException(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -2064,9 +2086,9 @@ pub mod normal {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -2113,7 +2135,7 @@ pub mod normal {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2140,9 +2162,9 @@ pub mod normal {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Ok(TestTest123ResultRecv::Ok(()))
+                    ::std::result::Result::Ok(TestTest123ResultRecv::Ok(()))
                 }
             }
 
@@ -2174,9 +2196,9 @@ pub mod normal {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Ok(TestTest123ResultRecv::Ok(()))
+                        ::std::result::Result::Ok(TestTest123ResultRecv::Ok(()))
                     }
                 })
             }
@@ -2223,13 +2245,13 @@ pub mod normal {
                         &value,
                         |protocol, val| {
                             protocol.write_struct(val)?;
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         },
                     )?;
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2245,7 +2267,7 @@ pub mod normal {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -2295,7 +2317,7 @@ pub mod normal {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
@@ -2304,7 +2326,7 @@ pub mod normal {
                     value,
                     sub_messages,
                 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -2325,7 +2347,7 @@ pub mod normal {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                     loop {
 
 
@@ -2371,7 +2393,7 @@ pub mod normal {
                 if let Some(field_id) = __pilota_decoding_field_id {
                     err.prepend_msg(&format!("decode struct `Message` field(#{}) failed, caused by: ", field_id));
                 }
-                return Err(err);
+                return ::std::result::Result::Err(err);
             };
                     protocol.read_struct_end().await?;
 
@@ -2380,7 +2402,7 @@ pub mod normal {
                         value,
                         sub_messages,
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/path_keyword.rs
+++ b/pilota-build/test_data/thrift/path_keyword.rs
@@ -22,7 +22,7 @@ pub mod path_keyword {
                 protocol.write_bytes_vec_field(2, &self.vec)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -37,7 +37,7 @@ pub mod path_keyword {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -74,25 +74,25 @@ pub mod path_keyword {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(bytes) = bytes else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field bytes is required".to_string(),
                     ));
                 };
                 let Some(vec) = vec else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field vec is required".to_string(),
                     ));
                 };
 
                 let data = Self { bytes, vec };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -112,7 +112,7 @@ pub mod path_keyword {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -150,25 +150,29 @@ pub mod path_keyword {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(bytes) = bytes else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field bytes is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field bytes is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(vec) = vec else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field vec is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field vec is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { bytes, vec };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -19,7 +19,7 @@ pub mod pilota_name {
                 protocol.write_faststr_field(1, (&self.id).clone())?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -33,7 +33,7 @@ pub mod pilota_name {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -65,19 +65,19 @@ pub mod pilota_name {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field id is required".to_string(),
                     ));
                 };
 
                 let data = Self { id };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -96,7 +96,7 @@ pub mod pilota_name {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -128,19 +128,21 @@ pub mod pilota_name {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(id) = id else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field id is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field id is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { id };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -172,7 +174,7 @@ pub mod pilota_name {
                 protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -186,7 +188,7 @@ pub mod pilota_name {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -215,19 +217,19 @@ pub mod pilota_name {
                     if let Some(field_id) = __pilota_decoding_field_id {
                         err.prepend_msg(&format!("decode struct `TestServiceTestArgsRecv` field(#{}) failed, caused by: ", field_id));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field req is required".to_string(),
                     ));
                 };
 
                 let data = Self { req };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -246,7 +248,7 @@ pub mod pilota_name {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -280,19 +282,21 @@ pub mod pilota_name {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestServiceTestArgsRecv` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(req) = req else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field req is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { req };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -331,7 +335,7 @@ pub mod pilota_name {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -356,10 +360,12 @@ pub mod pilota_name {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestServiceTestResultSend::Ok(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -370,9 +376,9 @@ pub mod pilota_name {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -409,10 +415,10 @@ pub mod pilota_name {
 
                                     ret = Some(TestServiceTestResultSend::Ok(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -423,9 +429,9 @@ pub mod pilota_name {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -466,7 +472,7 @@ pub mod pilota_name {
                 protocol.write_faststr_field(2, (&self.hello).clone())?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -481,7 +487,7 @@ pub mod pilota_name {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -518,25 +524,25 @@ pub mod pilota_name {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field id is required".to_string(),
                     ));
                 };
                 let Some(hello) = hello else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field hello is required".to_string(),
                     ));
                 };
 
                 let data = Self { id, hello };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -556,7 +562,7 @@ pub mod pilota_name {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -594,25 +600,29 @@ pub mod pilota_name {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(id) = id else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field id is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field id is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(hello) = hello else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field hello is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field hello is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { id, hello };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -645,7 +655,7 @@ pub mod pilota_name {
                 protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -659,7 +669,7 @@ pub mod pilota_name {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -688,19 +698,19 @@ pub mod pilota_name {
                     if let Some(field_id) = __pilota_decoding_field_id {
                         err.prepend_msg(&format!("decode struct `TestServiceTestArgsSend` field(#{}) failed, caused by: ", field_id));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field req is required".to_string(),
                     ));
                 };
 
                 let data = Self { req };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -719,7 +729,7 @@ pub mod pilota_name {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -753,19 +763,21 @@ pub mod pilota_name {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestServiceTestArgsSend` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(req) = req else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field req is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { req };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -806,7 +818,7 @@ pub mod pilota_name {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -831,10 +843,12 @@ pub mod pilota_name {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestServiceTestResultRecv::Ok(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -845,9 +859,9 @@ pub mod pilota_name {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -884,10 +898,10 @@ pub mod pilota_name {
 
                                     ret = Some(TestServiceTestResultRecv::Ok(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -898,9 +912,9 @@ pub mod pilota_name {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -964,7 +978,7 @@ pub mod pilota_name {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(self.inner())?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -973,12 +987,14 @@ pub mod pilota_name {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 let value = protocol.read_i32()?;
-                Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                    ::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        format!("invalid enum value for Index, value: {}", value),
-                    )
-                })?)
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Index, value: {}", value),
+                        )
+                    },
+                )?)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -993,12 +1009,14 @@ pub mod pilota_name {
             > {
                 ::std::boxed::Box::pin(async move {
                     let value = protocol.read_i32().await?;
-                    Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                        ::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            format!("invalid enum value for Index, value: {}", value),
-                        )
-                    })?)
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Index, value: {}", value),
+                            )
+                        },
+                    )?)
                 })
             }
 

--- a/pilota-build/test_data/thrift/recursive_type.rs
+++ b/pilota-build/test_data/thrift/recursive_type.rs
@@ -26,7 +26,7 @@ pub mod recursive_type {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -41,7 +41,7 @@ pub mod recursive_type {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -82,12 +82,12 @@ pub mod recursive_type {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { a, a_b };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -107,7 +107,7 @@ pub mod recursive_type {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -151,12 +151,12 @@ pub mod recursive_type {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { a, a_b };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -197,13 +197,13 @@ pub mod recursive_type {
                         &value,
                         |protocol, val| {
                             protocol.write_faststr((val).clone())?;
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         },
                     )?;
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -217,7 +217,7 @@ pub mod recursive_type {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -256,12 +256,12 @@ pub mod recursive_type {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { c };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -280,7 +280,7 @@ pub mod recursive_type {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -320,12 +320,12 @@ pub mod recursive_type {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { c };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -364,7 +364,7 @@ pub mod recursive_type {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -378,7 +378,7 @@ pub mod recursive_type {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -412,12 +412,12 @@ pub mod recursive_type {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { b_a };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -436,7 +436,7 @@ pub mod recursive_type {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -471,12 +471,12 @@ pub mod recursive_type {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { b_a };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -45,7 +45,7 @@ pub mod self_kw {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(self.inner())?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -54,12 +54,14 @@ pub mod self_kw {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 let value = protocol.read_i32()?;
-                Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                    ::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        format!("invalid enum value for Index, value: {}", value),
-                    )
-                })?)
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Index, value: {}", value),
+                        )
+                    },
+                )?)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -74,12 +76,14 @@ pub mod self_kw {
             > {
                 ::std::boxed::Box::pin(async move {
                     let value = protocol.read_i32().await?;
-                    Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                        ::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            format!("invalid enum value for Index, value: {}", value),
-                        )
-                    })?)
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Index, value: {}", value),
+                            )
+                        },
+                    )?)
                 })
             }
 
@@ -109,7 +113,7 @@ pub mod self_kw {
                 protocol.write_faststr_field(2, (&self.self_).clone())?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -124,7 +128,7 @@ pub mod self_kw {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -161,25 +165,25 @@ pub mod self_kw {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(r#type) = r#type else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field r#type is required".to_string(),
                     ));
                 };
                 let Some(self_) = self_ else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field self_ is required".to_string(),
                     ));
                 };
 
                 let data = Self { r#type, self_ };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -199,7 +203,7 @@ pub mod self_kw {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -237,25 +241,29 @@ pub mod self_kw {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(r#type) = r#type else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field r#type is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field r#type is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(self_) = self_ else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field self_ is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field self_ is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { r#type, self_ };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/string.rs
+++ b/pilota-build/test_data/thrift/string.rs
@@ -22,7 +22,7 @@ pub mod string {
                 protocol.write_string_field(2, &self.string)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -37,7 +37,7 @@ pub mod string {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -74,25 +74,25 @@ pub mod string {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(faststr) = faststr else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field faststr is required".to_string(),
                     ));
                 };
                 let Some(string) = string else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field string is required".to_string(),
                     ));
                 };
 
                 let data = Self { faststr, string };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -112,7 +112,7 @@ pub mod string {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -150,25 +150,29 @@ pub mod string {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(faststr) = faststr else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field faststr is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field faststr is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(string) = string else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field string is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field string is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { faststr, string };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/union.rs
+++ b/pilota-build/test_data/thrift/union.rs
@@ -31,7 +31,7 @@ pub mod union {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -56,10 +56,12 @@ pub mod union {
                                 protocol.faststr_len(&field_ident);
                                 ret = Some(Union::A(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         Some(2) => {
@@ -68,10 +70,12 @@ pub mod union {
                                 protocol.bytes_len(&field_ident);
                                 ret = Some(Union::B(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -82,9 +86,9 @@ pub mod union {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -117,10 +121,10 @@ pub mod union {
 
                                     ret = Some(Union::A(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             Some(2) => {
@@ -129,10 +133,10 @@ pub mod union {
 
                                     ret = Some(Union::B(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -143,9 +147,9 @@ pub mod union {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -182,7 +186,7 @@ pub mod union {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -209,9 +213,9 @@ pub mod union {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -246,9 +250,9 @@ pub mod union {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -286,7 +290,7 @@ pub mod union {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -300,7 +304,7 @@ pub mod union {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -332,12 +336,12 @@ pub mod union {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { u };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -356,7 +360,7 @@ pub mod union {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -393,12 +397,12 @@ pub mod union {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self { u };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -25,7 +25,7 @@ pub mod void {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -52,9 +52,9 @@ pub mod void {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Ok(TestTest123ResultRecv::Ok(()))
+                    ::std::result::Result::Ok(TestTest123ResultRecv::Ok(()))
                 }
             }
 
@@ -86,9 +86,9 @@ pub mod void {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Ok(TestTest123ResultRecv::Ok(()))
+                        ::std::result::Result::Ok(TestTest123ResultRecv::Ok(()))
                     }
                 })
             }
@@ -121,7 +121,7 @@ pub mod void {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -133,7 +133,7 @@ pub mod void {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -160,12 +160,12 @@ pub mod void {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -182,7 +182,7 @@ pub mod void {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -205,12 +205,12 @@ pub mod void {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTest123ArgsSend` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -240,7 +240,7 @@ pub mod void {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -252,7 +252,7 @@ pub mod void {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -279,12 +279,12 @@ pub mod void {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -301,7 +301,7 @@ pub mod void {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -324,12 +324,12 @@ pub mod void {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTest123ArgsRecv` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -365,7 +365,7 @@ pub mod void {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -392,9 +392,9 @@ pub mod void {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Ok(TestTest123ResultSend::Ok(()))
+                    ::std::result::Result::Ok(TestTest123ResultSend::Ok(()))
                 }
             }
 
@@ -426,9 +426,9 @@ pub mod void {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Ok(TestTest123ResultSend::Ok(()))
+                        ::std::result::Result::Ok(TestTest123ResultSend::Ok(()))
                     }
                 })
             }

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -17,7 +17,7 @@ pub mod wrapper_arc {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -29,7 +29,7 @@ pub mod wrapper_arc {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -56,12 +56,12 @@ pub mod wrapper_arc {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -78,7 +78,7 @@ pub mod wrapper_arc {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -104,12 +104,12 @@ pub mod wrapper_arc {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -147,7 +147,7 @@ pub mod wrapper_arc {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -172,10 +172,12 @@ pub mod wrapper_arc {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestServiceTestResultRecv::Ok(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -186,9 +188,9 @@ pub mod wrapper_arc {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -223,10 +225,10 @@ pub mod wrapper_arc {
 
                                     ret = Some(TestServiceTestResultRecv::Ok(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -237,9 +239,9 @@ pub mod wrapper_arc {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -279,7 +281,7 @@ pub mod wrapper_arc {
                 protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -293,7 +295,7 @@ pub mod wrapper_arc {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -322,19 +324,19 @@ pub mod wrapper_arc {
                     if let Some(field_id) = __pilota_decoding_field_id {
                         err.prepend_msg(&format!("decode struct `TestServiceTestArgsRecv` field(#{}) failed, caused by: ", field_id));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field req is required".to_string(),
                     ));
                 };
 
                 let data = Self { req };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -353,7 +355,7 @@ pub mod wrapper_arc {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -385,19 +387,21 @@ pub mod wrapper_arc {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestServiceTestArgsRecv` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(req) = req else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field req is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { req };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -436,7 +440,7 @@ pub mod wrapper_arc {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -463,10 +467,12 @@ pub mod wrapper_arc {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestServiceTestResultSend::Ok(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -477,9 +483,9 @@ pub mod wrapper_arc {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -515,10 +521,10 @@ pub mod wrapper_arc {
 
                                     ret = Some(TestServiceTestResultSend::Ok(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -529,9 +535,9 @@ pub mod wrapper_arc {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -581,10 +587,10 @@ pub mod wrapper_arc {
                             &val,
                             |protocol, val| {
                                 protocol.write_struct(val)?;
-                                Ok(())
+                                ::std::result::Result::Ok(())
                             },
                         )?;
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     },
                 )?;
                 protocol.write_map_field(
@@ -594,7 +600,7 @@ pub mod wrapper_arc {
                     &&self.name3,
                     |protocol, key| {
                         protocol.write_i32(*key)?;
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     },
                     |protocol, val| {
                         protocol.write_list(
@@ -602,15 +608,15 @@ pub mod wrapper_arc {
                             &val,
                             |protocol, val| {
                                 protocol.write_struct(val)?;
-                                Ok(())
+                                ::std::result::Result::Ok(())
                             },
                         )?;
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     },
                 )?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -626,7 +632,7 @@ pub mod wrapper_arc {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -714,31 +720,31 @@ pub mod wrapper_arc {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(id) = id else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field id is required".to_string(),
                     ));
                 };
                 let Some(name2) = name2 else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field name2 is required".to_string(),
                     ));
                 };
                 let Some(name3) = name3 else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field name3 is required".to_string(),
                     ));
                 };
 
                 let data = Self { id, name2, name3 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -759,7 +765,7 @@ pub mod wrapper_arc {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                     loop {
 
 
@@ -829,31 +835,37 @@ pub mod wrapper_arc {
                 if let Some(field_id) = __pilota_decoding_field_id {
                     err.prepend_msg(&format!("decode struct `TEST` field(#{}) failed, caused by: ", field_id));
                 }
-                return Err(err);
+                return ::std::result::Result::Err(err);
             };
                     protocol.read_struct_end().await?;
 
                     let Some(id) = id else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field id is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field id is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(name2) = name2 else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field name2 is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field name2 is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(name3) = name3 else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field name3 is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field name3 is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { id, name2, name3 };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -911,7 +923,7 @@ pub mod wrapper_arc {
                 protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -925,7 +937,7 @@ pub mod wrapper_arc {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -956,19 +968,19 @@ pub mod wrapper_arc {
                     if let Some(field_id) = __pilota_decoding_field_id {
                         err.prepend_msg(&format!("decode struct `TestServiceTestArgsSend` field(#{}) failed, caused by: ", field_id));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field req is required".to_string(),
                     ));
                 };
 
                 let data = Self { req };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -987,7 +999,7 @@ pub mod wrapper_arc {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1019,19 +1031,21 @@ pub mod wrapper_arc {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestServiceTestArgsSend` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(req) = req else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field req is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { req };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -36,7 +36,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -51,7 +51,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -88,12 +88,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { a, _unknown_fields };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -112,7 +112,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -143,7 +143,7 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
@@ -151,7 +151,7 @@ pub mod unknown_fields {
                         a,
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -202,7 +202,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -217,7 +217,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -256,12 +256,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { a, _unknown_fields };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -280,7 +280,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -315,7 +315,7 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
@@ -323,7 +323,7 @@ pub mod unknown_fields {
                         a,
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -378,7 +378,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -394,7 +394,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -438,18 +438,18 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(bytes) = bytes else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field bytes is required".to_string(),
                     ));
                 };
                 let Some(vec) = vec else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field vec is required".to_string(),
                     ));
@@ -460,7 +460,7 @@ pub mod unknown_fields {
                     vec,
                     _unknown_fields,
                 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -480,7 +480,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -518,21 +518,25 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(bytes) = bytes else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field bytes is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field bytes is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(vec) = vec else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field vec is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field vec is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self {
@@ -540,7 +544,7 @@ pub mod unknown_fields {
                         vec,
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -587,7 +591,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -602,7 +606,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -639,12 +643,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(td) = td else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field td is required".to_string(),
                     ));
@@ -654,7 +658,7 @@ pub mod unknown_fields {
                     td,
                     _unknown_fields,
                 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -673,7 +677,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -707,22 +711,24 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(td) = td else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field td is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field td is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self {
                         td,
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -765,7 +771,7 @@ pub mod unknown_fields {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -777,7 +783,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -804,12 +810,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -826,7 +832,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -849,12 +855,12 @@ pub mod unknown_fields {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTest123ArgsSend` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -910,10 +916,10 @@ pub mod unknown_fields {
                             &val,
                             |protocol, val| {
                                 protocol.write_faststr((val).clone())?;
-                                Ok(())
+                                ::std::result::Result::Ok(())
                             },
                         )?;
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     },
                 )?;
                 for bytes in self._unknown_fields.list.iter() {
@@ -921,7 +927,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -938,7 +944,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -1007,24 +1013,24 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(faststr) = faststr else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field faststr is required".to_string(),
                     ));
                 };
                 let Some(string) = string else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field string is required".to_string(),
                     ));
                 };
                 let Some(list) = list else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field list is required".to_string(),
                     ));
@@ -1036,7 +1042,7 @@ pub mod unknown_fields {
                     list,
                     _unknown_fields,
                 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1057,7 +1063,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1116,27 +1122,33 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(faststr) = faststr else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field faststr is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field faststr is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(string) = string else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field string is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field string is required".to_string(),
+                            ),
+                        );
                     };
                     let Some(list) = list else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field list is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field list is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self {
@@ -1145,7 +1157,7 @@ pub mod unknown_fields {
                         list,
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1202,7 +1214,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1216,7 +1228,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -1250,12 +1262,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { _unknown_fields };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1272,7 +1284,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1298,14 +1310,14 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1355,7 +1367,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1370,7 +1382,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -1409,7 +1421,7 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
@@ -1417,7 +1429,7 @@ pub mod unknown_fields {
                     message,
                     _unknown_fields,
                 };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1436,7 +1448,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1468,7 +1480,7 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
@@ -1476,7 +1488,7 @@ pub mod unknown_fields {
                         message,
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1522,7 +1534,7 @@ pub mod unknown_fields {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1534,7 +1546,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1561,12 +1573,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1583,7 +1595,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1606,12 +1618,12 @@ pub mod unknown_fields {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTest123ArgsRecv` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1663,7 +1675,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1678,7 +1690,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -1717,19 +1729,19 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(a) = a else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field a is required".to_string(),
                     ));
                 };
 
                 let data = Self { a, _unknown_fields };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1748,7 +1760,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                     loop {
 
 
@@ -1780,22 +1792,24 @@ pub mod unknown_fields {
                 if let Some(field_id) = __pilota_decoding_field_id {
                     err.prepend_msg(&format!("decode struct `C` field(#{}) failed, caused by: ", field_id));
                 }
-                return Err(err);
+                return ::std::result::Result::Err(err);
             };
                     protocol.read_struct_end().await?;
 
                     let Some(a) = a else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field a is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field a is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self {
                         a,
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1839,7 +1853,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -1853,7 +1867,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let mut __pilota_offset = 0;
                         let __pilota_begin_ptr = protocol.buf().chunk().as_ptr();
@@ -1887,12 +1901,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { _unknown_fields };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -1909,7 +1923,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -1935,14 +1949,14 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -1991,7 +2005,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2019,10 +2033,12 @@ pub mod unknown_fields {
                                 __pilota_offset += protocol.struct_len(&field_ident);
                                 ret = Some(TestUnion::A(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         Some(2) => {
@@ -2031,10 +2047,12 @@ pub mod unknown_fields {
                                 __pilota_offset += protocol.struct_len(&field_ident);
                                 ret = Some(TestUnion::B(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -2049,10 +2067,12 @@ pub mod unknown_fields {
                                     ret = Some(TestUnion::_UnknownFields(__pilota_linked_bytes));
                                 }
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                     }
@@ -2060,9 +2080,9 @@ pub mod unknown_fields {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -2097,10 +2117,10 @@ pub mod unknown_fields {
 
                                     ret = Some(TestUnion::A(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             Some(2) => {
@@ -2111,10 +2131,10 @@ pub mod unknown_fields {
 
                                     ret = Some(TestUnion::B(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -2125,9 +2145,9 @@ pub mod unknown_fields {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -2174,7 +2194,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2199,10 +2219,12 @@ pub mod unknown_fields {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionException::StException(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -2213,9 +2235,9 @@ pub mod unknown_fields {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -2253,10 +2275,10 @@ pub mod unknown_fields {
                                     ret =
                                         Some(TestTestExceptionException::StException(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -2267,9 +2289,9 @@ pub mod unknown_fields {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -2320,7 +2342,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2345,10 +2367,12 @@ pub mod unknown_fields {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionResultRecv::Ok(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         Some(1) => {
@@ -2357,10 +2381,12 @@ pub mod unknown_fields {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionResultRecv::StException(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -2371,9 +2397,9 @@ pub mod unknown_fields {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -2410,10 +2436,10 @@ pub mod unknown_fields {
 
                                     ret = Some(TestTestExceptionResultRecv::Ok(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             Some(1) => {
@@ -2427,10 +2453,10 @@ pub mod unknown_fields {
                                     ret =
                                         Some(TestTestExceptionResultRecv::StException(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -2441,9 +2467,9 @@ pub mod unknown_fields {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -2490,7 +2516,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2517,9 +2543,9 @@ pub mod unknown_fields {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Ok(TestTest123ResultRecv::Ok(()))
+                    ::std::result::Result::Ok(TestTest123ResultRecv::Ok(()))
                 }
             }
 
@@ -2551,9 +2577,9 @@ pub mod unknown_fields {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Ok(TestTest123ResultRecv::Ok(()))
+                        ::std::result::Result::Ok(TestTest123ResultRecv::Ok(()))
                     }
                 })
             }
@@ -2614,7 +2640,7 @@ pub mod unknown_fields {
                 #[allow(unused_imports)]
                 use ::pilota::thrift::TOutputProtocolExt;
                 protocol.write_i32(self.inner())?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2623,12 +2649,14 @@ pub mod unknown_fields {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 let value = protocol.read_i32()?;
-                Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                    ::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        format!("invalid enum value for Index, value: {}", value),
-                    )
-                })?)
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Index, value: {}", value),
+                        )
+                    },
+                )?)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -2643,12 +2671,14 @@ pub mod unknown_fields {
             > {
                 ::std::boxed::Box::pin(async move {
                     let value = protocol.read_i32().await?;
-                    Ok(::std::convert::TryFrom::try_from(value).map_err(|err| {
-                        ::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            format!("invalid enum value for Index, value: {}", value),
-                        )
-                    })?)
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Index, value: {}", value),
+                            )
+                        },
+                    )?)
                 })
             }
 
@@ -2688,7 +2718,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2703,7 +2733,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         if __pilota_fields_num == 0 {
                             let __pilota_remaining = protocol.buf().remaining();
@@ -2743,12 +2773,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self { _unknown_fields };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -2765,7 +2795,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -2791,14 +2821,14 @@ pub mod unknown_fields {
                                 field_id
                             ));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {
                         _unknown_fields: ::pilota::LinkedBytes::new(),
                     };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -2841,7 +2871,7 @@ pub mod unknown_fields {
                 protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -2855,7 +2885,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -2884,19 +2914,19 @@ pub mod unknown_fields {
                     if let Some(field_id) = __pilota_decoding_field_id {
                         err.prepend_msg(&format!("decode struct `TestTestExceptionArgsSend` field(#{}) failed, caused by: ", field_id));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field req is required".to_string(),
                     ));
                 };
 
                 let data = Self { req };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -2915,7 +2945,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -2949,19 +2979,21 @@ pub mod unknown_fields {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTestExceptionArgsSend` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(req) = req else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field req is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { req };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -2998,7 +3030,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -3025,9 +3057,9 @@ pub mod unknown_fields {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Ok(TestTest123ResultSend::Ok(()))
+                    ::std::result::Result::Ok(TestTest123ResultSend::Ok(()))
                 }
             }
 
@@ -3059,9 +3091,9 @@ pub mod unknown_fields {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Ok(TestTest123ResultSend::Ok(()))
+                        ::std::result::Result::Ok(TestTest123ResultSend::Ok(()))
                     }
                 })
             }
@@ -3121,13 +3153,13 @@ pub mod unknown_fields {
                             &val,
                             |protocol, val| {
                                 protocol.write_faststr((val).clone())?;
-                                Ok(())
+                                ::std::result::Result::Ok(())
                             },
                         )?;
-                        Ok(())
+                        ::std::result::Result::Ok(())
                     },
                 )?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -3135,7 +3167,7 @@ pub mod unknown_fields {
             ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
                 #[allow(unused_imports)]
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
-                Ok(Td(unsafe {
+                ::std::result::Result::Ok(Td(unsafe {
                     let list_ident = protocol.read_list_begin()?;
                     let mut val: Vec<::std::vec::Vec<::pilota::FastStr>> =
                         Vec::with_capacity(list_ident.size);
@@ -3171,7 +3203,7 @@ pub mod unknown_fields {
                 >,
             > {
                 ::std::boxed::Box::pin(async move {
-                    Ok(Td({
+                    ::std::result::Result::Ok(Td({
                         let list_ident = protocol.read_list_begin().await?;
                         let mut val = Vec::with_capacity(list_ident.size);
                         for _ in 0..list_ident.size {
@@ -3231,7 +3263,7 @@ pub mod unknown_fields {
                 protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -3245,7 +3277,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -3274,19 +3306,19 @@ pub mod unknown_fields {
                     if let Some(field_id) = __pilota_decoding_field_id {
                         err.prepend_msg(&format!("decode struct `TestTestExceptionArgsRecv` field(#{}) failed, caused by: ", field_id));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let Some(req) = req else {
-                    return Err(::pilota::thrift::new_protocol_exception(
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "field req is required".to_string(),
                     ));
                 };
 
                 let data = Self { req };
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -3305,7 +3337,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -3339,19 +3371,21 @@ pub mod unknown_fields {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTestExceptionArgsRecv` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let Some(req) = req else {
-                        return Err(::pilota::thrift::new_protocol_exception(
-                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                            "field req is required".to_string(),
-                        ));
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
                     };
 
                     let data = Self { req };
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -3395,7 +3429,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -3420,10 +3454,12 @@ pub mod unknown_fields {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionResultSend::Ok(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         Some(1) => {
@@ -3432,10 +3468,12 @@ pub mod unknown_fields {
                                 protocol.struct_len(&field_ident);
                                 ret = Some(TestTestExceptionResultSend::StException(field_ident));
                             } else {
-                                return Err(::pilota::thrift::new_protocol_exception(
-                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                    "received multiple fields for union from remote Message",
-                                ));
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
                             }
                         }
                         _ => {
@@ -3446,9 +3484,9 @@ pub mod unknown_fields {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Err(::pilota::thrift::new_protocol_exception(
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                         "received empty union from remote Message",
                     ))
@@ -3485,10 +3523,10 @@ pub mod unknown_fields {
 
                                     ret = Some(TestTestExceptionResultSend::Ok(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             Some(1) => {
@@ -3502,10 +3540,10 @@ pub mod unknown_fields {
                                     ret =
                                         Some(TestTestExceptionResultSend::StException(field_ident));
                                 } else {
-                                    return Err(::pilota::thrift::new_protocol_exception(
-                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                        "received multiple fields for union from remote Message",
-                                    ));
+                                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
                                 }
                             }
                             _ => {
@@ -3516,9 +3554,9 @@ pub mod unknown_fields {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Err(::pilota::thrift::new_protocol_exception(
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                             ::pilota::thrift::ProtocolExceptionKind::InvalidData,
                             "received empty union from remote Message",
                         ))
@@ -3577,7 +3615,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -3604,9 +3642,9 @@ pub mod unknown_fields {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Ok(TestTest123ResultRecv::Ok(()))
+                    ::std::result::Result::Ok(TestTest123ResultRecv::Ok(()))
                 }
             }
 
@@ -3638,9 +3676,9 @@ pub mod unknown_fields {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Ok(TestTest123ResultRecv::Ok(()))
+                        ::std::result::Result::Ok(TestTest123ResultRecv::Ok(()))
                     }
                 })
             }
@@ -3679,7 +3717,7 @@ pub mod unknown_fields {
                 }
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -3706,9 +3744,9 @@ pub mod unknown_fields {
                 protocol.read_field_end()?;
                 protocol.read_struct_end()?;
                 if let Some(ret) = ret {
-                    Ok(ret)
+                    ::std::result::Result::Ok(ret)
                 } else {
-                    Ok(TestTest123ResultSend::Ok(()))
+                    ::std::result::Result::Ok(TestTest123ResultSend::Ok(()))
                 }
             }
 
@@ -3740,9 +3778,9 @@ pub mod unknown_fields {
                     protocol.read_field_end().await?;
                     protocol.read_struct_end().await?;
                     if let Some(ret) = ret {
-                        Ok(ret)
+                        ::std::result::Result::Ok(ret)
                     } else {
-                        Ok(TestTest123ResultSend::Ok(()))
+                        ::std::result::Result::Ok(TestTest123ResultSend::Ok(()))
                     }
                 })
             }
@@ -3786,7 +3824,7 @@ pub mod unknown_fields {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -3798,7 +3836,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -3825,12 +3863,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -3847,7 +3885,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -3870,12 +3908,12 @@ pub mod unknown_fields {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTest123ArgsSend` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 
@@ -3916,7 +3954,7 @@ pub mod unknown_fields {
 
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
-                Ok(())
+                ::std::result::Result::Ok(())
             }
 
             fn decode<T: ::pilota::thrift::TInputProtocol>(
@@ -3928,7 +3966,7 @@ pub mod unknown_fields {
                 let mut __pilota_decoding_field_id = None;
 
                 protocol.read_struct_begin()?;
-                if let Err(mut err) = (|| {
+                if let ::std::result::Result::Err(mut err) = (|| {
                     loop {
                         let field_ident = protocol.read_field_begin()?;
                         if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -3955,12 +3993,12 @@ pub mod unknown_fields {
                             field_id
                         ));
                     }
-                    return Err(err);
+                    return ::std::result::Result::Err(err);
                 };
                 protocol.read_struct_end()?;
 
                 let data = Self {};
-                Ok(data)
+                ::std::result::Result::Ok(data)
             }
 
             fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
@@ -3977,7 +4015,7 @@ pub mod unknown_fields {
                     let mut __pilota_decoding_field_id = None;
 
                     protocol.read_struct_begin().await?;
-                    if let Err(mut err) = async {
+                    if let ::std::result::Result::Err(mut err) = async {
                         loop {
                             let field_ident = protocol.read_field_begin().await?;
                             if field_ident.field_type == ::pilota::thrift::TType::Stop {
@@ -4000,12 +4038,12 @@ pub mod unknown_fields {
                         if let Some(field_id) = __pilota_decoding_field_id {
                             err.prepend_msg(&format!("decode struct `TestTest123ArgsRecv` field(#{}) failed, caused by: ", field_id));
                         }
-                        return Err(err);
+                        return ::std::result::Result::Err(err);
                     };
                     protocol.read_struct_end().await?;
 
                     let data = Self {};
-                    Ok(data)
+                    ::std::result::Result::Ok(data)
                 })
             }
 


### PR DESCRIPTION
Prevent confliction from user defined struct in IDL