### PR TITLE
fix: calculate default value len when use pb encode default value feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota"
-version = "0.11.6"
+version = "0.11.7"
 edition = "2021"
 description = "Pilota is a thrift and protobuf implementation in pure rust with high performance and extensibility."
 documentation = "https://docs.rs/pilota"

--- a/pilota/src/prost/encoding.rs
+++ b/pilota/src/prost/encoding.rs
@@ -1658,10 +1658,10 @@ macro_rules! map {
             KL: Fn(u32, &K) -> usize,
             VL: Fn(u32, &V) -> usize,
         {
-            let mut skip_default_value = false;
+            let mut skip_default_value = true;
             #[cfg(feature = "pb-encode-default-value")]
             {
-                skip_default_value = true;
+                skip_default_value = false;
             }
 
             key_len(tag) * values.len()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

When the pb-encode-default-value feature is turned on, the length calculation is not taken into account, resulting in serialization errors.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Don't skip the default value len calculation.
