### PR TITLE
fix: use the method def_id as the parent of arg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.17"
+version = "0.11.18"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.17"
+version = "0.11.18"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -349,7 +349,7 @@ impl ContextBuilder {
             common_crate_name,
             names: Default::default(),
         };
-        let mut map: FxHashMap<(Option<DefId>, String), Vec<DefId>> = FxHashMap::default();
+        let mut map: FxHashMap<(Vec<DefId>, String), Vec<DefId>> = FxHashMap::default();
         cx.nodes()
             .iter()
             .for_each(|(def_id, node)| match node.kind {
@@ -360,15 +360,17 @@ impl ContextBuilder {
                         }
                     }
                     let rust_name = cx.item_path(*def_id).join("::");
-                    map.entry((None, rust_name)).or_default().push(*def_id);
+                    map.entry((vec![], rust_name)).or_default().push(*def_id);
                 }
                 _ => {
+                    let mut item_def_ids = vec![];
                     let mut item_def_id = *def_id;
                     while !matches!(cx.node(item_def_id).unwrap().kind, NodeKind::Item(_)) {
-                        item_def_id = cx.node(item_def_id).unwrap().parent.unwrap()
+                        item_def_id = cx.node(item_def_id).unwrap().parent.unwrap();
+                        item_def_ids.push(item_def_id);
                     }
                     let rust_name = cx.rust_name(*def_id).to_string();
-                    map.entry((Some(item_def_id), rust_name))
+                    map.entry((item_def_ids, rust_name))
                         .or_default()
                         .push(*def_id);
                 }

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -610,6 +610,7 @@ impl Resolver {
                     let def_id = self.did_counter.inc_one();
                     let tags_id = self.tags_id_counter.inc_one();
                     self.tags.insert(tags_id, m.tags.clone());
+                    let old_parent = self.parent_node.replace(def_id);
                     let method = Arc::from(Method {
                         def_id,
                         source: MethodSource::Own,
@@ -642,6 +643,7 @@ impl Resolver {
                             .as_ref()
                             .map(|p| self.lower_path(p, Namespace::Ty, true)),
                     });
+                    self.parent_node = old_parent;
                     self.nodes.insert(
                         def_id,
                         self.mk_node(NodeKind::Method(method.clone()), tags_id),


### PR DESCRIPTION
Use service:method:arg as the identification for arg