### PR TITLE
fix: evaluate to dynamic when encountering cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.14"
+version = "0.11.15"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/db.rs
+++ b/pilota-build/src/db.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     symbol::{DefId, FileId},
     tags::Tags,
-    TagId, MAX_RESOLVE_DEPTH,
+    TagId,
 };
 
 #[derive(Default)]
@@ -44,7 +44,7 @@ impl RootDatabase {
             visiting: &mut FxHashSet<DefId>,
             depth: usize,
         ) {
-            if map.contains_key(&def_id) || depth > *MAX_RESOLVE_DEPTH {
+            if map.contains_key(&def_id) {
                 return;
             }
             if !matches!(&*db.item(def_id).unwrap(), rir::Item::Mod(_)) {
@@ -75,7 +75,7 @@ impl RootDatabase {
                                     DefLocation::Fixed(_, _) => false,
                                     DefLocation::Dynamic => true,
                                 })
-                                .unwrap_or_default()
+                                .unwrap_or(true)
                             {
                                 map.insert(def_id, DefLocation::Dynamic);
                                 break;

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -47,13 +47,6 @@ use salsa::Durability;
 pub use symbol::{DefId, IdentName};
 pub use tags::TagId;
 
-lazy_static::lazy_static! {
-    pub(crate) static ref MAX_RESOLVE_DEPTH: usize = std::env::var("MAX_RESOLVE_DEPTH")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(256);
-}
-
 pub trait MakeBackend: Sized {
     type Target: CodegenBackend;
     fn make_backend(self, context: Context) -> Self::Target;


### PR DESCRIPTION
Previously, evaluate it to fixed location will cause incorrect dependencies in some situation.