### PR TITLE
feat: compatibility of bool and map default values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.12"
+version = "0.11.13"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -491,6 +491,10 @@ impl Context {
                 _ => panic!("invalid map type {:?}", map),
             },
             (Literal::Map(m), CodegenTy::Map(k_ty, v_ty)) => (mk_map(m, k_ty, v_ty)?, false),
+            (Literal::List(m), CodegenTy::Map(_, _) | CodegenTy::LazyStaticRef(_)) => {
+                assert!(m.is_empty());
+                ("::pilota::AHashMap::new()".into(), false)
+            }
             _ => self.lit_into_ty(lit, ty)?,
         })
     }

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -677,6 +677,10 @@ impl Context {
                 )
             }
             (Literal::Bool(b), CodegenTy::Bool) => (format! { "{b}" }.into(), true),
+            (Literal::Int(i), CodegenTy::Bool) => {
+                let b = *i != 0;
+                (format! { "{b}" }.into(), true)
+            }
             (Literal::String(s), CodegenTy::Bytes) => {
                 let s = &**s;
                 (

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -290,6 +290,7 @@ pub mod default_value {
                     },
                     test_set: ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]),
                     a2: Some(true),
+                    map2: Some(::pilota::AHashMap::new()),
                 }
             }
         }
@@ -323,6 +324,9 @@ pub mod default_value {
             pub test_set: ::pilota::AHashSet<::pilota::OrderedFloat<f64>>,
 
             pub a2: ::std::option::Option<bool>,
+
+            pub map2:
+                ::std::option::Option<::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>>,
         }
         impl ::pilota::thrift::Message for A {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -400,6 +404,22 @@ pub mod default_value {
                 if let Some(value) = self.a2.as_ref() {
                     __protocol.write_bool_field(13, *value)?;
                 }
+                if let Some(value) = self.map2.as_ref() {
+                    __protocol.write_map_field(
+                        14,
+                        ::pilota::thrift::TType::Binary,
+                        ::pilota::thrift::TType::Binary,
+                        &value,
+                        |__protocol, key| {
+                            __protocol.write_faststr((key).clone())?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_faststr((val).clone())?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
                 ::std::result::Result::Ok(())
@@ -425,6 +445,7 @@ pub mod default_value {
                 let mut test_map = None;
                 let mut test_set = None;
                 let mut a2 = Some(true);
+                let mut map2 = None;
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -527,6 +548,20 @@ pub mod default_value {
                             Some(13) if field_ident.field_type == ::pilota::thrift::TType::Bool => {
                                 a2 = Some(__protocol.read_bool()?);
                             }
+                            Some(14) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                map2 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            __protocol.read_faststr()?,
+                                            __protocol.read_faststr()?,
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
                             }
@@ -565,6 +600,9 @@ pub mod default_value {
                 });
                 let test_set = test_set
                     .unwrap_or_else(|| ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]));
+                if map2.is_none() {
+                    map2 = Some(::pilota::AHashMap::new());
+                }
 
                 let data = Self {
                     faststr,
@@ -581,6 +619,7 @@ pub mod default_value {
                     test_map,
                     test_set,
                     a2,
+                    map2,
                 };
                 ::std::result::Result::Ok(data)
             }
@@ -610,6 +649,7 @@ pub mod default_value {
                     let mut test_map = None;
                     let mut test_set = None;
                     let mut a2 = Some(true);
+                    let mut map2 = None;
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -742,6 +782,23 @@ pub mod default_value {
                                 {
                                     a2 = Some(__protocol.read_bool().await?);
                                 }
+                                Some(14)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Map =>
+                                {
+                                    map2 = Some({
+                                        let map_ident = __protocol.read_map_begin().await?;
+                                        let mut val =
+                                            ::pilota::AHashMap::with_capacity(map_ident.size);
+                                        for _ in 0..map_ident.size {
+                                            val.insert(
+                                                __protocol.read_faststr().await?,
+                                                __protocol.read_faststr().await?,
+                                            );
+                                        }
+                                        __protocol.read_map_end().await?;
+                                        val
+                                    });
+                                }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
                                 }
@@ -782,6 +839,9 @@ pub mod default_value {
                     let test_set = test_set.unwrap_or_else(|| {
                         ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)])
                     });
+                    if map2.is_none() {
+                        map2 = Some(::pilota::AHashMap::new());
+                    }
 
                     let data = Self {
                         faststr,
@@ -798,6 +858,7 @@ pub mod default_value {
                         test_map,
                         test_set,
                         a2,
+                        map2,
                     };
                     ::std::result::Result::Ok(data)
                 })
@@ -864,6 +925,16 @@ pub mod default_value {
                         .a2
                         .as_ref()
                         .map_or(0, |value| __protocol.bool_field_len(Some(13), *value))
+                    + self.map2.as_ref().map_or(0, |value| {
+                        __protocol.map_field_len(
+                            Some(14),
+                            ::pilota::thrift::TType::Binary,
+                            ::pilota::thrift::TType::Binary,
+                            value,
+                            |__protocol, key| __protocol.faststr_len(key),
+                            |__protocol, val| __protocol.faststr_len(val),
+                        )
+                    })
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -289,6 +289,7 @@ pub mod default_value {
                         map
                     },
                     test_set: ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]),
+                    a2: Some(true),
                 }
             }
         }
@@ -320,6 +321,8 @@ pub mod default_value {
             pub test_map: ::pilota::AHashMap<::pilota::OrderedFloat<f64>, f64>,
 
             pub test_set: ::pilota::AHashSet<::pilota::OrderedFloat<f64>>,
+
+            pub a2: ::std::option::Option<bool>,
         }
         impl ::pilota::thrift::Message for A {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -394,6 +397,9 @@ pub mod default_value {
                         ::std::result::Result::Ok(())
                     },
                 )?;
+                if let Some(value) = self.a2.as_ref() {
+                    __protocol.write_bool_field(13, *value)?;
+                }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
                 ::std::result::Result::Ok(())
@@ -418,6 +424,7 @@ pub mod default_value {
                 let mut empty = ::pilota::Bytes::from_static("".as_bytes());
                 let mut test_map = None;
                 let mut test_set = None;
+                let mut a2 = Some(true);
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -517,6 +524,9 @@ pub mod default_value {
                                     val
                                 });
                             }
+                            Some(13) if field_ident.field_type == ::pilota::thrift::TType::Bool => {
+                                a2 = Some(__protocol.read_bool()?);
+                            }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
                             }
@@ -570,6 +580,7 @@ pub mod default_value {
                     empty,
                     test_map,
                     test_set,
+                    a2,
                 };
                 ::std::result::Result::Ok(data)
             }
@@ -598,6 +609,7 @@ pub mod default_value {
                     let mut empty = ::pilota::Bytes::from_static("".as_bytes());
                     let mut test_map = None;
                     let mut test_set = None;
+                    let mut a2 = Some(true);
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -725,6 +737,11 @@ pub mod default_value {
                                         val
                                     });
                                 }
+                                Some(13)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Bool =>
+                                {
+                                    a2 = Some(__protocol.read_bool().await?);
+                                }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
                                 }
@@ -780,6 +797,7 @@ pub mod default_value {
                         empty,
                         test_map,
                         test_set,
+                        a2,
                     };
                     ::std::result::Result::Ok(data)
                 })
@@ -842,6 +860,10 @@ pub mod default_value {
                         &self.test_set,
                         |__protocol, el| __protocol.double_len(el.0),
                     )
+                    + self
+                        .a2
+                        .as_ref()
+                        .map_or(0, |value| __protocol.bool_field_len(Some(13), *value))
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/default_value.thrift
+++ b/pilota-build/test_data/thrift/default_value.thrift
@@ -20,6 +20,7 @@ struct A {
     11: required map<double, double> test_map = {1.0: 2.0},
     12: required set<double> test_set = [1.0],
     13: bool a2 = 3,
+    14: map<string, string> map2 = [],
  }
 
 struct C {

--- a/pilota-build/test_data/thrift/default_value.thrift
+++ b/pilota-build/test_data/thrift/default_value.thrift
@@ -19,7 +19,8 @@ struct A {
     10: required binary empty = "",
     11: required map<double, double> test_map = {1.0: 2.0},
     12: required set<double> test_set = [1.0],
-}
+    13: bool a2 = 3,
+ }
 
 struct C {
     1: string off = "off",

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -292,6 +292,7 @@ pub mod multi {
                     },
                     test_set: ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]),
                     a2: Some(true),
+                    map2: Some(::pilota::AHashMap::new()),
                 }
             }
         }
@@ -325,6 +326,9 @@ pub mod multi {
             pub test_set: ::pilota::AHashSet<::pilota::OrderedFloat<f64>>,
 
             pub a2: ::std::option::Option<bool>,
+
+            pub map2:
+                ::std::option::Option<::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>>,
         }
         impl ::pilota::thrift::Message for A {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -402,6 +406,22 @@ pub mod multi {
                 if let Some(value) = self.a2.as_ref() {
                     __protocol.write_bool_field(13, *value)?;
                 }
+                if let Some(value) = self.map2.as_ref() {
+                    __protocol.write_map_field(
+                        14,
+                        ::pilota::thrift::TType::Binary,
+                        ::pilota::thrift::TType::Binary,
+                        &value,
+                        |__protocol, key| {
+                            __protocol.write_faststr((key).clone())?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_faststr((val).clone())?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
                 ::std::result::Result::Ok(())
@@ -427,6 +447,7 @@ pub mod multi {
                 let mut test_map = None;
                 let mut test_set = None;
                 let mut a2 = Some(true);
+                let mut map2 = None;
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -529,6 +550,20 @@ pub mod multi {
                             Some(13) if field_ident.field_type == ::pilota::thrift::TType::Bool => {
                                 a2 = Some(__protocol.read_bool()?);
                             }
+                            Some(14) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                map2 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            __protocol.read_faststr()?,
+                                            __protocol.read_faststr()?,
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
                             }
@@ -567,6 +602,9 @@ pub mod multi {
                 });
                 let test_set = test_set
                     .unwrap_or_else(|| ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]));
+                if map2.is_none() {
+                    map2 = Some(::pilota::AHashMap::new());
+                }
 
                 let data = Self {
                     faststr,
@@ -583,6 +621,7 @@ pub mod multi {
                     test_map,
                     test_set,
                     a2,
+                    map2,
                 };
                 ::std::result::Result::Ok(data)
             }
@@ -612,6 +651,7 @@ pub mod multi {
                     let mut test_map = None;
                     let mut test_set = None;
                     let mut a2 = Some(true);
+                    let mut map2 = None;
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -744,6 +784,23 @@ pub mod multi {
                                 {
                                     a2 = Some(__protocol.read_bool().await?);
                                 }
+                                Some(14)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Map =>
+                                {
+                                    map2 = Some({
+                                        let map_ident = __protocol.read_map_begin().await?;
+                                        let mut val =
+                                            ::pilota::AHashMap::with_capacity(map_ident.size);
+                                        for _ in 0..map_ident.size {
+                                            val.insert(
+                                                __protocol.read_faststr().await?,
+                                                __protocol.read_faststr().await?,
+                                            );
+                                        }
+                                        __protocol.read_map_end().await?;
+                                        val
+                                    });
+                                }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
                                 }
@@ -784,6 +841,9 @@ pub mod multi {
                     let test_set = test_set.unwrap_or_else(|| {
                         ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)])
                     });
+                    if map2.is_none() {
+                        map2 = Some(::pilota::AHashMap::new());
+                    }
 
                     let data = Self {
                         faststr,
@@ -800,6 +860,7 @@ pub mod multi {
                         test_map,
                         test_set,
                         a2,
+                        map2,
                     };
                     ::std::result::Result::Ok(data)
                 })
@@ -866,6 +927,16 @@ pub mod multi {
                         .a2
                         .as_ref()
                         .map_or(0, |value| __protocol.bool_field_len(Some(13), *value))
+                    + self.map2.as_ref().map_or(0, |value| {
+                        __protocol.map_field_len(
+                            Some(14),
+                            ::pilota::thrift::TType::Binary,
+                            ::pilota::thrift::TType::Binary,
+                            value,
+                            |__protocol, key| __protocol.faststr_len(key),
+                            |__protocol, val| __protocol.faststr_len(val),
+                        )
+                    })
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -291,6 +291,7 @@ pub mod multi {
                         map
                     },
                     test_set: ::pilota::AHashSet::from([::pilota::OrderedFloat(1f64)]),
+                    a2: Some(true),
                 }
             }
         }
@@ -322,6 +323,8 @@ pub mod multi {
             pub test_map: ::pilota::AHashMap<::pilota::OrderedFloat<f64>, f64>,
 
             pub test_set: ::pilota::AHashSet<::pilota::OrderedFloat<f64>>,
+
+            pub a2: ::std::option::Option<bool>,
         }
         impl ::pilota::thrift::Message for A {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -396,6 +399,9 @@ pub mod multi {
                         ::std::result::Result::Ok(())
                     },
                 )?;
+                if let Some(value) = self.a2.as_ref() {
+                    __protocol.write_bool_field(13, *value)?;
+                }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
                 ::std::result::Result::Ok(())
@@ -420,6 +426,7 @@ pub mod multi {
                 let mut empty = ::pilota::Bytes::from_static("".as_bytes());
                 let mut test_map = None;
                 let mut test_set = None;
+                let mut a2 = Some(true);
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -519,6 +526,9 @@ pub mod multi {
                                     val
                                 });
                             }
+                            Some(13) if field_ident.field_type == ::pilota::thrift::TType::Bool => {
+                                a2 = Some(__protocol.read_bool()?);
+                            }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
                             }
@@ -572,6 +582,7 @@ pub mod multi {
                     empty,
                     test_map,
                     test_set,
+                    a2,
                 };
                 ::std::result::Result::Ok(data)
             }
@@ -600,6 +611,7 @@ pub mod multi {
                     let mut empty = ::pilota::Bytes::from_static("".as_bytes());
                     let mut test_map = None;
                     let mut test_set = None;
+                    let mut a2 = Some(true);
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -727,6 +739,11 @@ pub mod multi {
                                         val
                                     });
                                 }
+                                Some(13)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Bool =>
+                                {
+                                    a2 = Some(__protocol.read_bool().await?);
+                                }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
                                 }
@@ -782,6 +799,7 @@ pub mod multi {
                         empty,
                         test_map,
                         test_set,
+                        a2,
                     };
                     ::std::result::Result::Ok(data)
                 })
@@ -844,6 +862,10 @@ pub mod multi {
                         &self.test_set,
                         |__protocol, el| __protocol.double_len(el.0),
                     )
+                    + self
+                        .a2
+                        .as_ref()
+                        .map_or(0, |value| __protocol.bool_field_len(Some(13), *value))
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }


### PR DESCRIPTION
```thrift
struct A {
    13: bool a2 = 3,
    14: map<string, string> map2 = [],
}