### PR TITLE
feat: support double type as map/set key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +791,7 @@ dependencies = [
  "integer-encoding",
  "lazy_static",
  "linkedbytes",
+ "ordered-float",
  "paste",
  "proptest",
  "rand",

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -20,7 +20,7 @@ impl ThriftBackend {
             ty::I16 => "::pilota::thrift::TType::I16".into(),
             ty::I32 => "::pilota::thrift::TType::I32".into(),
             ty::I64 => "::pilota::thrift::TType::I64".into(),
-            ty::F64 => "::pilota::thrift::TType::Double".into(),
+            ty::F64 | ty::OrderedF64 => "::pilota::thrift::TType::Double".into(),
             ty::Uuid => "::pilota::thrift::TType::Uuid".into(),
             ty::Vec(_) => "::pilota::thrift::TType::List".into(),
             ty::Set(_) => "::pilota::thrift::TType::Set".into(),
@@ -59,6 +59,7 @@ impl ThriftBackend {
             ty::I32 => format!("protocol.write_i32(*{ident})?;").into(),
             ty::I64 => format!("protocol.write_i64(*{ident})?;").into(),
             ty::F64 => format!("protocol.write_double(*{ident})?;").into(),
+            ty::OrderedF64 => format!("protocol.write_double({ident}.0)?;").into(),
             ty::Uuid => format!("protocol.write_uuid({ident})?;").into(),
             ty::Vec(ty) => {
                 let el_ttype = self.ttype(ty);
@@ -133,6 +134,7 @@ impl ThriftBackend {
             ty::I32 => format!("protocol.write_i32_field({id}, *{ident})?;").into(),
             ty::I64 => format!("protocol.write_i64_field({id}, *{ident})?;").into(),
             ty::F64 => format!("protocol.write_double_field({id}, *{ident})?;").into(),
+            ty::OrderedF64 => format!("protocol.write_double_field({id}, {ident}.0)?;").into(),
             ty::Uuid => format!("protocol.write_uuid_field({id}, *{ident})?;").into(),
             ty::Vec(ty) => {
                 let el_ttype = self.ttype(ty);
@@ -207,6 +209,7 @@ impl ThriftBackend {
             ty::I32 => format!("protocol.i32_len(*{ident})").into(),
             ty::I64 => format!("protocol.i64_len(*{ident})").into(),
             ty::F64 => format!("protocol.double_len(*{ident})").into(),
+            ty::OrderedF64 => format!("protocol.double_len({ident}.0)").into(),
             ty::Uuid => format!("protocol.uuid_len(*{ident})").into(),
             ty::Vec(el) => {
                 let add_el = self.codegen_ty_size(el, "el".into());
@@ -263,6 +266,7 @@ impl ThriftBackend {
             ty::I32 => format!("protocol.i32_field_len(Some({id}), *{ident})").into(),
             ty::I64 => format!("protocol.i64_field_len(Some({id}), *{ident})").into(),
             ty::F64 => format!("protocol.double_field_len(Some({id}), *{ident}) ").into(),
+            ty::OrderedF64 => format!("protocol.double_field_len(Some({id}), {ident}.0) ").into(),
             ty::Uuid => format!("protocol.uuid_field_len(Some({id}), *{ident}) ").into(),
             ty::Vec(el) => {
                 let add_el = self.codegen_ty_size(el, "el".into());
@@ -326,6 +330,10 @@ impl ThriftBackend {
             ty::I32 => helper.codegen_read_i32(),
             ty::I64 => helper.codegen_read_i64(),
             ty::F64 => helper.codegen_read_double(),
+            ty::OrderedF64 => {
+                let read_double = helper.codegen_read_double();
+                format!("::pilota::OrderedFloat({read_double})").into()
+            }
             ty::Uuid => helper.codegen_read_uuid(),
             ty::Vec(ty) => {
                 let read_list_begin = helper.codegen_read_list_begin();

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -25,6 +25,7 @@ pub enum TyKind {
     UInt64,
     F32,
     F64,
+    OrderedF64,
     Uuid,
     Vec(Arc<Ty>),
     Set(Arc<Ty>),
@@ -68,6 +69,7 @@ pub enum CodegenTy {
     UInt64,
     F32,
     F64,
+    OrderedF64,
     Uuid,
     Bytes,
     LazyStaticRef(Arc<CodegenTy>),
@@ -111,6 +113,7 @@ impl CodegenTy {
             CodegenTy::I32 => "i32".into(),
             CodegenTy::I64 => "i64".into(),
             CodegenTy::F64 => "f64".into(),
+            CodegenTy::OrderedF64 => "::pilota::OrderedFloat<f64>".into(),
             CodegenTy::UInt32 => "u32".into(),
             CodegenTy::UInt64 => "u64".into(),
             CodegenTy::F32 => "f32".into(),
@@ -174,6 +177,7 @@ impl Display for CodegenTy {
             CodegenTy::I32 => f.write_str("i32"),
             CodegenTy::I64 => f.write_str("i64"),
             CodegenTy::F64 => f.write_str("f64"),
+            CodegenTy::OrderedF64 => f.write_str("::pilota::OrderedFloat<f64>"),
             CodegenTy::UInt32 => f.write_str("u32"),
             CodegenTy::UInt64 => f.write_str("u64"),
             CodegenTy::F32 => f.write_str("f32"),
@@ -298,6 +302,11 @@ pub trait TyTransformer {
     }
 
     #[inline]
+    fn ordered_f64(&self) -> CodegenTy {
+        CodegenTy::OrderedF64
+    }
+
+    #[inline]
     fn f32(&self) -> CodegenTy {
         CodegenTy::F32
     }
@@ -356,6 +365,7 @@ pub trait TyTransformer {
             I32 => self.i32(),
             I64 => self.i64(),
             F64 => self.f64(),
+            OrderedF64 => self.ordered_f64(),
             Uuid => self.uuid(),
             Vec(ty) => self.vec(ty),
             Set(ty) => self.set(ty),
@@ -467,6 +477,7 @@ pub(crate) fn fold_ty<F: Folder>(f: &mut F, ty: &Ty) -> Ty {
         I32 => TyKind::I32,
         I64 => TyKind::I64,
         F64 => TyKind::F64,
+        OrderedF64 => TyKind::OrderedF64,
         Uuid => TyKind::Uuid,
         Vec(ty) => TyKind::Vec(f.fold_ty(ty).into()),
         Set(ty) => TyKind::Set(f.fold_ty(ty).into()),

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -374,9 +374,40 @@ impl Resolver {
             ir::TyKind::F64 => ty::F64,
             ir::TyKind::Uuid => ty::Uuid,
             ir::TyKind::Vec(ty) => ty::Vec(Arc::from(self.lower_type(ty, false))),
-            ir::TyKind::Set(ty) => ty::Set(Arc::from(self.lower_type(ty, false))),
+            ir::TyKind::Set(ty) => ty::Set(Arc::from(self.lower_type_for_hash_key(ty, false))),
             ir::TyKind::Map(k, v) => ty::Map(
-                Arc::from(self.lower_type(k, false)),
+                Arc::from(self.lower_type_for_hash_key(k, false)),
+                Arc::from(self.lower_type(v, false)),
+            ),
+            ir::TyKind::Path(p) => ty::Path(self.lower_path(p, Namespace::Ty, is_args)),
+            ir::TyKind::UInt64 => ty::UInt64,
+            ir::TyKind::UInt32 => ty::UInt32,
+            ir::TyKind::F32 => ty::F32,
+        };
+        let tags_id = self.tags_id_counter.inc_one();
+
+        self.tags.insert(tags_id, ty.tags.clone());
+
+        Ty { kind, tags_id }
+    }
+
+    fn lower_type_for_hash_key(&mut self, ty: &ir::Ty, is_args: bool) -> Ty {
+        let kind = match &ty.kind {
+            ir::TyKind::String => ty::FastStr,
+            ir::TyKind::Void => ty::Void,
+            ir::TyKind::U8 => ty::U8,
+            ir::TyKind::Bool => ty::Bool,
+            ir::TyKind::Bytes => ty::Bytes,
+            ir::TyKind::I8 => ty::I8,
+            ir::TyKind::I16 => ty::I16,
+            ir::TyKind::I32 => ty::I32,
+            ir::TyKind::I64 => ty::I64,
+            ir::TyKind::F64 => ty::OrderedF64,
+            ir::TyKind::Uuid => ty::Uuid,
+            ir::TyKind::Vec(ty) => ty::Vec(Arc::from(self.lower_type_for_hash_key(ty, false))),
+            ir::TyKind::Set(ty) => ty::Set(Arc::from(self.lower_type_for_hash_key(ty, false))),
+            ir::TyKind::Map(k, v) => ty::Map(
+                Arc::from(self.lower_type_for_hash_key(k, false)),
                 Arc::from(self.lower_type(v, false)),
             ),
             ir::TyKind::Path(p) => ty::Path(self.lower_path(p, Namespace::Ty, is_args)),

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -217,6 +217,9 @@ mod tests {
 
         let err = A::decode(&mut TBinaryProtocol::new(&mut data, false)).unwrap_err();
 
-        assert_eq!(err.to_string(), "Protocol(ProtocolException { kind: InvalidData, message: \"decode struct `A` field(#1) failed, caused by: decode struct `B` field(#1) failed, caused by: invalid ttype 100\" })")
+        assert_eq!(
+            err.to_string(),
+            "Protocol(ProtocolException { kind: InvalidData, message: \"decode struct `A` field(#1) failed, caused by: decode struct `B` field(#1) failed, caused by: invalid ttype 100\" })"
+        )
     }
 }

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -283,6 +283,12 @@ pub mod default_value {
                     test_double2: Some(1.2f64),
                     alias_str: Some(::pilota::FastStr::from_static_str(A_S)),
                     empty: ::pilota::Bytes::from_static("".as_bytes()),
+                    test_map: {
+                        let mut map = ::pilota::AHashMap::with_capacity(1);
+                        map.insert(::pilota::OrderedFloat(1f64), 2f64);
+                        map
+                    },
+                    test_set: ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]),
                 }
             }
         }
@@ -310,6 +316,10 @@ pub mod default_value {
             pub alias_str: ::std::option::Option<::pilota::FastStr>,
 
             pub empty: ::pilota::Bytes,
+
+            pub test_map: ::pilota::AHashMap<::pilota::OrderedFloat<f64>, f64>,
+
+            pub test_set: ::pilota::AHashSet<::pilota::OrderedFloat<f64>>,
         }
         impl ::pilota::thrift::Message for A {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -361,6 +371,29 @@ pub mod default_value {
                     protocol.write_faststr_field(9, (value).clone())?;
                 }
                 protocol.write_bytes_field(10, (&self.empty).clone())?;
+                protocol.write_map_field(
+                    11,
+                    ::pilota::thrift::TType::Double,
+                    ::pilota::thrift::TType::Double,
+                    &&self.test_map,
+                    |protocol, key| {
+                        protocol.write_double(key.0)?;
+                        ::std::result::Result::Ok(())
+                    },
+                    |protocol, val| {
+                        protocol.write_double(*val)?;
+                        ::std::result::Result::Ok(())
+                    },
+                )?;
+                protocol.write_set_field(
+                    12,
+                    ::pilota::thrift::TType::Double,
+                    &&self.test_set,
+                    |protocol, val| {
+                        protocol.write_double(val.0)?;
+                        ::std::result::Result::Ok(())
+                    },
+                )?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
                 ::std::result::Result::Ok(())
@@ -383,6 +416,8 @@ pub mod default_value {
                 let mut test_double2 = Some(1.2f64);
                 let mut alias_str = Some(::pilota::FastStr::from_static_str(A_S));
                 let mut empty = ::pilota::Bytes::from_static("".as_bytes());
+                let mut test_map = None;
+                let mut test_set = None;
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -454,6 +489,32 @@ pub mod default_value {
                             {
                                 empty = protocol.read_bytes()?;
                             }
+                            Some(11) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                test_map = Some({
+                                    let map_ident = protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::OrderedFloat(protocol.read_double()?),
+                                            protocol.read_double()?,
+                                        );
+                                    }
+                                    protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(12) if field_ident.field_type == ::pilota::thrift::TType::Set => {
+                                test_set = Some({
+                                    let list_ident = protocol.read_set_begin()?;
+                                    let mut val =
+                                        ::pilota::AHashSet::with_capacity(list_ident.size);
+                                    for _ in 0..list_ident.size {
+                                        val.insert(::pilota::OrderedFloat(protocol.read_double()?));
+                                    }
+                                    protocol.read_set_end()?;
+                                    val
+                                });
+                            }
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
                             }
@@ -485,6 +546,13 @@ pub mod default_value {
                         map
                     });
                 }
+                let test_map = test_map.unwrap_or_else(|| {
+                    let mut map = ::pilota::AHashMap::with_capacity(1);
+                    map.insert(::pilota::OrderedFloat(1f64), 2f64);
+                    map
+                });
+                let test_set = test_set
+                    .unwrap_or_else(|| ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]));
 
                 let data = Self {
                     faststr,
@@ -498,6 +566,8 @@ pub mod default_value {
                     test_double2,
                     alias_str,
                     empty,
+                    test_map,
+                    test_set,
                 };
                 ::std::result::Result::Ok(data)
             }
@@ -524,6 +594,8 @@ pub mod default_value {
                     let mut test_double2 = Some(1.2f64);
                     let mut alias_str = Some(::pilota::FastStr::from_static_str(A_S));
                     let mut empty = ::pilota::Bytes::from_static("".as_bytes());
+                    let mut test_map = None;
+                    let mut test_set = None;
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -616,6 +688,41 @@ pub mod default_value {
                                 {
                                     empty = protocol.read_bytes().await?;
                                 }
+                                Some(11)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Map =>
+                                {
+                                    test_map = Some({
+                                        let map_ident = protocol.read_map_begin().await?;
+                                        let mut val =
+                                            ::pilota::AHashMap::with_capacity(map_ident.size);
+                                        for _ in 0..map_ident.size {
+                                            val.insert(
+                                                ::pilota::OrderedFloat(
+                                                    protocol.read_double().await?,
+                                                ),
+                                                protocol.read_double().await?,
+                                            );
+                                        }
+                                        protocol.read_map_end().await?;
+                                        val
+                                    });
+                                }
+                                Some(12)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Set =>
+                                {
+                                    test_set = Some({
+                                        let list_ident = protocol.read_set_begin().await?;
+                                        let mut val =
+                                            ::pilota::AHashSet::with_capacity(list_ident.size);
+                                        for _ in 0..list_ident.size {
+                                            val.insert(::pilota::OrderedFloat(
+                                                protocol.read_double().await?,
+                                            ));
+                                        }
+                                        protocol.read_set_end().await?;
+                                        val
+                                    });
+                                }
                                 _ => {
                                     protocol.skip(field_ident.field_type).await?;
                                 }
@@ -648,6 +755,14 @@ pub mod default_value {
                             map
                         });
                     }
+                    let test_map = test_map.unwrap_or_else(|| {
+                        let mut map = ::pilota::AHashMap::with_capacity(1);
+                        map.insert(::pilota::OrderedFloat(1f64), 2f64);
+                        map
+                    });
+                    let test_set = test_set.unwrap_or_else(|| {
+                        ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)])
+                    });
 
                     let data = Self {
                         faststr,
@@ -661,6 +776,8 @@ pub mod default_value {
                         test_double2,
                         alias_str,
                         empty,
+                        test_map,
+                        test_set,
                     };
                     ::std::result::Result::Ok(data)
                 })
@@ -711,6 +828,20 @@ pub mod default_value {
                         .as_ref()
                         .map_or(0, |value| protocol.faststr_field_len(Some(9), value))
                     + protocol.bytes_field_len(Some(10), &self.empty)
+                    + protocol.map_field_len(
+                        Some(11),
+                        ::pilota::thrift::TType::Double,
+                        ::pilota::thrift::TType::Double,
+                        &self.test_map,
+                        |protocol, key| protocol.double_len(key.0),
+                        |protocol, val| protocol.double_len(*val),
+                    )
+                    + protocol.set_field_len(
+                        Some(12),
+                        ::pilota::thrift::TType::Double,
+                        &self.test_set,
+                        |protocol, el| protocol.double_len(el.0),
+                    )
                     + protocol.field_stop_len()
                     + protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/default_value.thrift
+++ b/pilota-build/test_data/thrift/default_value.thrift
@@ -17,6 +17,8 @@ struct A {
     8: optional double test_double2 = 1.2,
     9: optional string alias_str = A_S,
     10: required binary empty = "",
+    11: required map<double, double> test_map = {1.0: 2.0},
+    12: required set<double> test_set = [1.0],
 }
 
 struct C {

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -285,6 +285,12 @@ pub mod multi {
                     test_double2: Some(1.2f64),
                     alias_str: Some(::pilota::FastStr::from_static_str(A_S)),
                     empty: ::pilota::Bytes::from_static("".as_bytes()),
+                    test_map: {
+                        let mut map = ::pilota::AHashMap::with_capacity(1);
+                        map.insert(::pilota::OrderedFloat(1f64), 2f64);
+                        map
+                    },
+                    test_set: ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]),
                 }
             }
         }
@@ -312,6 +318,10 @@ pub mod multi {
             pub alias_str: ::std::option::Option<::pilota::FastStr>,
 
             pub empty: ::pilota::Bytes,
+
+            pub test_map: ::pilota::AHashMap<::pilota::OrderedFloat<f64>, f64>,
+
+            pub test_set: ::pilota::AHashSet<::pilota::OrderedFloat<f64>>,
         }
         impl ::pilota::thrift::Message for A {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -363,6 +373,29 @@ pub mod multi {
                     protocol.write_faststr_field(9, (value).clone())?;
                 }
                 protocol.write_bytes_field(10, (&self.empty).clone())?;
+                protocol.write_map_field(
+                    11,
+                    ::pilota::thrift::TType::Double,
+                    ::pilota::thrift::TType::Double,
+                    &&self.test_map,
+                    |protocol, key| {
+                        protocol.write_double(key.0)?;
+                        ::std::result::Result::Ok(())
+                    },
+                    |protocol, val| {
+                        protocol.write_double(*val)?;
+                        ::std::result::Result::Ok(())
+                    },
+                )?;
+                protocol.write_set_field(
+                    12,
+                    ::pilota::thrift::TType::Double,
+                    &&self.test_set,
+                    |protocol, val| {
+                        protocol.write_double(val.0)?;
+                        ::std::result::Result::Ok(())
+                    },
+                )?;
                 protocol.write_field_stop()?;
                 protocol.write_struct_end()?;
                 ::std::result::Result::Ok(())
@@ -385,6 +418,8 @@ pub mod multi {
                 let mut test_double2 = Some(1.2f64);
                 let mut alias_str = Some(::pilota::FastStr::from_static_str(A_S));
                 let mut empty = ::pilota::Bytes::from_static("".as_bytes());
+                let mut test_map = None;
+                let mut test_set = None;
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -456,6 +491,32 @@ pub mod multi {
                             {
                                 empty = protocol.read_bytes()?;
                             }
+                            Some(11) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                test_map = Some({
+                                    let map_ident = protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::OrderedFloat(protocol.read_double()?),
+                                            protocol.read_double()?,
+                                        );
+                                    }
+                                    protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(12) if field_ident.field_type == ::pilota::thrift::TType::Set => {
+                                test_set = Some({
+                                    let list_ident = protocol.read_set_begin()?;
+                                    let mut val =
+                                        ::pilota::AHashSet::with_capacity(list_ident.size);
+                                    for _ in 0..list_ident.size {
+                                        val.insert(::pilota::OrderedFloat(protocol.read_double()?));
+                                    }
+                                    protocol.read_set_end()?;
+                                    val
+                                });
+                            }
                             _ => {
                                 protocol.skip(field_ident.field_type)?;
                             }
@@ -487,6 +548,13 @@ pub mod multi {
                         map
                     });
                 }
+                let test_map = test_map.unwrap_or_else(|| {
+                    let mut map = ::pilota::AHashMap::with_capacity(1);
+                    map.insert(::pilota::OrderedFloat(1f64), 2f64);
+                    map
+                });
+                let test_set = test_set
+                    .unwrap_or_else(|| ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]));
 
                 let data = Self {
                     faststr,
@@ -500,6 +568,8 @@ pub mod multi {
                     test_double2,
                     alias_str,
                     empty,
+                    test_map,
+                    test_set,
                 };
                 ::std::result::Result::Ok(data)
             }
@@ -526,6 +596,8 @@ pub mod multi {
                     let mut test_double2 = Some(1.2f64);
                     let mut alias_str = Some(::pilota::FastStr::from_static_str(A_S));
                     let mut empty = ::pilota::Bytes::from_static("".as_bytes());
+                    let mut test_map = None;
+                    let mut test_set = None;
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -618,6 +690,41 @@ pub mod multi {
                                 {
                                     empty = protocol.read_bytes().await?;
                                 }
+                                Some(11)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Map =>
+                                {
+                                    test_map = Some({
+                                        let map_ident = protocol.read_map_begin().await?;
+                                        let mut val =
+                                            ::pilota::AHashMap::with_capacity(map_ident.size);
+                                        for _ in 0..map_ident.size {
+                                            val.insert(
+                                                ::pilota::OrderedFloat(
+                                                    protocol.read_double().await?,
+                                                ),
+                                                protocol.read_double().await?,
+                                            );
+                                        }
+                                        protocol.read_map_end().await?;
+                                        val
+                                    });
+                                }
+                                Some(12)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Set =>
+                                {
+                                    test_set = Some({
+                                        let list_ident = protocol.read_set_begin().await?;
+                                        let mut val =
+                                            ::pilota::AHashSet::with_capacity(list_ident.size);
+                                        for _ in 0..list_ident.size {
+                                            val.insert(::pilota::OrderedFloat(
+                                                protocol.read_double().await?,
+                                            ));
+                                        }
+                                        protocol.read_set_end().await?;
+                                        val
+                                    });
+                                }
                                 _ => {
                                     protocol.skip(field_ident.field_type).await?;
                                 }
@@ -650,6 +757,14 @@ pub mod multi {
                             map
                         });
                     }
+                    let test_map = test_map.unwrap_or_else(|| {
+                        let mut map = ::pilota::AHashMap::with_capacity(1);
+                        map.insert(::pilota::OrderedFloat(1f64), 2f64);
+                        map
+                    });
+                    let test_set = test_set.unwrap_or_else(|| {
+                        ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)])
+                    });
 
                     let data = Self {
                         faststr,
@@ -663,6 +778,8 @@ pub mod multi {
                         test_double2,
                         alias_str,
                         empty,
+                        test_map,
+                        test_set,
                     };
                     ::std::result::Result::Ok(data)
                 })
@@ -713,6 +830,20 @@ pub mod multi {
                         .as_ref()
                         .map_or(0, |value| protocol.faststr_field_len(Some(9), value))
                     + protocol.bytes_field_len(Some(10), &self.empty)
+                    + protocol.map_field_len(
+                        Some(11),
+                        ::pilota::thrift::TType::Double,
+                        ::pilota::thrift::TType::Double,
+                        &self.test_map,
+                        |protocol, key| protocol.double_len(key.0),
+                        |protocol, val| protocol.double_len(*val),
+                    )
+                    + protocol.set_field_len(
+                        Some(12),
+                        ::pilota::thrift::TType::Double,
+                        &self.test_set,
+                        |protocol, el| protocol.double_len(el.0),
+                    )
                     + protocol.field_stop_len()
                     + protocol.struct_end_len()
             }

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -32,6 +32,7 @@ faststr = { version = "0.2", features = ["serde"] }
 integer-encoding = { version = "4", features = ["tokio", "tokio_async"] }
 serde = { version = "1", features = ["derive"] }
 smallvec = "1"
+ordered-float = "4"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/pilota/src/lib.rs
+++ b/pilota/src/lib.rs
@@ -13,6 +13,7 @@ pub use bytes::*;
 pub use derivative;
 pub use faststr::FastStr;
 pub use lazy_static;
+pub use ordered_float::OrderedFloat;
 pub use serde;
 pub use thiserror::Error as ThisError;
 pub use tokio::io::AsyncRead;


### PR DESCRIPTION
```thrift
struct A {
    1: required map<double, double> test_map,
    2: required set<double> test_set,
}
```
Generated:
```rust
pub struct A {
    pub test_map: ::pilota::AHashMap<::pilota::OrderedFloat<f64>, f64>,
    pub test_set: ::pilota::AHashSet<::pilota::OrderedFloat<f64>>,
}
```