### PR TITLE
fix(pilota)/use advance method to align the inner buffer index with the protocol index when feasible

### DIFF
--- a/pilota/src/thrift/binary_unsafe.rs
+++ b/pilota/src/thrift/binary_unsafe.rs
@@ -533,7 +533,6 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
     fn write_bytes_without_len(&mut self, b: Bytes) -> Result<(), ThriftException> {
         if self.zero_copy && b.len() >= ZERO_COPY_THRESHOLD {
             self.zero_copy_len += b.len();
-            self.advance_mut(self.index);
             self.trans.insert(b);
             self.buf = unsafe {
                 let l = self.trans.bytes_mut().len();

--- a/pilota/src/thrift/binary_unsafe.rs
+++ b/pilota/src/thrift/binary_unsafe.rs
@@ -469,7 +469,6 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
         self.write_i32(version)?;
         self.write_faststr(identifier.name.clone())?;
         self.write_i32(identifier.sequence_number)?;
-        self.advance_mut(self.index);
         Ok(())
     }
 
@@ -499,7 +498,6 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
                 .unwrap_unchecked();
             *buf = id.to_be_bytes();
             self.index += 3;
-            self.advance_mut(self.index);
         }
         Ok(())
     }
@@ -533,6 +531,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
     fn write_bytes_without_len(&mut self, b: Bytes) -> Result<(), ThriftException> {
         if self.zero_copy && b.len() >= ZERO_COPY_THRESHOLD {
             self.zero_copy_len += b.len();
+            self.advance_mut(self.index);
             self.trans.insert(b);
             self.buf = unsafe {
                 let l = self.trans.bytes_mut().len();
@@ -674,9 +673,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
     #[inline]
     fn write_list_begin(&mut self, identifier: TListIdentifier) -> Result<(), ThriftException> {
         self.write_byte(identifier.element_type.into())?;
-        self.write_i32(identifier.size as i32)?;
-        self.advance_mut(self.index);
-        Ok(())
+        self.write_i32(identifier.size as i32)
     }
 
     #[inline]
@@ -687,9 +684,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
     #[inline]
     fn write_set_begin(&mut self, identifier: TSetIdentifier) -> Result<(), ThriftException> {
         self.write_byte(identifier.element_type.into())?;
-        self.write_i32(identifier.size as i32)?;
-        self.advance_mut(self.index);
-        Ok(())
+        self.write_i32(identifier.size as i32)
     }
 
     #[inline]
@@ -703,9 +698,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
         self.write_byte(key_type.into())?;
         let val_type = identifier.value_type;
         self.write_byte(val_type.into())?;
-        self.write_i32(identifier.size as i32)?;
-        self.advance_mut(self.index);
-        Ok(())
+        self.write_i32(identifier.size as i32)
     }
 
     #[inline]
@@ -721,7 +714,6 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
     #[inline]
     fn write_bytes_vec(&mut self, b: &[u8]) -> Result<(), ThriftException> {
         self.write_i32(b.len() as i32)?;
-        self.advance_mut(self.index);
         unsafe {
             ptr::copy_nonoverlapping(b.as_ptr(), self.buf.as_mut_ptr().add(self.index), b.len());
             self.index += b.len();

--- a/pilota/src/thrift/binary_unsafe.rs
+++ b/pilota/src/thrift/binary_unsafe.rs
@@ -967,7 +967,6 @@ impl<'a> TInputProtocol for TBinaryUnsafeInputProtocol<'a> {
             TType::Stop => Ok(0),
             _ => self.read_i16(),
         }?;
-        self.advance(self.index);
         Ok(TFieldIdentifier::new::<Option<&'static str>, i16>(
             None, field_type, id,
         ))

--- a/pilota/src/thrift/binary_unsafe.rs
+++ b/pilota/src/thrift/binary_unsafe.rs
@@ -451,6 +451,7 @@ impl TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
     fn advance_mut(&mut self, len: usize) {
         unsafe {
             self.trans.bytes_mut().advance_mut(len);
+            self.buf.advance_mut(len);
         }
         self.index -= len;
     }
@@ -469,6 +470,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
         self.write_i32(version)?;
         self.write_faststr(identifier.name.clone())?;
         self.write_i32(identifier.sequence_number)?;
+        self.advance_mut(self.index);
         Ok(())
     }
 
@@ -498,6 +500,7 @@ impl TOutputProtocol for TBinaryUnsafeOutputProtocol<&mut LinkedBytes> {
                 .unwrap_unchecked();
             *buf = id.to_be_bytes();
             self.index += 3;
+            self.advance_mut(self.index);
         }
         Ok(())
     }
@@ -1100,7 +1103,6 @@ impl<'a> TInputProtocol for TBinaryUnsafeInputProtocol<'a> {
     fn read_list_begin(&mut self) -> Result<TListIdentifier, ThriftException> {
         let element_type: TType = self.read_byte().and_then(|n| Ok(field_type_from_u8(n)?))?;
         let size = self.read_i32()?;
-        self.advance(self.index);
         Ok(TListIdentifier::new(element_type, size as usize))
     }
 
@@ -1113,7 +1115,6 @@ impl<'a> TInputProtocol for TBinaryUnsafeInputProtocol<'a> {
     fn read_set_begin(&mut self) -> Result<TSetIdentifier, ThriftException> {
         let element_type: TType = self.read_byte().and_then(|n| Ok(field_type_from_u8(n)?))?;
         let size = self.read_i32()?;
-        self.advance(self.index);
         Ok(TSetIdentifier::new(element_type, size as usize))
     }
 
@@ -1127,7 +1128,6 @@ impl<'a> TInputProtocol for TBinaryUnsafeInputProtocol<'a> {
         let key_type: TType = self.read_byte().and_then(|n| Ok(field_type_from_u8(n)?))?;
         let value_type: TType = self.read_byte().and_then(|n| Ok(field_type_from_u8(n)?))?;
         let size = self.read_i32()?;
-        self.advance(self.index);
         Ok(TMapIdentifier::new(key_type, value_type, size as usize))
     }
 

--- a/pilota/src/thrift/mod.rs
+++ b/pilota/src/thrift/mod.rs
@@ -877,7 +877,6 @@ pub trait TAsyncInputProtocol: Send {
                 format!("cannot skip field type {:?}", &u),
             )),
         }
-        // }
     }
 }
 


### PR DESCRIPTION
## Motivation
The inner buffer index might not align with the index of protocol for better performance of vector encoding or decoding. Thus, when we use the `buf` or `buf_mut` interface which return the inner buffer, we might encounter the issue of reading or writing at wrong position of the buffer. 

## Solution
As there are some low frequency option, such as `read_message_begin`, which are not pursuing performance, we can use the `advance` and `advance_mut` method to align the inner buffer index with the index of protocol implement. Then, we can get the right payload after `read_message_begin`. 

As a reminder, this PR cannot completely resolve the inconsistency problem of these two indexes, so be careful of using the `buf` and `buf_mut` in the middle of processing the thrift message.