### PR TITLE
fix(pilota-thrift-parser): match comment after annotations in EnumValue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "nom",
 ]

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.11.4"
+version = "0.11.5"
 edition = "2021"
 description = "Pilota thrift Parser."
 documentation = "https://docs.rs/pilota"

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -23,8 +23,9 @@ impl Parser for EnumValue {
                 opt(blank),
                 opt(Annotations::parse),
                 opt(list_separator),
+                opt(blank),
             )),
-            |(name, _, value, _, annotations, _)| EnumValue {
+            |(name, _, value, _, annotations, _, _)| EnumValue {
                 name,
                 value,
                 annotations: annotations.unwrap_or_default(),
@@ -66,7 +67,7 @@ mod tests {
         let (_remain, _e) = Enum::parse(
             r#"enum Sex {
                 UNKNOWN = 0,
-                MALE = 1,
+                MALE = 1 (pilota.key="male") // male
                 FEMALE = 2,
             }"#,
         )


### PR DESCRIPTION
When the list_separator is missing in EnumValues, there is no matching for the comment. This PR fixes it.