### PR TITLE
fix: add the default value len when turn on the encode default value feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "ahash",
  "anyhow",

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -29,5 +29,8 @@ fn test_pb_encode_zero_value() {
     a.encode(&mut buf).unwrap();
 
     println!("{:?}", buf);
-    println!("{:?}", buf.freeze().as_ref());
+    // println!("{:?}", buf.freeze().as_ref());
+
+    let parsed_a = zero_value::zero_value::A::decode(buf).unwrap();
+    println!("{:?}", parsed_a);
 }

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2021"
 description = "Pilota is a thrift and protobuf implementation in pure rust with high performance and extensibility."
 documentation = "https://docs.rs/pilota"

--- a/pilota/src/prost/encoding.rs
+++ b/pilota/src/prost/encoding.rs
@@ -1658,15 +1658,21 @@ macro_rules! map {
             KL: Fn(u32, &K) -> usize,
             VL: Fn(u32, &V) -> usize,
         {
+            let mut skip_default_value = false;
+            #[cfg(feature = "pb-encode-default-value")]
+            {
+                skip_default_value = true;
+            }
+
             key_len(tag) * values.len()
                 + values
                     .iter()
                     .map(|(key, val)| {
-                        let len = (if key == &K::default() {
+                        let len = (if key == &K::default() && skip_default_value {
                             0
                         } else {
                             key_encoded_len(1, key)
-                        }) + (if val == val_default {
+                        }) + (if val == val_default && skip_default_value {
                             0
                         } else {
                             val_encoded_len(2, val)


### PR DESCRIPTION
## Motivation
When the pb-encode-default-value feature is turned on, the length calculation is not taken into account, resulting in serialization errors.

## Solution
Don't skip the default value len calculation.