### PR TITLE
fix(pilota-thrift-parser): trim extra whitespace characters at the end of annotation list item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "nom",
 ]

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 description = "Pilota thrift Parser."
 documentation = "https://docs.rs/pilota"

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -51,5 +51,14 @@ mod tests {
     #[test]
     fn test_annotations() {
         let _a = Annotations::parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#).unwrap();
+
+        let input = r#"(
+            cpp.type = "DenseFoo",
+            python.type = "DenseFoo",
+            java.final = "",
+            )"#;
+        let (remain, a) = Annotations::parse(input).unwrap();
+        assert!(remain.is_empty());
+        assert_eq!(a.len(), 3);
     }
 }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -49,7 +49,7 @@ impl Parser for Path {
 }
 
 pub(crate) fn list_separator(input: &str) -> IResult<&str, char> {
-    one_of(",;")(input)
+    map(tuple((one_of(",;"), opt(blank))), |(sep, _)| sep)(input)
 }
 
 fn comment(input: &str) -> IResult<&str, &str> {

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -95,14 +95,8 @@ mod tests {
         let str = r#"struct ImMsgContent {
             1: string user_id (go.tag = 'json:\"user_id,omitempty\"'),
             2: string __files (go.tag = 'json:\"__files,omitempty\"'),
-        }
-        (
-        cpp.type = "DenseFoo",
-        python.type = "DenseFoo",
-        java.final = "",
-        )"#;
-        let (remain, _) = Struct::parse(str).unwrap();
-        assert!(remain.is_empty());
+        }"#;
+        Struct::parse(str).unwrap();
     }
 
     #[test]

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -95,8 +95,14 @@ mod tests {
         let str = r#"struct ImMsgContent {
             1: string user_id (go.tag = 'json:\"user_id,omitempty\"'),
             2: string __files (go.tag = 'json:\"__files,omitempty\"'),
-        }"#;
-        Struct::parse(str).unwrap();
+        }
+        (
+        cpp.type = "DenseFoo",
+        python.type = "DenseFoo",
+        java.final = "",
+        )"#;
+        let (remain, _) = Struct::parse(str).unwrap();
+        assert!(remain.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The previous annotations‘ parser was not compatible with extra null characters at the end of the list. Thus, the [apache thrift test data](https://github.com/apache/thrift/blob/master/test/AnnotationTest.thrift#L27C3-L32C2) would encounter error for its blank after the last list item.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
We will identify and remove whitespace characters at the end of the list item. Considering multiple list parsing scenarios, we choose to remove whitespace characters in the extraction of each list item separator, although these characters may have been extracted in the outer layer.
