### PR TITLE
fix: avoid recalculating the location of def_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.15"
+version = "0.11.16"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -54,14 +54,17 @@ where
     }
 
     pub fn group_defs(&self, entry_def_ids: &[DefId]) -> Result<(), anyhow::Error> {
-        let location_map = self.collect_def_ids(entry_def_ids);
+        let location_map = self.collect_def_ids(entry_def_ids, None);
         let entry_map = location_map.iter().into_group_map_by(|item| item.1);
 
         let entry_deps = entry_map
             .iter()
             .map(|(k, v)| {
                 let def_ids = v.iter().map(|i| i.0).copied().collect_vec();
-                let deps = self.collect_def_ids(&def_ids).into_iter().collect_vec();
+                let deps = self
+                    .collect_def_ids(&def_ids, Some(&location_map))
+                    .into_iter()
+                    .collect_vec();
                 (k, deps)
             })
             .collect::<FxHashMap<_, _>>();
@@ -163,8 +166,12 @@ where
         Ok(())
     }
 
-    fn collect_def_ids(&self, input: &[DefId]) -> FxHashMap<DefId, DefLocation> {
-        self.cg.db.collect_def_ids(input)
+    fn collect_def_ids(
+        &self,
+        input: &[DefId],
+        locations: Option<&FxHashMap<DefId, DefLocation>>,
+    ) -> FxHashMap<DefId, DefLocation> {
+        self.cg.db.collect_def_ids(input, locations)
     }
 
     fn create_crate(

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -275,7 +275,7 @@ impl ContextBuilder {
         &self,
         input: &[DefId],
     ) -> FxHashMap<DefId, DefLocation> {
-        self.db.collect_def_ids(input)
+        self.db.collect_def_ids(input, None)
     }
 
     pub(crate) fn keep(&mut self, keep_unknown_fields: Vec<PathBuf>) {


### PR DESCRIPTION
Instead of recalculating with a subset of def_id, we should use the location calculated by all def_id directly