### PR TITLE
feat: support generate BTreeSet/BTreeMap for thrift set/map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.25"
+version = "0.11.26"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.25"
+version = "0.11.26"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -592,12 +592,12 @@ where
         To avoid problems when generating files for services with similar names, e.g.
         testService and TestService, such names are de-duplicated by adding a number to their nam5e
     */
-    fn generate_unique_name(existing_names: &AHashSet<String>, simple_name: &String) -> String {
+    fn generate_unique_name(existing_names: &AHashSet<String>, simple_name: &str) -> String {
         let mut counter = 1;
-        let mut name = simple_name.clone();
+        let mut name = simple_name.to_string();
         while existing_names.contains(name.to_ascii_lowercase().as_str()) {
             counter += 1;
-            name = format!("{}_{}", simple_name.clone(), counter)
+            name = format!("{}_{}", simple_name, counter)
         }
         name
     }

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -29,7 +29,9 @@ pub enum TyKind {
     Uuid,
     Vec(Arc<Ty>),
     Set(Arc<Ty>),
+    BTreeSet(Arc<Ty>),
     Map(Arc<Ty>, Arc<Ty>),
+    BTreeMap(Arc<Ty>, Arc<Ty>),
     Arc(Arc<Ty>),
     Path(Path),
 }
@@ -77,7 +79,9 @@ pub enum CodegenTy {
     Vec(Arc<CodegenTy>),
     Array(Arc<CodegenTy>, usize),
     Set(Arc<CodegenTy>),
+    BTreeSet(Arc<CodegenTy>),
     Map(Arc<CodegenTy>, Arc<CodegenTy>),
+    BTreeMap(Arc<CodegenTy>, Arc<CodegenTy>),
     Adt(AdtDef),
     Arc(Arc<CodegenTy>),
 }
@@ -89,7 +93,8 @@ impl CodegenTy {
             | CodegenTy::LazyStaticRef(_)
             | CodegenTy::StaticRef(_)
             | CodegenTy::Vec(_)
-            | CodegenTy::Map(_, _) => true,
+            | CodegenTy::Map(_, _)
+            | CodegenTy::BTreeMap(_, _) => true,
             CodegenTy::Adt(AdtDef {
                 did: _,
                 kind: AdtKind::NewType(inner),
@@ -133,11 +138,29 @@ impl CodegenTy {
                 let ty = &**ty;
                 format!("::pilota::AHashSet<{}>", ty.global_path(adt_prefix)).into()
             }
+            CodegenTy::BTreeSet(ty) => {
+                let ty = &**ty;
+                format!(
+                    "::std::collections::BTreeSet<{}>",
+                    ty.global_path(adt_prefix)
+                )
+                .into()
+            }
             CodegenTy::Map(k, v) => {
                 let k = &**k;
                 let v = &**v;
                 format!(
                     "::pilota::AHashMap<{}, {}>",
+                    k.global_path(adt_prefix),
+                    v.global_path(adt_prefix)
+                )
+                .into()
+            }
+            CodegenTy::BTreeMap(k, v) => {
+                let k = &**k;
+                let v = &**v;
+                format!(
+                    "::std::collections::BTreeMap<{}, {}>",
                     k.global_path(adt_prefix),
                     v.global_path(adt_prefix)
                 )
@@ -197,10 +220,19 @@ impl Display for CodegenTy {
                 let ty = &**ty;
                 write!(f, "::pilota::AHashSet<{ty}>")
             }
+            CodegenTy::BTreeSet(ty) => {
+                let ty = &**ty;
+                write!(f, "::std::collections::BTreeSet<{ty}>")
+            }
             CodegenTy::Map(k, v) => {
                 let k = &**k;
                 let v = &**v;
                 write!(f, "::pilota::AHashMap<{k}, {v}>")
+            }
+            CodegenTy::BTreeMap(k, v) => {
+                let k = &**k;
+                let v = &**v;
+                write!(f, "::std::collections::BTreeMap<{k}, {v}>")
             }
             CodegenTy::Adt(def) => with_cx(|cx| {
                 let path = cx.cur_related_item_path(def.did);
@@ -331,10 +363,22 @@ pub trait TyTransformer {
     }
 
     #[inline]
+    fn btree_set(&self, ty: &Ty) -> CodegenTy {
+        CodegenTy::BTreeSet(Arc::from(self.codegen_item_ty(&ty.kind)))
+    }
+
+    #[inline]
     fn map(&self, key: &Ty, value: &Ty) -> CodegenTy {
         let key = self.codegen_item_ty(&key.kind);
         let value = self.codegen_item_ty(&value.kind);
         CodegenTy::Map(Arc::from(key), Arc::from(value))
+    }
+
+    #[inline]
+    fn btree_map(&self, key: &Ty, value: &Ty) -> CodegenTy {
+        let key = self.codegen_item_ty(&key.kind);
+        let value = self.codegen_item_ty(&value.kind);
+        CodegenTy::BTreeMap(Arc::from(key), Arc::from(value))
     }
 
     #[inline]
@@ -368,7 +412,9 @@ pub trait TyTransformer {
             Uuid => self.uuid(),
             Vec(ty) => self.vec(ty),
             Set(ty) => self.set(ty),
+            BTreeSet(ty) => self.btree_set(ty),
             Map(k, v) => self.map(k, v),
+            BTreeMap(k, v) => self.btree_map(k, v),
             Path(path) => self.path(path),
             UInt32 => self.uint32(),
             UInt64 => self.uint64(),
@@ -424,10 +470,27 @@ impl TyTransformer for ConstTyTransformer<'_> {
     }
 
     #[inline]
+    fn btree_set(&self, ty: &Ty) -> CodegenTy {
+        CodegenTy::StaticRef(Arc::from(CodegenTy::BTreeSet(Arc::from(
+            self.dyn_codegen_item_ty(&ty.kind),
+        ))))
+    }
+
+    #[inline]
     fn map(&self, key: &Ty, value: &Ty) -> CodegenTy {
         let key = self.dyn_codegen_item_ty(&key.kind);
         let value = self.dyn_codegen_item_ty(&value.kind);
         CodegenTy::StaticRef(Arc::from(CodegenTy::Map(Arc::from(key), Arc::from(value))))
+    }
+
+    #[inline]
+    fn btree_map(&self, key: &Ty, value: &Ty) -> CodegenTy {
+        let key = self.dyn_codegen_item_ty(&key.kind);
+        let value = self.dyn_codegen_item_ty(&value.kind);
+        CodegenTy::StaticRef(Arc::from(CodegenTy::BTreeMap(
+            Arc::from(key),
+            Arc::from(value),
+        )))
     }
 
     fn get_db(&self) -> &dyn RirDatabase {
@@ -446,7 +509,16 @@ pub(crate) trait Visitor: Sized {
         self.visit(el)
     }
 
+    fn visit_btree_set(&mut self, el: &Ty) {
+        self.visit(el)
+    }
+
     fn visit_map(&mut self, k: &Ty, v: &Ty) {
+        self.visit(k);
+        self.visit(v);
+    }
+
+    fn visit_btree_map(&mut self, k: &Ty, v: &Ty) {
         self.visit(k);
         self.visit(v);
     }
@@ -480,7 +552,9 @@ pub(crate) fn fold_ty<F: Folder>(f: &mut F, ty: &Ty) -> Ty {
         Uuid => TyKind::Uuid,
         Vec(ty) => TyKind::Vec(f.fold_ty(ty).into()),
         Set(ty) => TyKind::Set(f.fold_ty(ty).into()),
+        BTreeSet(ty) => TyKind::BTreeSet(f.fold_ty(ty).into()),
         Map(k, v) => TyKind::Map(fold_ty(f, k).into(), fold_ty(f, v).into()),
+        BTreeMap(k, v) => TyKind::BTreeMap(fold_ty(f, k).into(), fold_ty(f, v).into()),
         Path(path) => TyKind::Path(path.clone()),
         UInt32 => TyKind::UInt32,
         UInt64 => TyKind::UInt64,
@@ -498,7 +572,9 @@ pub(crate) fn walk_ty<V: Visitor>(v: &mut V, ty: &Ty) {
     match &ty.kind {
         Vec(el) => v.visit_vec(el),
         Set(el) => v.visit_set(el),
+        BTreeSet(el) => v.visit_btree_set(el),
         Map(key, value) => v.visit_map(key, value),
+        BTreeMap(key, value) => v.visit_btree_map(key, value),
         Path(p) => v.visit_path(p),
         Arc(p) => v.visit(p),
         _ => {}
@@ -510,7 +586,7 @@ mod tests {
     #[test]
     fn test_global_path() {
         use super::CodegenTy::*;
-        let ty = Vec(std::sync::Arc::new(U8).into());
+        let ty = Vec(std::sync::Arc::new(U8));
         assert_eq!(ty.global_path("adt_prefix"), "::std::vec::Vec<u8>");
 
         let ty = Set(std::sync::Arc::new(U8));

--- a/pilota-build/test_data/thrift/btree.rs
+++ b/pilota-build/test_data/thrift/btree.rs
@@ -1,0 +1,847 @@
+pub mod btree {
+    #![allow(warnings, clippy::all)]
+
+    pub mod btree {
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct A {}
+        impl ::pilota::thrift::Message for A {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "A" };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{thrift::TLengthProtocolExt, Buf};
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `A` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let data = Self {};
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `A` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let data = Self {};
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "A" })
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct TypeA(
+            pub ::std::collections::BTreeMap<::std::collections::BTreeSet<i32>, ::pilota::FastStr>,
+        );
+
+        impl ::std::ops::Deref for TypeA {
+            type Target =
+                ::std::collections::BTreeMap<::std::collections::BTreeSet<i32>, ::pilota::FastStr>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl
+            From<::std::collections::BTreeMap<::std::collections::BTreeSet<i32>, ::pilota::FastStr>>
+            for TypeA
+        {
+            fn from(
+                v: ::std::collections::BTreeMap<
+                    ::std::collections::BTreeSet<i32>,
+                    ::pilota::FastStr,
+                >,
+            ) -> Self {
+                Self(v)
+            }
+        }
+
+        impl ::pilota::thrift::Message for TypeA {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                __protocol.write_btree_map(
+                    ::pilota::thrift::TType::Set,
+                    ::pilota::thrift::TType::Binary,
+                    &(&**self),
+                    |__protocol, key| {
+                        __protocol.write_btree_set(
+                            ::pilota::thrift::TType::I32,
+                            &key,
+                            |__protocol, val| {
+                                __protocol.write_i32(*val)?;
+                                ::std::result::Result::Ok(())
+                            },
+                        )?;
+                        ::std::result::Result::Ok(())
+                    },
+                    |__protocol, val| {
+                        __protocol.write_faststr((val).clone())?;
+                        ::std::result::Result::Ok(())
+                    },
+                )?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{thrift::TLengthProtocolExt, Buf};
+                ::std::result::Result::Ok(TypeA({
+                    let map_ident = __protocol.read_map_begin()?;
+                    let mut val = ::std::collections::BTreeMap::new();
+                    for _ in 0..map_ident.size {
+                        val.insert(
+                            {
+                                let list_ident = __protocol.read_set_begin()?;
+                                let mut val = ::std::collections::BTreeSet::new();
+                                for _ in 0..list_ident.size {
+                                    val.insert(__protocol.read_i32()?);
+                                }
+                                __protocol.read_set_end()?;
+                                val
+                            },
+                            __protocol.read_faststr()?,
+                        );
+                    }
+                    __protocol.read_map_end()?;
+                    val
+                }))
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    ::std::result::Result::Ok(TypeA({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::std::collections::BTreeMap::new();
+                        for _ in 0..map_ident.size {
+                            val.insert(
+                                {
+                                    let list_ident = __protocol.read_set_begin().await?;
+                                    let mut val = ::std::collections::BTreeSet::new();
+                                    for _ in 0..list_ident.size {
+                                        val.insert(__protocol.read_i32().await?);
+                                    }
+                                    __protocol.read_set_end().await?;
+                                    val
+                                },
+                                __protocol.read_faststr().await?,
+                            );
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    }))
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.btree_map_len(
+                    ::pilota::thrift::TType::Set,
+                    ::pilota::thrift::TType::Binary,
+                    &**self,
+                    |__protocol, key| {
+                        __protocol.btree_set_len(
+                            ::pilota::thrift::TType::I32,
+                            key,
+                            |__protocol, el| __protocol.i32_len(*el),
+                        )
+                    },
+                    |__protocol, val| __protocol.faststr_len(val),
+                )
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct B {
+            pub m: ::std::collections::BTreeMap<i32, ::std::vec::Vec<::std::sync::Arc<A>>>,
+
+            pub s: ::std::collections::BTreeSet<i32>,
+
+            pub m2: ::std::collections::BTreeMap<
+                ::std::vec::Vec<
+                    ::std::collections::BTreeMap<::std::collections::BTreeSet<i32>, i32>,
+                >,
+                ::std::collections::BTreeSet<i32>,
+            >,
+        }
+        impl ::pilota::thrift::Message for B {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "B" };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+                __protocol.write_btree_map_field(
+                    1,
+                    ::pilota::thrift::TType::I32,
+                    ::pilota::thrift::TType::List,
+                    &&self.m,
+                    |__protocol, key| {
+                        __protocol.write_i32(*key)?;
+                        ::std::result::Result::Ok(())
+                    },
+                    |__protocol, val| {
+                        __protocol.write_list(
+                            ::pilota::thrift::TType::Struct,
+                            &val,
+                            |__protocol, val| {
+                                __protocol.write_struct(val)?;
+                                ::std::result::Result::Ok(())
+                            },
+                        )?;
+                        ::std::result::Result::Ok(())
+                    },
+                )?;
+                __protocol.write_btree_set_field(
+                    2,
+                    ::pilota::thrift::TType::I32,
+                    &&self.s,
+                    |__protocol, val| {
+                        __protocol.write_i32(*val)?;
+                        ::std::result::Result::Ok(())
+                    },
+                )?;
+                __protocol.write_btree_map_field(
+                    3,
+                    ::pilota::thrift::TType::List,
+                    ::pilota::thrift::TType::Set,
+                    &&self.m2,
+                    |__protocol, key| {
+                        __protocol.write_list(
+                            ::pilota::thrift::TType::Map,
+                            &key,
+                            |__protocol, val| {
+                                __protocol.write_btree_map(
+                                    ::pilota::thrift::TType::Set,
+                                    ::pilota::thrift::TType::I32,
+                                    &val,
+                                    |__protocol, key| {
+                                        __protocol.write_btree_set(
+                                            ::pilota::thrift::TType::I32,
+                                            &key,
+                                            |__protocol, val| {
+                                                __protocol.write_i32(*val)?;
+                                                ::std::result::Result::Ok(())
+                                            },
+                                        )?;
+                                        ::std::result::Result::Ok(())
+                                    },
+                                    |__protocol, val| {
+                                        __protocol.write_i32(*val)?;
+                                        ::std::result::Result::Ok(())
+                                    },
+                                )?;
+                                ::std::result::Result::Ok(())
+                            },
+                        )?;
+                        ::std::result::Result::Ok(())
+                    },
+                    |__protocol, val| {
+                        __protocol.write_btree_set(
+                            ::pilota::thrift::TType::I32,
+                            &val,
+                            |__protocol, val| {
+                                __protocol.write_i32(*val)?;
+                                ::std::result::Result::Ok(())
+                            },
+                        )?;
+                        ::std::result::Result::Ok(())
+                    },
+                )?;
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{thrift::TLengthProtocolExt, Buf};
+
+                let mut var_1 = None;
+                let mut var_2 = None;
+                let mut var_3 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_1 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::std::collections::BTreeMap::new();
+                                    for _ in 0..map_ident.size {
+                                        val.insert(__protocol.read_i32()?, unsafe {
+                                            let list_ident = __protocol.read_list_begin()?;
+                                            let mut val: Vec<::std::sync::Arc<A>> =
+                                                Vec::with_capacity(list_ident.size);
+                                            for i in 0..list_ident.size {
+                                                val.as_mut_ptr().offset(i as isize).write(
+                                                    ::std::sync::Arc::new(
+                                                        ::pilota::thrift::Message::decode(
+                                                            __protocol,
+                                                        )?,
+                                                    ),
+                                                );
+                                            }
+                                            val.set_len(list_ident.size);
+                                            __protocol.read_list_end()?;
+                                            val
+                                        });
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(2) if field_ident.field_type == ::pilota::thrift::TType::Set => {
+                                var_2 = Some({
+                                    let list_ident = __protocol.read_set_begin()?;
+                                    let mut val = ::std::collections::BTreeSet::new();
+                                    for _ in 0..list_ident.size {
+                                        val.insert(__protocol.read_i32()?);
+                                    }
+                                    __protocol.read_set_end()?;
+                                    val
+                                });
+                            }
+                            Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_3 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::std::collections::BTreeMap::new();
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            unsafe {
+                                                let list_ident = __protocol.read_list_begin()?;
+                                                let mut val: Vec<
+                                                    ::std::collections::BTreeMap<
+                                                        ::std::collections::BTreeSet<i32>,
+                                                        i32,
+                                                    >,
+                                                > = Vec::with_capacity(list_ident.size);
+                                                for i in 0..list_ident.size {
+                                                    val.as_mut_ptr().offset(i as isize).write({
+                        let map_ident = __protocol.read_map_begin()?;
+                        let mut val = ::std::collections::BTreeMap::new();
+                        for _ in 0..map_ident.size {
+                            val.insert({let list_ident = __protocol.read_set_begin()?;
+                    let mut val = ::std::collections::BTreeSet::new();
+                    for _ in 0..list_ident.size {
+                        val.insert(__protocol.read_i32()?);
+                    };
+                    __protocol.read_set_end()?;
+                    val}, __protocol.read_i32()?);
+                        }
+                        __protocol.read_map_end()?;
+                        val
+                    });
+                                                }
+                                                val.set_len(list_ident.size);
+                                                __protocol.read_list_end()?;
+                                                val
+                                            },
+                                            {
+                                                let list_ident = __protocol.read_set_begin()?;
+                                                let mut val = ::std::collections::BTreeSet::new();
+                                                for _ in 0..list_ident.size {
+                                                    val.insert(__protocol.read_i32()?);
+                                                }
+                                                __protocol.read_set_end()?;
+                                                val
+                                            },
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `B` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field m is required".to_string(),
+                    ));
+                };
+                let Some(var_2) = var_2 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field s is required".to_string(),
+                    ));
+                };
+                let Some(var_3) = var_3 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field m2 is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    m: var_1,
+                    s: var_2,
+                    m2: var_3,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = None;
+                    let mut var_3 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_1 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::std::collections::BTreeMap::new();
+                        for _ in 0..map_ident.size {
+                            val.insert(__protocol.read_i32().await?, {
+                            let list_ident = __protocol.read_list_begin().await?;
+                            let mut val = Vec::with_capacity(list_ident.size);
+                            for _ in 0..list_ident.size {
+                                val.push(::std::sync::Arc::new(<A as ::pilota::thrift::Message>::decode_async(__protocol).await?));
+                            };
+                            __protocol.read_list_end().await?;
+                            val
+                        });
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::Set  => {
+                    var_2 = Some({let list_ident = __protocol.read_set_begin().await?;
+                    let mut val = ::std::collections::BTreeSet::new();
+                    for _ in 0..list_ident.size {
+                        val.insert(__protocol.read_i32().await?);
+                    };
+                    __protocol.read_set_end().await?;
+                    val});
+
+                },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_3 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::std::collections::BTreeMap::new();
+                        for _ in 0..map_ident.size {
+                            val.insert({
+                            let list_ident = __protocol.read_list_begin().await?;
+                            let mut val = Vec::with_capacity(list_ident.size);
+                            for _ in 0..list_ident.size {
+                                val.push({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::std::collections::BTreeMap::new();
+                        for _ in 0..map_ident.size {
+                            val.insert({let list_ident = __protocol.read_set_begin().await?;
+                    let mut val = ::std::collections::BTreeSet::new();
+                    for _ in 0..list_ident.size {
+                        val.insert(__protocol.read_i32().await?);
+                    };
+                    __protocol.read_set_end().await?;
+                    val}, __protocol.read_i32().await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+                            };
+                            __protocol.read_list_end().await?;
+                            val
+                        }, {let list_ident = __protocol.read_set_begin().await?;
+                    let mut val = ::std::collections::BTreeSet::new();
+                    for _ in 0..list_ident.size {
+                        val.insert(__protocol.read_i32().await?);
+                    };
+                    __protocol.read_set_end().await?;
+                    val});
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `B` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field m is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_2) = var_2 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field s is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_3) = var_3 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field m2 is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        m: var_1,
+                        s: var_2,
+                        m2: var_3,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "B" })
+                    + __protocol.btree_map_field_len(
+                        Some(1),
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::List,
+                        &self.m,
+                        |__protocol, key| __protocol.i32_len(*key),
+                        |__protocol, val| {
+                            __protocol.list_len(
+                                ::pilota::thrift::TType::Struct,
+                                val,
+                                |__protocol, el| __protocol.struct_len(el),
+                            )
+                        },
+                    )
+                    + __protocol.btree_set_field_len(
+                        Some(2),
+                        ::pilota::thrift::TType::I32,
+                        &self.s,
+                        |__protocol, el| __protocol.i32_len(*el),
+                    )
+                    + __protocol.btree_map_field_len(
+                        Some(3),
+                        ::pilota::thrift::TType::List,
+                        ::pilota::thrift::TType::Set,
+                        &self.m2,
+                        |__protocol, key| {
+                            __protocol.list_len(
+                                ::pilota::thrift::TType::Map,
+                                key,
+                                |__protocol, el| {
+                                    __protocol.btree_map_len(
+                                        ::pilota::thrift::TType::Set,
+                                        ::pilota::thrift::TType::I32,
+                                        el,
+                                        |__protocol, key| {
+                                            __protocol.btree_set_len(
+                                                ::pilota::thrift::TType::I32,
+                                                key,
+                                                |__protocol, el| __protocol.i32_len(*el),
+                                            )
+                                        },
+                                        |__protocol, val| __protocol.i32_len(*val),
+                                    )
+                                },
+                            )
+                        },
+                        |__protocol, val| {
+                            __protocol.btree_set_len(
+                                ::pilota::thrift::TType::I32,
+                                val,
+                                |__protocol, el| __protocol.i32_len(*el),
+                            )
+                        },
+                    )
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        pub static TEST_MAP_LIST: ::std::sync::LazyLock<
+            ::std::collections::BTreeMap<i32, ::std::vec::Vec<&'static str>>,
+        > = ::std::sync::LazyLock::new(|| {
+            let mut map = ::std::collections::BTreeMap::new();
+            map.insert(1i32, ::std::vec!["hello"]);
+            map
+        });
+
+        pub static TEST_MAP: ::std::sync::LazyLock<
+            ::std::collections::BTreeMap<Index, &'static str>,
+        > = ::std::sync::LazyLock::new(|| {
+            let mut map = ::std::collections::BTreeMap::new();
+            map.insert(Index::A, "hello");
+            map.insert(Index::B, "world");
+            map
+        });
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
+        #[derivative(Default)]
+        #[derive(Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Index(i32);
+
+        impl Index {
+            pub const A: Self = Self(0);
+            pub const B: Self = Self(1);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
+
+            pub fn to_string(&self) -> ::std::string::String {
+                match self {
+                    Self(0) => ::std::string::String::from("A"),
+                    Self(1) => ::std::string::String::from("B"),
+                    Self(val) => val.to_string(),
+                }
+            }
+        }
+
+        impl ::std::convert::From<i32> for Index {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
+
+        impl ::std::convert::From<Index> for i32 {
+            fn from(value: Index) -> i32 {
+                value.0
+            }
+        }
+
+        impl ::pilota::thrift::Message for Index {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                __protocol.write_i32(self.inner())?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{thrift::TLengthProtocolExt, Buf};
+                let value = __protocol.read_i32()?;
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Index, value: {}", value),
+                        )
+                    },
+                )?)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let value = __protocol.read_i32().await?;
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Index, value: {}", value),
+                            )
+                        },
+                    )?)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.i32_len(self.inner())
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift/btree.thrift
+++ b/pilota-build/test_data/thrift/btree.thrift
@@ -1,0 +1,25 @@
+struct A {
+
+}
+
+struct B {
+    1: required map<i32, list<A>> m(pilota.rust_type = "btree", pilota.rust_wrapper_arc = "true"),
+    2: required set<i32> s(pilota.rust_type = "btree"),
+    3: required map<list<map<set<i32>, i32>>, set<i32>> m2(pilota.rust_type = "btree"),
+}
+
+const map<i32, list<string>> TEST_MAP_LIST = {
+    1: ["hello"]
+}(pilota.rust_type = "btree")
+
+enum Index {
+    A = 0,
+    B = 1,
+}
+
+const map<Index, string> TEST_MAP = {
+    Index.A: "hello",
+    Index.B: "world",
+}(pilota.rust_type = "btree")
+
+typedef map<set<i32>, string> TypeA(pilota.rust_type = "btree")

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota"
-version = "0.11.7"
+version = "0.11.8"
 edition = "2021"
 description = "Pilota is a thrift and protobuf implementation in pure rust with high performance and extensibility."
 documentation = "https://docs.rs/pilota"


### PR DESCRIPTION
Support generate BTreeMap and BTreeSet by pilota annotations, for which implements PartialEq, Eq, PartialOrd, Ord that makes it able to be used in set/map.

```thrift
struct B {
    1: required map<i32, list<A>> m(pilota.rust_type = "btree", pilota.rust_wrapper_arc = "true"),
    2: required set<i32> s(pilota.rust_type = "btree"),
    3: required map<list<map<set<i32>, i32>>, set<i32>> m2(pilota.rust_type = "btree"),
}

const map<i32, list<string>> TEST_MAP_LIST = {
    1: ["hello"]
}(pilota.rust_type = "btree")

typedef map<set<i32>, string> TypeA(pilota.rust_type = "btree")
```
