### PR TITLE
fix(pilota): align the inner buffer index with the protocol index

### DIFF
--- a/pilota/src/thrift/binary_unsafe.rs
+++ b/pilota/src/thrift/binary_unsafe.rs
@@ -758,6 +758,7 @@ impl<'a> TBinaryUnsafeInputProtocol<'a> {
     #[doc(hidden)]
     fn advance(&mut self, len: usize) {
         self.trans.advance(len);
+        self.buf.advance(len);
         self.index -= len;
     }
 }


### PR DESCRIPTION
## Motivation
The previous `advance` won't align the inner buffer index with the input protocol index, so the reading of inner buffer might encounter error.

## Solution
Align these two indexes for correctness of input protocol.

