### PR TITLE
fix: remove dependency on derivative

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,28 +308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-where"
-version = "1.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "diffy"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,8 +346,6 @@ dependencies = [
  "anyhow",
  "criterion",
  "dashmap 5.5.3",
- "derivative",
- "derive-where",
  "diffy",
  "faststr",
  "heck 0.5.0",
@@ -860,7 +836,6 @@ dependencies = [
  "async-recursion",
  "bytes",
  "criterion",
- "derivative",
  "faststr",
  "integer-encoding",
  "lazy_static",
@@ -883,8 +858,6 @@ dependencies = [
  "anyhow",
  "criterion",
  "dashmap 6.1.0",
- "derivative",
- "derive-where",
  "diffy",
  "faststr",
  "heck 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "diffy"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +883,7 @@ dependencies = [
  "criterion",
  "dashmap 6.1.0",
  "derivative",
+ "derive-where",
  "diffy",
  "faststr",
  "heck 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
  "criterion",
  "dashmap 5.5.3",
  "derivative",
+ "derive-where",
  "diffy",
  "faststr",
  "heck 0.5.0",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -51,6 +51,7 @@ faststr = "0.2"
 
 tokio = { version = "1", features = ["io-util"] }
 derivative = "2"
+derive-where = "1.2.7"
 tempfile = "3"
 diffy = "0.4"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -50,8 +50,6 @@ faststr = "0.2"
 [dev-dependencies]
 
 tokio = { version = "1", features = ["io-util"] }
-derivative = "2"
-derive-where = "1.2.7"
 tempfile = "3"
 diffy = "0.4"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -51,6 +51,7 @@ faststr = "0.2"
 pilota = { path = "../pilota" }
 tokio = { version = "1", features = ["io-util"] }
 derivative = "2"
+derive-where = "1.2.7"
 tempfile = "3"
 diffy = "0.4"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -50,8 +50,6 @@ faststr = "0.2"
 [dev-dependencies]
 pilota = { path = "../pilota" }
 tokio = { version = "1", features = ["io-util"] }
-derivative = "2"
-derive-where = "1.2.7"
 tempfile = "3"
 diffy = "0.4"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -410,14 +410,14 @@ impl Plugin for ImplDefaultPlugin {
                         let fields = first_variant
                             .fields
                             .iter()
-                            .map(|_| "Default::default()".to_string())
+                            .map(|_| "::std::default::Default::default()".to_string())
                             .join(",\n");
 
                         cx.with_adjust_mut(def_id, |adj| {
                             adj.add_nested_item(
                                 format!(
                                     r#"
-                                    impl Default for {enum_name} {{
+                                    impl ::std::default::Default for {enum_name} {{
                                         fn default() -> Self {{
                                             {enum_name}::{variant_name} ({fields})
                                         }}

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     middle::context::tls::CUR_ITEM,
     rir::{EnumVariant, Field, Item, NodeKind},
     symbol::DefId,
-    ty::{self, Ty, TyKind, Visitor},
+    ty::{self, Ty, Visitor},
     Context,
 };
 

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     middle::context::tls::CUR_ITEM,
     rir::{EnumVariant, Field, Item, NodeKind},
     symbol::DefId,
-    ty::{self, Ty, Visitor},
+    ty::{self, Ty, TyKind, Visitor},
     Context,
 };
 
@@ -391,18 +391,42 @@ impl Plugin for ImplDefaultPlugin {
                 cx.with_adjust_mut(def_id, |adj| adj.add_attrs(&["#[derive(Default)]".into()]))
             }
             Item::Enum(e) => {
-                if !e.variants.is_empty() {
-                    cx.with_adjust_mut(def_id, |adj| {
-                        adj.add_attrs(&[
-                            "#[derive(::pilota::derivative::Derivative)]".into(),
-                            "#[derivative(Default)]".into(),
-                        ]);
-                    });
+                if let Some(first_variant) = e.variants.first() {
+                    let is_unit_variant = first_variant.fields.is_empty();
+                    if is_unit_variant {
+                        cx.with_adjust_mut(def_id, |adj| {
+                            adj.add_attrs(&["#[derive(Default)]".into()]);
+                        });
 
-                    if let Some(v) = e.variants.first() {
-                        cx.with_adjust_mut(v.did, |adj| {
-                            adj.add_attrs(&["#[derivative(Default)]".into()]);
-                        })
+                        if let Some(v) = e.variants.first() {
+                            cx.with_adjust_mut(v.did, |adj| {
+                                adj.add_attrs(&["#[default]".into()]);
+                            })
+                        }
+                    } else {
+                        // for non unit variant, we need to impl Default for the enum
+                        let enum_name = cx.rust_name(def_id);
+                        let variant_name = cx.rust_name(first_variant.did);
+                        let fields = first_variant
+                            .fields
+                            .iter()
+                            .map(|_| "Default::default()".to_string())
+                            .join(",\n");
+
+                        cx.with_adjust_mut(def_id, |adj| {
+                            adj.add_nested_item(
+                                format!(
+                                    r#"
+                                    impl Default for {enum_name} {{
+                                        fn default() -> Self {{
+                                            {enum_name}::{variant_name} ({fields})
+                                        }}
+                                    }}
+                                "#
+                                )
+                                .into(),
+                            )
+                        });
                     }
                 }
             }

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -195,9 +195,16 @@ pub mod serde {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize)]
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            Default,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+        )]
         #[serde(untagged)]
         #[serde(transparent)]
         #[derive(Clone, PartialEq, Copy)]

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -84,9 +84,7 @@ pub mod nested_message {
     }
 
     pub mod tt1 {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Label(i32);
 

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -97,11 +97,14 @@ pub mod oneof {
     }
 
     pub mod test {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for Test {
+            fn default() -> Self {
+                Test::A(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum Test {
-            #[derivative(Default)]
             A(::pilota::FastStr),
 
             B(i32),
@@ -168,11 +171,13 @@ pub mod oneof {
                 ::core::result::Result::Ok(())
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for Type {
+            fn default() -> Self {
+                Type::S(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum Type {
-            #[derivative(Default)]
             S(::pilota::FastStr),
 
             I(i32),

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -98,9 +98,9 @@ pub mod oneof {
 
     pub mod test {
 
-        impl Default for Test {
+        impl ::std::default::Default for Test {
             fn default() -> Self {
-                Test::A(Default::default())
+                Test::A(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -171,9 +171,9 @@ pub mod oneof {
                 ::core::result::Result::Ok(())
             }
         }
-        impl Default for Type {
+        impl ::std::default::Default for Type {
             fn default() -> Self {
-                Type::S(Default::default())
+                Type::S(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/apache.rs
+++ b/pilota-build/test_data/thrift/apache.rs
@@ -819,9 +819,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMultiExceptionException {
+        impl ::std::default::Default for ThriftTestTestMultiExceptionException {
             fn default() -> Self {
-                ThriftTestTestMultiExceptionException::Err1(Default::default())
+                ThriftTestTestMultiExceptionException::Err1(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1278,9 +1278,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMultiResultRecv {
+        impl ::std::default::Default for ThriftTestTestMultiResultRecv {
             fn default() -> Self {
-                ThriftTestTestMultiResultRecv::Ok(Default::default())
+                ThriftTestTestMultiResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1740,9 +1740,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestEnumResultRecv {
+        impl ::std::default::Default for ThriftTestTestEnumResultRecv {
             fn default() -> Self {
-                ThriftTestTestEnumResultRecv::Ok(Default::default())
+                ThriftTestTestEnumResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1884,9 +1884,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestOnewayResultSend {
+        impl ::std::default::Default for ThriftTestTestOnewayResultSend {
             fn default() -> Self {
-                ThriftTestTestOnewayResultSend::Ok(Default::default())
+                ThriftTestTestOnewayResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -2138,9 +2138,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMapResultRecv {
+        impl ::std::default::Default for ThriftTestTestMapResultRecv {
             fn default() -> Self {
-                ThriftTestTestMapResultRecv::Ok(Default::default())
+                ThriftTestTestMapResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -2532,9 +2532,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestBinaryResultRecv {
+        impl ::std::default::Default for ThriftTestTestBinaryResultRecv {
             fn default() -> Self {
-                ThriftTestTestBinaryResultRecv::Ok(Default::default())
+                ThriftTestTestBinaryResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -2672,9 +2672,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for SecondServiceSecondtestStringResultSend {
+        impl ::std::default::Default for SecondServiceSecondtestStringResultSend {
             fn default() -> Self {
-                SecondServiceSecondtestStringResultSend::Ok(Default::default())
+                SecondServiceSecondtestStringResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -2815,9 +2815,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestByteResultRecv {
+        impl ::std::default::Default for ThriftTestTestByteResultRecv {
             fn default() -> Self {
-                ThriftTestTestByteResultRecv::Ok(Default::default())
+                ThriftTestTestByteResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -3105,9 +3105,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMapMapResultSend {
+        impl ::std::default::Default for ThriftTestTestMapMapResultSend {
             fn default() -> Self {
-                ThriftTestTestMapMapResultSend::Ok(Default::default())
+                ThriftTestTestMapMapResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -3536,9 +3536,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestSetResultSend {
+        impl ::std::default::Default for ThriftTestTestSetResultSend {
             fn default() -> Self {
-                ThriftTestTestSetResultSend::Ok(Default::default())
+                ThriftTestTestSetResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -3709,9 +3709,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestStructResultSend {
+        impl ::std::default::Default for ThriftTestTestStructResultSend {
             fn default() -> Self {
-                ThriftTestTestStructResultSend::Ok(Default::default())
+                ThriftTestTestStructResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -4284,9 +4284,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestI64ResultSend {
+        impl ::std::default::Default for ThriftTestTestI64ResultSend {
             fn default() -> Self {
-                ThriftTestTestI64ResultSend::Ok(Default::default())
+                ThriftTestTestI64ResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -4611,9 +4611,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestStringResultSend {
+        impl ::std::default::Default for ThriftTestTestStringResultSend {
             fn default() -> Self {
-                ThriftTestTestStringResultSend::Ok(Default::default())
+                ThriftTestTestStringResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -6726,9 +6726,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestInsanityResultRecv {
+        impl ::std::default::Default for ThriftTestTestInsanityResultRecv {
             fn default() -> Self {
-                ThriftTestTestInsanityResultRecv::Ok(Default::default())
+                ThriftTestTestInsanityResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -7315,9 +7315,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestListResultRecv {
+        impl ::std::default::Default for ThriftTestTestListResultRecv {
             fn default() -> Self {
-                ThriftTestTestListResultRecv::Ok(Default::default())
+                ThriftTestTestListResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -7605,9 +7605,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestNestResultRecv {
+        impl ::std::default::Default for ThriftTestTestNestResultRecv {
             fn default() -> Self {
-                ThriftTestTestNestResultRecv::Ok(Default::default())
+                ThriftTestTestNestResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -7960,9 +7960,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestDoubleResultRecv {
+        impl ::std::default::Default for ThriftTestTestDoubleResultRecv {
             fn default() -> Self {
-                ThriftTestTestDoubleResultRecv::Ok(Default::default())
+                ThriftTestTestDoubleResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Debug, Clone, PartialEq)]
@@ -8100,9 +8100,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestBoolResultRecv {
+        impl ::std::default::Default for ThriftTestTestBoolResultRecv {
             fn default() -> Self {
-                ThriftTestTestBoolResultRecv::Ok(Default::default())
+                ThriftTestTestBoolResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -8473,9 +8473,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestTypedefResultSend {
+        impl ::std::default::Default for ThriftTestTestTypedefResultSend {
             fn default() -> Self {
-                ThriftTestTestTypedefResultSend::Ok(Default::default())
+                ThriftTestTestTypedefResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -8617,9 +8617,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestStringMapResultSend {
+        impl ::std::default::Default for ThriftTestTestStringMapResultSend {
             fn default() -> Self {
-                ThriftTestTestStringMapResultSend::Ok(Default::default())
+                ThriftTestTestStringMapResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -8954,9 +8954,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestUuidResultSend {
+        impl ::std::default::Default for ThriftTestTestUuidResultSend {
             fn default() -> Self {
-                ThriftTestTestUuidResultSend::Ok(Default::default())
+                ThriftTestTestUuidResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -9292,9 +9292,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestI32ResultSend {
+        impl ::std::default::Default for ThriftTestTestI32ResultSend {
             fn default() -> Self {
-                ThriftTestTestI32ResultSend::Ok(Default::default())
+                ThriftTestTestI32ResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -9432,9 +9432,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestVoidResultSend {
+        impl ::std::default::Default for ThriftTestTestVoidResultSend {
             fn default() -> Self {
-                ThriftTestTestVoidResultSend::Ok(Default::default())
+                ThriftTestTestVoidResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -10049,9 +10049,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestOnewayResultRecv {
+        impl ::std::default::Default for ThriftTestTestOnewayResultRecv {
             fn default() -> Self {
-                ThriftTestTestOnewayResultRecv::Ok(Default::default())
+                ThriftTestTestOnewayResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -11173,9 +11173,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for SecondServiceSecondtestStringResultRecv {
+        impl ::std::default::Default for SecondServiceSecondtestStringResultRecv {
             fn default() -> Self {
-                SecondServiceSecondtestStringResultRecv::Ok(Default::default())
+                SecondServiceSecondtestStringResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -11649,9 +11649,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestExceptionException {
+        impl ::std::default::Default for ThriftTestTestExceptionException {
             fn default() -> Self {
-                ThriftTestTestExceptionException::Err1(Default::default())
+                ThriftTestTestExceptionException::Err1(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -11943,9 +11943,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMapMapResultRecv {
+        impl ::std::default::Default for ThriftTestTestMapMapResultRecv {
             fn default() -> Self {
-                ThriftTestTestMapMapResultRecv::Ok(Default::default())
+                ThriftTestTestMapMapResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -12515,9 +12515,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestSetResultRecv {
+        impl ::std::default::Default for ThriftTestTestSetResultRecv {
             fn default() -> Self {
-                ThriftTestTestSetResultRecv::Ok(Default::default())
+                ThriftTestTestSetResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -12836,9 +12836,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestStructResultRecv {
+        impl ::std::default::Default for ThriftTestTestStructResultRecv {
             fn default() -> Self {
-                ThriftTestTestStructResultRecv::Ok(Default::default())
+                ThriftTestTestStructResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -13220,9 +13220,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestI64ResultRecv {
+        impl ::std::default::Default for ThriftTestTestI64ResultRecv {
             fn default() -> Self {
-                ThriftTestTestI64ResultRecv::Ok(Default::default())
+                ThriftTestTestI64ResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -13360,9 +13360,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestStringResultRecv {
+        impl ::std::default::Default for ThriftTestTestStringResultRecv {
             fn default() -> Self {
-                ThriftTestTestStringResultRecv::Ok(Default::default())
+                ThriftTestTestStringResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -13500,9 +13500,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMultiResultSend {
+        impl ::std::default::Default for ThriftTestTestMultiResultSend {
             fn default() -> Self {
-                ThriftTestTestMultiResultSend::Ok(Default::default())
+                ThriftTestTestMultiResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -14003,9 +14003,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestEnumResultSend {
+        impl ::std::default::Default for ThriftTestTestEnumResultSend {
             fn default() -> Self {
-                ThriftTestTestEnumResultSend::Ok(Default::default())
+                ThriftTestTestEnumResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -14298,9 +14298,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMapResultSend {
+        impl ::std::default::Default for ThriftTestTestMapResultSend {
             fn default() -> Self {
-                ThriftTestTestMapResultSend::Ok(Default::default())
+                ThriftTestTestMapResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -14482,9 +14482,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestExceptionResultSend {
+        impl ::std::default::Default for ThriftTestTestExceptionResultSend {
             fn default() -> Self {
-                ThriftTestTestExceptionResultSend::Ok(Default::default())
+                ThriftTestTestExceptionResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -15140,9 +15140,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestBinaryResultSend {
+        impl ::std::default::Default for ThriftTestTestBinaryResultSend {
             fn default() -> Self {
-                ThriftTestTestBinaryResultSend::Ok(Default::default())
+                ThriftTestTestBinaryResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -15430,9 +15430,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestByteResultSend {
+        impl ::std::default::Default for ThriftTestTestByteResultSend {
             fn default() -> Self {
-                ThriftTestTestByteResultSend::Ok(Default::default())
+                ThriftTestTestByteResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -15570,9 +15570,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMultiExceptionResultRecv {
+        impl ::std::default::Default for ThriftTestTestMultiExceptionResultRecv {
             fn default() -> Self {
-                ThriftTestTestMultiExceptionResultRecv::Ok(Default::default())
+                ThriftTestTestMultiExceptionResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -17655,9 +17655,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestExceptionResultRecv {
+        impl ::std::default::Default for ThriftTestTestExceptionResultRecv {
             fn default() -> Self {
-                ThriftTestTestExceptionResultRecv::Ok(Default::default())
+                ThriftTestTestExceptionResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -18142,9 +18142,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestTypedefResultRecv {
+        impl ::std::default::Default for ThriftTestTestTypedefResultRecv {
             fn default() -> Self {
-                ThriftTestTestTypedefResultRecv::Ok(Default::default())
+                ThriftTestTestTypedefResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -18433,9 +18433,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestStringMapResultRecv {
+        impl ::std::default::Default for ThriftTestTestStringMapResultRecv {
             fn default() -> Self {
-                ThriftTestTestStringMapResultRecv::Ok(Default::default())
+                ThriftTestTestStringMapResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -18620,9 +18620,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestUuidResultRecv {
+        impl ::std::default::Default for ThriftTestTestUuidResultRecv {
             fn default() -> Self {
-                ThriftTestTestUuidResultRecv::Ok(Default::default())
+                ThriftTestTestUuidResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -19251,9 +19251,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestI32ResultRecv {
+        impl ::std::default::Default for ThriftTestTestI32ResultRecv {
             fn default() -> Self {
-                ThriftTestTestI32ResultRecv::Ok(Default::default())
+                ThriftTestTestI32ResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -19391,9 +19391,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestMultiExceptionResultSend {
+        impl ::std::default::Default for ThriftTestTestMultiExceptionResultSend {
             fn default() -> Self {
-                ThriftTestTestMultiExceptionResultSend::Ok(Default::default())
+                ThriftTestTestMultiExceptionResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -19619,9 +19619,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestVoidResultRecv {
+        impl ::std::default::Default for ThriftTestTestVoidResultRecv {
             fn default() -> Self {
-                ThriftTestTestVoidResultRecv::Ok(Default::default())
+                ThriftTestTestVoidResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -19723,9 +19723,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestInsanityResultSend {
+        impl ::std::default::Default for ThriftTestTestInsanityResultSend {
             fn default() -> Self {
-                ThriftTestTestInsanityResultSend::Ok(Default::default())
+                ThriftTestTestInsanityResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -20162,9 +20162,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestListResultSend {
+        impl ::std::default::Default for ThriftTestTestListResultSend {
             fn default() -> Self {
-                ThriftTestTestListResultSend::Ok(Default::default())
+                ThriftTestTestListResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -20523,9 +20523,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestNestResultSend {
+        impl ::std::default::Default for ThriftTestTestNestResultSend {
             fn default() -> Self {
-                ThriftTestTestNestResultSend::Ok(Default::default())
+                ThriftTestTestNestResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -20958,9 +20958,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestDoubleResultSend {
+        impl ::std::default::Default for ThriftTestTestDoubleResultSend {
             fn default() -> Self {
-                ThriftTestTestDoubleResultSend::Ok(Default::default())
+                ThriftTestTestDoubleResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Debug, Clone, PartialEq)]
@@ -21249,9 +21249,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ThriftTestTestBoolResultSend {
+        impl ::std::default::Default for ThriftTestTestBoolResultSend {
             fn default() -> Self {
-                ThriftTestTestBoolResultSend::Ok(Default::default())
+                ThriftTestTestBoolResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -21389,9 +21389,9 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for SomeUnion {
+        impl ::std::default::Default for SomeUnion {
             fn default() -> Self {
-                SomeUnion::MapThing(Default::default())
+                SomeUnion::MapThing(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/apache.rs
+++ b/pilota-build/test_data/thrift/apache.rs
@@ -2,9 +2,7 @@ pub mod apache {
     #![allow(warnings, clippy::all)]
 
     pub mod apache {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Numberz(i32);
 
@@ -821,11 +819,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMultiExceptionException {
+            fn default() -> Self {
+                ThriftTestTestMultiExceptionException::Err1(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMultiExceptionException {
-            #[derivative(Default)]
             Err1(Xception),
 
             Err2(Xception2),
@@ -1278,11 +1278,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMultiResultRecv {
+            fn default() -> Self {
+                ThriftTestTestMultiResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMultiResultRecv {
-            #[derivative(Default)]
             Ok(Xtruct),
         }
 
@@ -1738,11 +1740,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestEnumResultRecv {
+            fn default() -> Self {
+                ThriftTestTestEnumResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestEnumResultRecv {
-            #[derivative(Default)]
             Ok(Numberz),
         }
 
@@ -1880,11 +1884,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestOnewayResultSend {
+            fn default() -> Self {
+                ThriftTestTestOnewayResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestOnewayResultSend {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -2132,11 +2138,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMapResultRecv {
+            fn default() -> Self {
+                ThriftTestTestMapResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMapResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::AHashMap<i32, i32>),
         }
 
@@ -2524,11 +2532,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestBinaryResultRecv {
+            fn default() -> Self {
+                ThriftTestTestBinaryResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestBinaryResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::Bytes),
         }
 
@@ -2662,11 +2672,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for SecondServiceSecondtestStringResultSend {
+            fn default() -> Self {
+                SecondServiceSecondtestStringResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum SecondServiceSecondtestStringResultSend {
-            #[derivative(Default)]
             Ok(::pilota::FastStr),
         }
 
@@ -2803,11 +2815,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestByteResultRecv {
+            fn default() -> Self {
+                ThriftTestTestByteResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestByteResultRecv {
-            #[derivative(Default)]
             Ok(i8),
         }
 
@@ -3091,11 +3105,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMapMapResultSend {
+            fn default() -> Self {
+                ThriftTestTestMapMapResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMapMapResultSend {
-            #[derivative(Default)]
             Ok(::pilota::AHashMap<i32, ::pilota::AHashMap<i32, i32>>),
         }
 
@@ -3520,11 +3536,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestSetResultSend {
+            fn default() -> Self {
+                ThriftTestTestSetResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestSetResultSend {
-            #[derivative(Default)]
             Ok(::pilota::AHashSet<i32>),
         }
 
@@ -3691,11 +3709,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestStructResultSend {
+            fn default() -> Self {
+                ThriftTestTestStructResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestStructResultSend {
-            #[derivative(Default)]
             Ok(Xtruct),
         }
 
@@ -4264,11 +4284,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestI64ResultSend {
+            fn default() -> Self {
+                ThriftTestTestI64ResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestI64ResultSend {
-            #[derivative(Default)]
             Ok(i64),
         }
 
@@ -4589,11 +4611,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestStringResultSend {
+            fn default() -> Self {
+                ThriftTestTestStringResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestStringResultSend {
-            #[derivative(Default)]
             Ok(::pilota::FastStr),
         }
 
@@ -6702,11 +6726,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestInsanityResultRecv {
+            fn default() -> Self {
+                ThriftTestTestInsanityResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestInsanityResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::AHashMap<UserId, ::pilota::AHashMap<Numberz, Insanity>>),
         }
 
@@ -7289,11 +7315,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestListResultRecv {
+            fn default() -> Self {
+                ThriftTestTestListResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestListResultRecv {
-            #[derivative(Default)]
             Ok(::std::vec::Vec<i32>),
         }
 
@@ -7577,11 +7605,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestNestResultRecv {
+            fn default() -> Self {
+                ThriftTestTestNestResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestNestResultRecv {
-            #[derivative(Default)]
             Ok(Xtruct2),
         }
 
@@ -7930,11 +7960,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestDoubleResultRecv {
+            fn default() -> Self {
+                ThriftTestTestDoubleResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestDoubleResultRecv {
-            #[derivative(Default)]
             Ok(f64),
         }
 
@@ -8068,11 +8100,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestBoolResultRecv {
+            fn default() -> Self {
+                ThriftTestTestBoolResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestBoolResultRecv {
-            #[derivative(Default)]
             Ok(bool),
         }
 
@@ -8439,11 +8473,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestTypedefResultSend {
+            fn default() -> Self {
+                ThriftTestTestTypedefResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestTypedefResultSend {
-            #[derivative(Default)]
             Ok(UserId),
         }
 
@@ -8581,11 +8617,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestStringMapResultSend {
+            fn default() -> Self {
+                ThriftTestTestStringMapResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestStringMapResultSend {
-            #[derivative(Default)]
             Ok(::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>),
         }
 
@@ -8916,11 +8954,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestUuidResultSend {
+            fn default() -> Self {
+                ThriftTestTestUuidResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestUuidResultSend {
-            #[derivative(Default)]
             Ok([u8; 16]),
         }
 
@@ -9252,11 +9292,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestI32ResultSend {
+            fn default() -> Self {
+                ThriftTestTestI32ResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestI32ResultSend {
-            #[derivative(Default)]
             Ok(i32),
         }
 
@@ -9390,11 +9432,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestVoidResultSend {
+            fn default() -> Self {
+                ThriftTestTestVoidResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestVoidResultSend {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -10005,11 +10049,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestOnewayResultRecv {
+            fn default() -> Self {
+                ThriftTestTestOnewayResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestOnewayResultRecv {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -11127,11 +11173,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for SecondServiceSecondtestStringResultRecv {
+            fn default() -> Self {
+                SecondServiceSecondtestStringResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum SecondServiceSecondtestStringResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::FastStr),
         }
 
@@ -11601,11 +11649,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestExceptionException {
+            fn default() -> Self {
+                ThriftTestTestExceptionException::Err1(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestExceptionException {
-            #[derivative(Default)]
             Err1(Xception),
         }
 
@@ -11893,11 +11943,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMapMapResultRecv {
+            fn default() -> Self {
+                ThriftTestTestMapMapResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMapMapResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::AHashMap<i32, ::pilota::AHashMap<i32, i32>>),
         }
 
@@ -12463,11 +12515,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestSetResultRecv {
+            fn default() -> Self {
+                ThriftTestTestSetResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestSetResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::AHashSet<i32>),
         }
 
@@ -12782,11 +12836,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestStructResultRecv {
+            fn default() -> Self {
+                ThriftTestTestStructResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestStructResultRecv {
-            #[derivative(Default)]
             Ok(Xtruct),
         }
 
@@ -13164,11 +13220,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestI64ResultRecv {
+            fn default() -> Self {
+                ThriftTestTestI64ResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestI64ResultRecv {
-            #[derivative(Default)]
             Ok(i64),
         }
 
@@ -13302,11 +13360,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestStringResultRecv {
+            fn default() -> Self {
+                ThriftTestTestStringResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestStringResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::FastStr),
         }
 
@@ -13440,11 +13500,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMultiResultSend {
+            fn default() -> Self {
+                ThriftTestTestMultiResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMultiResultSend {
-            #[derivative(Default)]
             Ok(Xtruct),
         }
 
@@ -13941,11 +14003,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestEnumResultSend {
+            fn default() -> Self {
+                ThriftTestTestEnumResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestEnumResultSend {
-            #[derivative(Default)]
             Ok(Numberz),
         }
 
@@ -14234,11 +14298,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMapResultSend {
+            fn default() -> Self {
+                ThriftTestTestMapResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMapResultSend {
-            #[derivative(Default)]
             Ok(::pilota::AHashMap<i32, i32>),
         }
 
@@ -14416,11 +14482,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestExceptionResultSend {
+            fn default() -> Self {
+                ThriftTestTestExceptionResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestExceptionResultSend {
-            #[derivative(Default)]
             Ok(()),
 
             Err1(Xception),
@@ -15072,11 +15140,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestBinaryResultSend {
+            fn default() -> Self {
+                ThriftTestTestBinaryResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestBinaryResultSend {
-            #[derivative(Default)]
             Ok(::pilota::Bytes),
         }
 
@@ -15360,11 +15430,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestByteResultSend {
+            fn default() -> Self {
+                ThriftTestTestByteResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestByteResultSend {
-            #[derivative(Default)]
             Ok(i8),
         }
 
@@ -15498,11 +15570,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMultiExceptionResultRecv {
+            fn default() -> Self {
+                ThriftTestTestMultiExceptionResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMultiExceptionResultRecv {
-            #[derivative(Default)]
             Ok(Xtruct),
 
             Err1(Xception),
@@ -17581,11 +17655,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestExceptionResultRecv {
+            fn default() -> Self {
+                ThriftTestTestExceptionResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestExceptionResultRecv {
-            #[derivative(Default)]
             Ok(()),
 
             Err1(Xception),
@@ -18066,11 +18142,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestTypedefResultRecv {
+            fn default() -> Self {
+                ThriftTestTestTypedefResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestTypedefResultRecv {
-            #[derivative(Default)]
             Ok(UserId),
         }
 
@@ -18355,11 +18433,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestStringMapResultRecv {
+            fn default() -> Self {
+                ThriftTestTestStringMapResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestStringMapResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>),
         }
 
@@ -18540,11 +18620,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestUuidResultRecv {
+            fn default() -> Self {
+                ThriftTestTestUuidResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestUuidResultRecv {
-            #[derivative(Default)]
             Ok([u8; 16]),
         }
 
@@ -19169,11 +19251,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestI32ResultRecv {
+            fn default() -> Self {
+                ThriftTestTestI32ResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestI32ResultRecv {
-            #[derivative(Default)]
             Ok(i32),
         }
 
@@ -19307,11 +19391,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestMultiExceptionResultSend {
+            fn default() -> Self {
+                ThriftTestTestMultiExceptionResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestMultiExceptionResultSend {
-            #[derivative(Default)]
             Ok(Xtruct),
 
             Err1(Xception),
@@ -19533,11 +19619,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestVoidResultRecv {
+            fn default() -> Self {
+                ThriftTestTestVoidResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestVoidResultRecv {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -19635,11 +19723,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestInsanityResultSend {
+            fn default() -> Self {
+                ThriftTestTestInsanityResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum ThriftTestTestInsanityResultSend {
-            #[derivative(Default)]
             Ok(::pilota::AHashMap<UserId, ::pilota::AHashMap<Numberz, Insanity>>),
         }
 
@@ -20072,11 +20162,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestListResultSend {
+            fn default() -> Self {
+                ThriftTestTestListResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestListResultSend {
-            #[derivative(Default)]
             Ok(::std::vec::Vec<i32>),
         }
 
@@ -20431,11 +20523,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestNestResultSend {
+            fn default() -> Self {
+                ThriftTestTestNestResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestNestResultSend {
-            #[derivative(Default)]
             Ok(Xtruct2),
         }
 
@@ -20864,11 +20958,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestDoubleResultSend {
+            fn default() -> Self {
+                ThriftTestTestDoubleResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestDoubleResultSend {
-            #[derivative(Default)]
             Ok(f64),
         }
 
@@ -21153,11 +21249,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ThriftTestTestBoolResultSend {
+            fn default() -> Self {
+                ThriftTestTestBoolResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ThriftTestTestBoolResultSend {
-            #[derivative(Default)]
             Ok(bool),
         }
 
@@ -21291,11 +21389,13 @@ pub mod apache {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for SomeUnion {
+            fn default() -> Self {
+                SomeUnion::MapThing(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum SomeUnion {
-            #[derivative(Default)]
             MapThing(::pilota::AHashMap<Numberz, UserId>),
 
             StringThing(::pilota::FastStr),

--- a/pilota-build/test_data/thrift/auto_name.rs
+++ b/pilota-build/test_data/thrift/auto_name.rs
@@ -156,11 +156,14 @@ pub mod auto_name {
             }
         }
         pub trait service {}
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for serviceTest2ResultRecv {
+            fn default() -> Self {
+                serviceTest2ResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum serviceTest2ResultRecv {
-            #[derivative(Default)]
             Ok(Test),
         }
 
@@ -737,11 +740,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for servicetestResultSend {
+            fn default() -> Self {
+                servicetestResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum servicetestResultSend {
-            #[derivative(Default)]
             Ok(Test),
 
             E(TestException),
@@ -1233,11 +1238,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ServicetestException {
+            fn default() -> Self {
+                ServicetestException::E(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServicetestException {
-            #[derivative(Default)]
             E(TestException),
         }
 
@@ -1375,11 +1382,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ServicetestResultRecv {
+            fn default() -> Self {
+                ServicetestResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServicetestResultRecv {
-            #[derivative(Default)]
             Ok(Test),
 
             E(TestException),
@@ -1556,11 +1565,13 @@ pub mod auto_name {
             }
         }
         pub const IP: &'static str = "IP";
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for serviceTest2ResultSend {
+            fn default() -> Self {
+                serviceTest2ResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum serviceTest2ResultSend {
-            #[derivative(Default)]
             Ok(Test),
         }
 
@@ -1698,11 +1709,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for serviceTestException {
+            fn default() -> Self {
+                serviceTestException::E(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum serviceTestException {
-            #[derivative(Default)]
             E(TestException),
         }
 
@@ -1840,11 +1853,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for serviceTestResultRecv {
+            fn default() -> Self {
+                serviceTestResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum serviceTestResultRecv {
-            #[derivative(Default)]
             Ok(Test),
 
             E(TestException),
@@ -2336,11 +2351,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ServiceTestResultSend {
+            fn default() -> Self {
+                ServiceTestResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTestResultSend {
-            #[derivative(Default)]
             Ok(Test),
 
             E(TestException),
@@ -2707,11 +2724,14 @@ pub mod auto_name {
             }
         }
         pub trait Service {}
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for ServiceTest2ResultRecv {
+            fn default() -> Self {
+                ServiceTest2ResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTest2ResultRecv {
-            #[derivative(Default)]
             Ok(Test),
         }
 
@@ -3049,9 +3069,7 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Index(i32);
 
@@ -3456,11 +3474,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for servicetestException {
+            fn default() -> Self {
+                servicetestException::E(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum servicetestException {
-            #[derivative(Default)]
             E(TestException),
         }
 
@@ -3598,11 +3618,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for servicetestResultRecv {
+            fn default() -> Self {
+                servicetestResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum servicetestResultRecv {
-            #[derivative(Default)]
             Ok(Test),
 
             E(TestException),
@@ -3978,11 +4000,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ServicetestResultSend {
+            fn default() -> Self {
+                ServicetestResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServicetestResultSend {
-            #[derivative(Default)]
             Ok(Test),
 
             E(TestException),
@@ -4474,11 +4498,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for serviceTestResultSend {
+            fn default() -> Self {
+                serviceTestResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum serviceTestResultSend {
-            #[derivative(Default)]
             Ok(Test),
 
             E(TestException),
@@ -4654,11 +4680,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ServiceTest2ResultSend {
+            fn default() -> Self {
+                ServiceTest2ResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTest2ResultSend {
-            #[derivative(Default)]
             Ok(Test),
         }
 
@@ -4796,11 +4824,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ServiceTestException {
+            fn default() -> Self {
+                ServiceTestException::E(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTestException {
-            #[derivative(Default)]
             E(TestException),
         }
 
@@ -4938,11 +4968,13 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ServiceTestResultRecv {
+            fn default() -> Self {
+                ServiceTestResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTestResultRecv {
-            #[derivative(Default)]
             Ok(Test),
 
             E(TestException),

--- a/pilota-build/test_data/thrift/auto_name.rs
+++ b/pilota-build/test_data/thrift/auto_name.rs
@@ -157,9 +157,9 @@ pub mod auto_name {
         }
         pub trait service {}
 
-        impl Default for serviceTest2ResultRecv {
+        impl ::std::default::Default for serviceTest2ResultRecv {
             fn default() -> Self {
-                serviceTest2ResultRecv::Ok(Default::default())
+                serviceTest2ResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -740,9 +740,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for servicetestResultSend {
+        impl ::std::default::Default for servicetestResultSend {
             fn default() -> Self {
-                servicetestResultSend::Ok(Default::default())
+                servicetestResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1238,9 +1238,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ServicetestException {
+        impl ::std::default::Default for ServicetestException {
             fn default() -> Self {
-                ServicetestException::E(Default::default())
+                ServicetestException::E(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1382,9 +1382,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ServicetestResultRecv {
+        impl ::std::default::Default for ServicetestResultRecv {
             fn default() -> Self {
-                ServicetestResultRecv::Ok(Default::default())
+                ServicetestResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1565,9 +1565,9 @@ pub mod auto_name {
             }
         }
         pub const IP: &'static str = "IP";
-        impl Default for serviceTest2ResultSend {
+        impl ::std::default::Default for serviceTest2ResultSend {
             fn default() -> Self {
-                serviceTest2ResultSend::Ok(Default::default())
+                serviceTest2ResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1709,9 +1709,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for serviceTestException {
+        impl ::std::default::Default for serviceTestException {
             fn default() -> Self {
-                serviceTestException::E(Default::default())
+                serviceTestException::E(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1853,9 +1853,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for serviceTestResultRecv {
+        impl ::std::default::Default for serviceTestResultRecv {
             fn default() -> Self {
-                serviceTestResultRecv::Ok(Default::default())
+                serviceTestResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -2351,9 +2351,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ServiceTestResultSend {
+        impl ::std::default::Default for ServiceTestResultSend {
             fn default() -> Self {
-                ServiceTestResultSend::Ok(Default::default())
+                ServiceTestResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -2725,9 +2725,9 @@ pub mod auto_name {
         }
         pub trait Service {}
 
-        impl Default for ServiceTest2ResultRecv {
+        impl ::std::default::Default for ServiceTest2ResultRecv {
             fn default() -> Self {
-                ServiceTest2ResultRecv::Ok(Default::default())
+                ServiceTest2ResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -3474,9 +3474,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for servicetestException {
+        impl ::std::default::Default for servicetestException {
             fn default() -> Self {
-                servicetestException::E(Default::default())
+                servicetestException::E(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -3618,9 +3618,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for servicetestResultRecv {
+        impl ::std::default::Default for servicetestResultRecv {
             fn default() -> Self {
-                servicetestResultRecv::Ok(Default::default())
+                servicetestResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -4000,9 +4000,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ServicetestResultSend {
+        impl ::std::default::Default for ServicetestResultSend {
             fn default() -> Self {
-                ServicetestResultSend::Ok(Default::default())
+                ServicetestResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -4498,9 +4498,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for serviceTestResultSend {
+        impl ::std::default::Default for serviceTestResultSend {
             fn default() -> Self {
-                serviceTestResultSend::Ok(Default::default())
+                serviceTestResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -4680,9 +4680,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ServiceTest2ResultSend {
+        impl ::std::default::Default for ServiceTest2ResultSend {
             fn default() -> Self {
-                ServiceTest2ResultSend::Ok(Default::default())
+                ServiceTest2ResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -4824,9 +4824,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ServiceTestException {
+        impl ::std::default::Default for ServiceTestException {
             fn default() -> Self {
-                ServiceTestException::E(Default::default())
+                ServiceTestException::E(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -4968,9 +4968,9 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ServiceTestResultRecv {
+        impl ::std::default::Default for ServiceTestResultRecv {
             fn default() -> Self {
-                ServiceTestResultRecv::Ok(Default::default())
+                ServiceTestResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/btree.rs
+++ b/pilota-build/test_data/thrift/btree.rs
@@ -752,9 +752,7 @@ pub mod btree {
             map.insert(Index::B, "world");
             map
         });
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Index(i32);
 

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -2,9 +2,7 @@ pub mod const_val {
     #![allow(warnings, clippy::all)]
 
     pub mod const_val {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Index(i32);
 

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -2,9 +2,7 @@ pub mod default_value {
     #![allow(warnings, clippy::all)]
 
     pub mod default_value {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct B(i32);
 

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -638,9 +638,9 @@ pub mod enum_test {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestEnumVarTypeNameConflictResultSend {
+        impl ::std::default::Default for TestTestEnumVarTypeNameConflictResultSend {
             fn default() -> Self {
-                TestTestEnumVarTypeNameConflictResultSend::Ok(Default::default())
+                TestTestEnumVarTypeNameConflictResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -939,9 +939,9 @@ pub mod enum_test {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestEnumResultSend {
+        impl ::std::default::Default for TestTestEnumResultSend {
             fn default() -> Self {
-                TestTestEnumResultSend::Ok(Default::default())
+                TestTestEnumResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1384,9 +1384,9 @@ pub mod enum_test {
         }
         pub trait Test {}
 
-        impl Default for TestTestEnumVarTypeNameConflictResultRecv {
+        impl ::std::default::Default for TestTestEnumVarTypeNameConflictResultRecv {
             fn default() -> Self {
-                TestTestEnumVarTypeNameConflictResultRecv::Ok(Default::default())
+                TestTestEnumVarTypeNameConflictResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1532,9 +1532,9 @@ pub mod enum_test {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestEnumResultRecv {
+        impl ::std::default::Default for TestTestEnumResultRecv {
             fn default() -> Self {
-                TestTestEnumResultRecv::Ok(Default::default())
+                TestTestEnumResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -2,9 +2,7 @@ pub mod enum_test {
     #![allow(warnings, clippy::all)]
 
     pub mod enum_test {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Index(i32);
 
@@ -640,11 +638,13 @@ pub mod enum_test {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTestEnumVarTypeNameConflictResultSend {
+            fn default() -> Self {
+                TestTestEnumVarTypeNameConflictResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTestEnumVarTypeNameConflictResultSend {
-            #[derivative(Default)]
             Ok(Err),
         }
 
@@ -939,11 +939,13 @@ pub mod enum_test {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTestEnumResultSend {
+            fn default() -> Self {
+                TestTestEnumResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTestEnumResultSend {
-            #[derivative(Default)]
             Ok(Err),
         }
 
@@ -1291,9 +1293,7 @@ pub mod enum_test {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct _Enum(i32);
 
@@ -1383,11 +1383,14 @@ pub mod enum_test {
             }
         }
         pub trait Test {}
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for TestTestEnumVarTypeNameConflictResultRecv {
+            fn default() -> Self {
+                TestTestEnumVarTypeNameConflictResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTestEnumVarTypeNameConflictResultRecv {
-            #[derivative(Default)]
             Ok(Err),
         }
 
@@ -1529,11 +1532,13 @@ pub mod enum_test {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTestEnumResultRecv {
+            fn default() -> Self {
+                TestTestEnumResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTestEnumResultRecv {
-            #[derivative(Default)]
             Ok(Err),
         }
 

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -179,9 +179,7 @@ pub mod multi {
             }
         }
         pub const A_S: &'static str = "string";
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct B(i32);
 

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -1062,11 +1062,13 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTest123ResultSend {
+            fn default() -> Self {
+                TestTest123ResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTest123ResultSend {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -1607,11 +1609,13 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTestExceptionException {
+            fn default() -> Self {
+                TestTestExceptionException::StException(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTestExceptionException {
-            #[derivative(Default)]
             StException(StException),
         }
 
@@ -1750,11 +1754,13 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTestExceptionResultSend {
+            fn default() -> Self {
+                TestTestExceptionResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum TestTestExceptionResultSend {
-            #[derivative(Default)]
             Ok(ObjReq),
 
             StException(StException),
@@ -1931,11 +1937,13 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTestExceptionResultRecv {
+            fn default() -> Self {
+                TestTestExceptionResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum TestTestExceptionResultRecv {
-            #[derivative(Default)]
             Ok(ObjReq),
 
             StException(StException),
@@ -2112,11 +2120,13 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTest123ResultRecv {
+            fn default() -> Self {
+                TestTest123ResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTest123ResultRecv {
-            #[derivative(Default)]
             Ok(()),
         }
 

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -1062,9 +1062,9 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTest123ResultSend {
+        impl ::std::default::Default for TestTest123ResultSend {
             fn default() -> Self {
-                TestTest123ResultSend::Ok(Default::default())
+                TestTest123ResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1609,9 +1609,9 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestExceptionException {
+        impl ::std::default::Default for TestTestExceptionException {
             fn default() -> Self {
-                TestTestExceptionException::StException(Default::default())
+                TestTestExceptionException::StException(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -1754,9 +1754,9 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestExceptionResultSend {
+        impl ::std::default::Default for TestTestExceptionResultSend {
             fn default() -> Self {
-                TestTestExceptionResultSend::Ok(Default::default())
+                TestTestExceptionResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -1937,9 +1937,9 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestExceptionResultRecv {
+        impl ::std::default::Default for TestTestExceptionResultRecv {
             fn default() -> Self {
-                TestTestExceptionResultRecv::Ok(Default::default())
+                TestTestExceptionResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -2120,9 +2120,9 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTest123ResultRecv {
+        impl ::std::default::Default for TestTest123ResultRecv {
             fn default() -> Self {
-                TestTest123ResultRecv::Ok(Default::default())
+                TestTest123ResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -310,9 +310,9 @@ pub mod pilota_name {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestServiceTestResultSend {
+        impl ::std::default::Default for TestServiceTestResultSend {
             fn default() -> Self {
-                TestServiceTestResultSend::Ok(Default::default())
+                TestServiceTestResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -802,9 +802,9 @@ pub mod pilota_name {
         pub const LANG_ID: &'static str = "id";
         pub trait TestService {}
 
-        impl Default for TestServiceTestResultRecv {
+        impl ::std::default::Default for TestServiceTestResultRecv {
             fn default() -> Self {
-                TestServiceTestResultRecv::Ok(Default::default())
+                TestServiceTestResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -310,11 +310,13 @@ pub mod pilota_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestServiceTestResultSend {
+            fn default() -> Self {
+                TestServiceTestResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestServiceTestResultSend {
-            #[derivative(Default)]
             Ok(Test1),
         }
 
@@ -799,11 +801,14 @@ pub mod pilota_name {
         }
         pub const LANG_ID: &'static str = "id";
         pub trait TestService {}
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for TestServiceTestResultRecv {
+            fn default() -> Self {
+                TestServiceTestResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestServiceTestResultRecv {
-            #[derivative(Default)]
             Ok(Test1),
         }
 
@@ -941,9 +946,7 @@ pub mod pilota_name {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Index(i32);
 

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -2,9 +2,7 @@ pub mod self_kw {
     #![allow(warnings, clippy::all)]
 
     pub mod self_kw {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Index(i32);
 

--- a/pilota-build/test_data/thrift/underscore.rs
+++ b/pilota-build/test_data/thrift/underscore.rs
@@ -2,11 +2,14 @@ pub mod underscore {
     #![allow(warnings, clippy::all)]
 
     pub mod underscore {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for Test_UnderscoredResultRecv {
+            fn default() -> Self {
+                Test_UnderscoredResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum Test_UnderscoredResultRecv {
-            #[derivative(Default)]
             Ok(::pilota::FastStr),
         }
 
@@ -440,11 +443,13 @@ pub mod underscore {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for Test_UnderscoredResultSend {
+            fn default() -> Self {
+                Test_UnderscoredResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum Test_UnderscoredResultSend {
-            #[derivative(Default)]
             Ok(::pilota::FastStr),
         }
 

--- a/pilota-build/test_data/thrift/underscore.rs
+++ b/pilota-build/test_data/thrift/underscore.rs
@@ -3,9 +3,9 @@ pub mod underscore {
 
     pub mod underscore {
 
-        impl Default for Test_UnderscoredResultRecv {
+        impl ::std::default::Default for Test_UnderscoredResultRecv {
             fn default() -> Self {
-                Test_UnderscoredResultRecv::Ok(Default::default())
+                Test_UnderscoredResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -443,9 +443,9 @@ pub mod underscore {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for Test_UnderscoredResultSend {
+        impl ::std::default::Default for Test_UnderscoredResultSend {
             fn default() -> Self {
-                Test_UnderscoredResultSend::Ok(Default::default())
+                Test_UnderscoredResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/union.rs
+++ b/pilota-build/test_data/thrift/union.rs
@@ -2,11 +2,14 @@ pub mod union {
     #![allow(warnings, clippy::all)]
 
     pub mod union {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for Union {
+            fn default() -> Self {
+                Union::A(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum Union {
-            #[derivative(Default)]
             A(::pilota::FastStr),
 
             B(::pilota::Bytes),

--- a/pilota-build/test_data/thrift/union.rs
+++ b/pilota-build/test_data/thrift/union.rs
@@ -3,9 +3,9 @@ pub mod union {
 
     pub mod union {
 
-        impl Default for Union {
+        impl ::std::default::Default for Union {
             fn default() -> Self {
-                Union::A(Default::default())
+                Union::A(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -168,6 +168,126 @@ pub mod union {
                         Union::A(ref value) => __protocol.faststr_field_len(Some(1), value),
                         Union::B(ref value) => __protocol.bytes_field_len(Some(2), value),
                     }
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct Default {}
+        impl ::pilota::thrift::Message for Default {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Default" };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{thrift::TLengthProtocolExt, Buf};
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `Default` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let data = Self {};
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `Default` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let data = Self {};
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol
+                    .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Default" })
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/union.thrift
+++ b/pilota-build/test_data/thrift/union.thrift
@@ -10,3 +10,5 @@ struct A {
 union Empty {
 
 }
+
+struct Default {}

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -2,11 +2,14 @@ pub mod void {
     #![allow(warnings, clippy::all)]
 
     pub mod void {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for TestTest123ResultRecv {
+            fn default() -> Self {
+                TestTest123ResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTest123ResultRecv {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -342,11 +345,13 @@ pub mod void {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestTest123ResultSend {
+            fn default() -> Self {
+                TestTest123ResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum TestTest123ResultSend {
-            #[derivative(Default)]
             Ok(()),
         }
 

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -3,9 +3,9 @@ pub mod void {
 
     pub mod void {
 
-        impl Default for TestTest123ResultRecv {
+        impl ::std::default::Default for TestTest123ResultRecv {
             fn default() -> Self {
-                TestTest123ResultRecv::Ok(Default::default())
+                TestTest123ResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -345,9 +345,9 @@ pub mod void {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTest123ResultSend {
+        impl ::std::default::Default for TestTest123ResultSend {
             fn default() -> Self {
-                TestTest123ResultSend::Ok(Default::default())
+                TestTest123ResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -123,9 +123,9 @@ pub mod wrapper_arc {
         }
         pub trait TestService {}
 
-        impl Default for TestServiceTestResultRecv {
+        impl ::std::default::Default for TestServiceTestResultRecv {
             fn default() -> Self {
-                TestServiceTestResultRecv::Ok(Default::default())
+                TestServiceTestResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]
@@ -422,9 +422,9 @@ pub mod wrapper_arc {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestServiceTestResultSend {
+        impl ::std::default::Default for TestServiceTestResultSend {
             fn default() -> Self {
-                TestServiceTestResultSend::Ok(Default::default())
+                TestServiceTestResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -122,11 +122,14 @@ pub mod wrapper_arc {
             }
         }
         pub trait TestService {}
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for TestServiceTestResultRecv {
+            fn default() -> Self {
+                TestServiceTestResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum TestServiceTestResultRecv {
-            #[derivative(Default)]
             Ok(Test),
         }
 
@@ -419,11 +422,13 @@ pub mod wrapper_arc {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for TestServiceTestResultSend {
+            fn default() -> Self {
+                TestServiceTestResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
         pub enum TestServiceTestResultSend {
-            #[derivative(Default)]
             Ok(::std::sync::Arc<Test>),
         }
 

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultRecv.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultRecv.rs
@@ -1,7 +1,7 @@
 
-impl Default for TestServiceTestResultRecv {
+impl ::std::default::Default for TestServiceTestResultRecv {
     fn default() -> Self {
-        TestServiceTestResultRecv::Ok(Default::default())
+        TestServiceTestResultRecv::Ok(::std::default::Default::default())
     }
 }
 #[derive(Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultRecv.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultRecv.rs
@@ -1,8 +1,11 @@
-#[derive(Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for TestServiceTestResultRecv {
+    fn default() -> Self {
+        TestServiceTestResultRecv::Ok(Default::default())
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
 pub enum TestServiceTestResultRecv {
-    #[derivative(Default)]
     Ok(Test),
 }
 

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultSend_2.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultSend_2.rs
@@ -1,8 +1,11 @@
-#[derive(Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for TestServiceTestResultSend {
+    fn default() -> Self {
+        TestServiceTestResultSend::Ok(Default::default())
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
 pub enum TestServiceTestResultSend {
-    #[derivative(Default)]
     Ok(::std::sync::Arc<Test>),
 }
 

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultSend_2.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultSend_2.rs
@@ -1,7 +1,7 @@
 
-impl Default for TestServiceTestResultSend {
+impl ::std::default::Default for TestServiceTestResultSend {
     fn default() -> Self {
-        TestServiceTestResultSend::Ok(Default::default())
+        TestServiceTestResultSend::Ok(::std::default::Default::default())
     }
 }
 #[derive(Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultRecv_2.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultRecv_2.rs
@@ -1,8 +1,11 @@
-#[derive(Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for testServiceTestResultRecv {
+    fn default() -> Self {
+        testServiceTestResultRecv::Ok(Default::default())
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
 pub enum testServiceTestResultRecv {
-    #[derivative(Default)]
     Ok(Test),
 }
 

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultRecv_2.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultRecv_2.rs
@@ -1,7 +1,7 @@
 
-impl Default for testServiceTestResultRecv {
+impl ::std::default::Default for testServiceTestResultRecv {
     fn default() -> Self {
-        testServiceTestResultRecv::Ok(Default::default())
+        testServiceTestResultRecv::Ok(::std::default::Default::default())
     }
 }
 #[derive(Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultSend.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultSend.rs
@@ -1,8 +1,11 @@
-#[derive(Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for testServiceTestResultSend {
+    fn default() -> Self {
+        testServiceTestResultSend::Ok(Default::default())
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
 pub enum testServiceTestResultSend {
-    #[derivative(Default)]
     Ok(::std::sync::Arc<Test>),
 }
 

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultSend.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultSend.rs
@@ -1,7 +1,7 @@
 
-impl Default for testServiceTestResultSend {
+impl ::std::default::Default for testServiceTestResultSend {
     fn default() -> Self {
-        testServiceTestResultSend::Ok(Default::default())
+        testServiceTestResultSend::Ok(::std::default::Default::default())
     }
 }
 #[derive(Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
@@ -244,9 +244,9 @@ pub mod gen {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for ArticleServiceGetArticleResultSend {
+        impl ::std::default::Default for ArticleServiceGetArticleResultSend {
             fn default() -> Self {
-                ArticleServiceGetArticleResultSend::Ok(Default::default())
+                ArticleServiceGetArticleResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -853,9 +853,9 @@ pub mod gen {
         }
         pub trait ArticleService {}
 
-        impl Default for ArticleServiceGetArticleResultRecv {
+        impl ::std::default::Default for ArticleServiceGetArticleResultRecv {
             fn default() -> Self {
-                ArticleServiceGetArticleResultRecv::Ok(Default::default())
+                ArticleServiceGetArticleResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
@@ -2,9 +2,7 @@ pub mod gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq, Copy)]
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
         #[repr(transparent)]
         pub struct Status(i32);
 
@@ -246,11 +244,13 @@ pub mod gen {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for ArticleServiceGetArticleResultSend {
+            fn default() -> Self {
+                ArticleServiceGetArticleResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ArticleServiceGetArticleResultSend {
-            #[derivative(Default)]
             Ok(GetArticleResponse),
         }
 
@@ -852,11 +852,14 @@ pub mod gen {
             }
         }
         pub trait ArticleService {}
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for ArticleServiceGetArticleResultRecv {
+            fn default() -> Self {
+                ArticleServiceGetArticleResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ArticleServiceGetArticleResultRecv {
-            #[derivative(Default)]
             Ok(GetArticleResponse),
         }
 

--- a/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
@@ -14,11 +14,14 @@ pub mod gen {
     pub mod author {
 
         pub trait AuthorService {}
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+
+        impl Default for AuthorServiceGetAuthorResultRecv {
+            fn default() -> Self {
+                AuthorServiceGetAuthorResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum AuthorServiceGetAuthorResultRecv {
-            #[derivative(Default)]
             Ok(GetAuthorResponse),
         }
 
@@ -305,11 +308,13 @@ pub mod gen {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(Clone, PartialEq)]
+        impl Default for AuthorServiceGetAuthorResultSend {
+            fn default() -> Self {
+                AuthorServiceGetAuthorResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum AuthorServiceGetAuthorResultSend {
-            #[derivative(Default)]
             Ok(GetAuthorResponse),
         }
 

--- a/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
@@ -15,9 +15,9 @@ pub mod gen {
 
         pub trait AuthorService {}
 
-        impl Default for AuthorServiceGetAuthorResultRecv {
+        impl ::std::default::Default for AuthorServiceGetAuthorResultRecv {
             fn default() -> Self {
-                AuthorServiceGetAuthorResultRecv::Ok(Default::default())
+                AuthorServiceGetAuthorResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -308,9 +308,9 @@ pub mod gen {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for AuthorServiceGetAuthorResultSend {
+        impl ::std::default::Default for AuthorServiceGetAuthorResultSend {
             fn default() -> Self {
-                AuthorServiceGetAuthorResultSend::Ok(Default::default())
+                AuthorServiceGetAuthorResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace/output/image/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/image/src/gen.rs
@@ -164,9 +164,9 @@ pub mod gen {
                         + __protocol.struct_end_len()
                 }
             }
-            impl Default for ImageServiceGetImageResultSend {
+            impl ::std::default::Default for ImageServiceGetImageResultSend {
                 fn default() -> Self {
-                    ImageServiceGetImageResultSend::Ok(Default::default())
+                    ImageServiceGetImageResultSend::Ok(::std::default::Default::default())
                 }
             }
             #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
@@ -799,9 +799,9 @@ pub mod gen {
             }
             pub trait ImageService {}
 
-            impl Default for ImageServiceGetImageResultRecv {
+            impl ::std::default::Default for ImageServiceGetImageResultRecv {
                 fn default() -> Self {
-                    ImageServiceGetImageResultRecv::Ok(Default::default())
+                    ImageServiceGetImageResultRecv::Ok(::std::default::Default::default())
                 }
             }
             #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace/output/image/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/image/src/gen.rs
@@ -164,11 +164,13 @@ pub mod gen {
                         + __protocol.struct_end_len()
                 }
             }
-            #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-            #[derivative(Default)]
-            #[derive(Clone, PartialEq)]
+            impl Default for ImageServiceGetImageResultSend {
+                fn default() -> Self {
+                    ImageServiceGetImageResultSend::Ok(Default::default())
+                }
+            }
+            #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
             pub enum ImageServiceGetImageResultSend {
-                #[derivative(Default)]
                 Ok(GetImageResponse),
             }
 
@@ -796,11 +798,14 @@ pub mod gen {
                 }
             }
             pub trait ImageService {}
-            #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-            #[derivative(Default)]
-            #[derive(Clone, PartialEq)]
+
+            impl Default for ImageServiceGetImageResultRecv {
+                fn default() -> Self {
+                    ImageServiceGetImageResultRecv::Ok(Default::default())
+                }
+            }
+            #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
             pub enum ImageServiceGetImageResultRecv {
-                #[derivative(Default)]
                 Ok(GetImageResponse),
             }
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultRecv.rs
@@ -1,7 +1,7 @@
 
-impl Default for ArticleServiceGetArticleResultRecv {
+impl ::std::default::Default for ArticleServiceGetArticleResultRecv {
     fn default() -> Self {
-        ArticleServiceGetArticleResultRecv::Ok(Default::default())
+        ArticleServiceGetArticleResultRecv::Ok(::std::default::Default::default())
     }
 }
 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultRecv.rs
@@ -1,8 +1,11 @@
-#[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for ArticleServiceGetArticleResultRecv {
+    fn default() -> Self {
+        ArticleServiceGetArticleResultRecv::Ok(Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
 pub enum ArticleServiceGetArticleResultRecv {
-    #[derivative(Default)]
     Ok(GetArticleResponse),
 }
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultSend.rs
@@ -1,8 +1,11 @@
-#[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for ArticleServiceGetArticleResultSend {
+    fn default() -> Self {
+        ArticleServiceGetArticleResultSend::Ok(Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
 pub enum ArticleServiceGetArticleResultSend {
-    #[derivative(Default)]
     Ok(GetArticleResponse),
 }
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultSend.rs
@@ -1,7 +1,7 @@
 
-impl Default for ArticleServiceGetArticleResultSend {
+impl ::std::default::Default for ArticleServiceGetArticleResultSend {
     fn default() -> Self {
-        ArticleServiceGetArticleResultSend::Ok(Default::default())
+        ArticleServiceGetArticleResultSend::Ok(::std::default::Default::default())
     }
 }
 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_Status.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_Status.rs
@@ -1,6 +1,4 @@
-#[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq, Copy)]
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
 #[repr(transparent)]
 pub struct Status(i32);
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultRecv.rs
@@ -1,7 +1,7 @@
 
-impl Default for AuthorServiceGetAuthorResultRecv {
+impl ::std::default::Default for AuthorServiceGetAuthorResultRecv {
     fn default() -> Self {
-        AuthorServiceGetAuthorResultRecv::Ok(Default::default())
+        AuthorServiceGetAuthorResultRecv::Ok(::std::default::Default::default())
     }
 }
 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultRecv.rs
@@ -1,8 +1,11 @@
-#[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for AuthorServiceGetAuthorResultRecv {
+    fn default() -> Self {
+        AuthorServiceGetAuthorResultRecv::Ok(Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
 pub enum AuthorServiceGetAuthorResultRecv {
-    #[derivative(Default)]
     Ok(GetAuthorResponse),
 }
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultSend.rs
@@ -1,8 +1,11 @@
-#[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for AuthorServiceGetAuthorResultSend {
+    fn default() -> Self {
+        AuthorServiceGetAuthorResultSend::Ok(Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
 pub enum AuthorServiceGetAuthorResultSend {
-    #[derivative(Default)]
     Ok(GetAuthorResponse),
 }
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultSend.rs
@@ -1,7 +1,7 @@
 
-impl Default for AuthorServiceGetAuthorResultSend {
+impl ::std::default::Default for AuthorServiceGetAuthorResultSend {
     fn default() -> Self {
-        AuthorServiceGetAuthorResultSend::Ok(Default::default())
+        AuthorServiceGetAuthorResultSend::Ok(::std::default::Default::default())
     }
 }
 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultRecv.rs
@@ -1,8 +1,11 @@
-#[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for ImageServiceGetImageResultRecv {
+    fn default() -> Self {
+        ImageServiceGetImageResultRecv::Ok(Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
 pub enum ImageServiceGetImageResultRecv {
-    #[derivative(Default)]
     Ok(GetImageResponse),
 }
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultRecv.rs
@@ -1,7 +1,7 @@
 
-impl Default for ImageServiceGetImageResultRecv {
+impl ::std::default::Default for ImageServiceGetImageResultRecv {
     fn default() -> Self {
-        ImageServiceGetImageResultRecv::Ok(Default::default())
+        ImageServiceGetImageResultRecv::Ok(::std::default::Default::default())
     }
 }
 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultSend.rs
@@ -1,7 +1,7 @@
 
-impl Default for ImageServiceGetImageResultSend {
+impl ::std::default::Default for ImageServiceGetImageResultSend {
     fn default() -> Self {
-        ImageServiceGetImageResultSend::Ok(Default::default())
+        ImageServiceGetImageResultSend::Ok(::std::default::Default::default())
     }
 }
 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultSend.rs
@@ -1,8 +1,11 @@
-#[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-#[derivative(Default)]
-#[derive(Clone, PartialEq)]
+
+impl Default for ImageServiceGetImageResultSend {
+    fn default() -> Self {
+        ImageServiceGetImageResultSend::Ok(Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
 pub enum ImageServiceGetImageResultSend {
-    #[derivative(Default)]
     Ok(GetImageResponse),
 }
 

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -1980,11 +1980,23 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
+        impl Default for TestUnion {
+            fn default() -> Self {
+                TestUnion::A(Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
         pub enum TestUnion {
-            #[derivative(Default)]
             A(A),
 
             B(B),
@@ -2180,11 +2192,23 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
+        impl Default for TestTestExceptionException {
+            fn default() -> Self {
+                TestTestExceptionException::StException(Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
         pub enum TestTestExceptionException {
-            #[derivative(Default)]
             StException(StException),
         }
 
@@ -2323,11 +2347,23 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
+        impl Default for TestTestExceptionResultRecv {
+            fn default() -> Self {
+                TestTestExceptionResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
         pub enum TestTestExceptionResultRecv {
-            #[derivative(Default)]
             Ok(ObjReq),
 
             StException(StException),
@@ -2504,11 +2540,23 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
+        impl Default for TestTest123ResultRecv {
+            fn default() -> Self {
+                TestTest123ResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
         pub enum TestTest123ResultRecv {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -2606,9 +2654,16 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize)]
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            Default,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+        )]
         #[serde(transparent)]
         #[derive(Clone, PartialEq, Copy)]
         #[repr(transparent)]
@@ -3018,11 +3073,23 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
+        impl Default for TestTest123ResultSend {
+            fn default() -> Self {
+                TestTest123ResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
         pub enum TestTest123ResultSend {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -3410,11 +3477,23 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
+        impl Default for TestTestExceptionResultSend {
+            fn default() -> Self {
+                TestTestExceptionResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
         pub enum TestTestExceptionResultSend {
-            #[derivative(Default)]
             Ok(ObjReq),
 
             StException(StException),
@@ -3603,11 +3682,24 @@ pub mod unknown_fields {
     pub mod void {
 
         pub trait Test {}
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
+
+        impl Default for TestTest123ResultRecv {
+            fn default() -> Self {
+                TestTest123ResultRecv::Ok(Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
         pub enum TestTest123ResultRecv {
-            #[derivative(Default)]
             Ok(()),
         }
 
@@ -3705,11 +3797,23 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, ::pilota::derivative::Derivative)]
-        #[derivative(Default)]
-        #[derive(::pilota::serde::Serialize, ::pilota::serde::Deserialize, Clone, PartialEq)]
+        impl Default for TestTest123ResultSend {
+            fn default() -> Self {
+                TestTest123ResultSend::Ok(Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
         pub enum TestTest123ResultSend {
-            #[derivative(Default)]
             Ok(()),
         }
 

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -1980,9 +1980,9 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestUnion {
+        impl ::std::default::Default for TestUnion {
             fn default() -> Self {
-                TestUnion::A(Default::default())
+                TestUnion::A(::std::default::Default::default())
             }
         }
         #[derive(
@@ -2192,9 +2192,9 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestExceptionException {
+        impl ::std::default::Default for TestTestExceptionException {
             fn default() -> Self {
-                TestTestExceptionException::StException(Default::default())
+                TestTestExceptionException::StException(::std::default::Default::default())
             }
         }
         #[derive(
@@ -2347,9 +2347,9 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestExceptionResultRecv {
+        impl ::std::default::Default for TestTestExceptionResultRecv {
             fn default() -> Self {
-                TestTestExceptionResultRecv::Ok(Default::default())
+                TestTestExceptionResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(
@@ -2540,9 +2540,9 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTest123ResultRecv {
+        impl ::std::default::Default for TestTest123ResultRecv {
             fn default() -> Self {
-                TestTest123ResultRecv::Ok(Default::default())
+                TestTest123ResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(
@@ -3073,9 +3073,9 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTest123ResultSend {
+        impl ::std::default::Default for TestTest123ResultSend {
             fn default() -> Self {
-                TestTest123ResultSend::Ok(Default::default())
+                TestTest123ResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(
@@ -3477,9 +3477,9 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTestExceptionResultSend {
+        impl ::std::default::Default for TestTestExceptionResultSend {
             fn default() -> Self {
-                TestTestExceptionResultSend::Ok(Default::default())
+                TestTestExceptionResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(
@@ -3683,9 +3683,9 @@ pub mod unknown_fields {
 
         pub trait Test {}
 
-        impl Default for TestTest123ResultRecv {
+        impl ::std::default::Default for TestTest123ResultRecv {
             fn default() -> Self {
-                TestTest123ResultRecv::Ok(Default::default())
+                TestTest123ResultRecv::Ok(::std::default::Default::default())
             }
         }
         #[derive(
@@ -3797,9 +3797,9 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-        impl Default for TestTest123ResultSend {
+        impl ::std::default::Default for TestTest123ResultSend {
             fn default() -> Self {
-                TestTest123ResultSend::Ok(Default::default())
+                TestTest123ResultSend::Ok(::std::default::Default::default())
             }
         }
         #[derive(

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -25,7 +25,6 @@ async-recursion = "1"
 tokio = { version = "1", features = ["io-util"] }
 lazy_static = "1"
 linkedbytes = "0.1"
-derivative = "2"
 anyhow = "1"
 thiserror = "1"
 faststr = { version = "0.2", features = ["serde"] }

--- a/pilota/src/lib.rs
+++ b/pilota/src/lib.rs
@@ -11,6 +11,7 @@ pub use ahash::{AHashMap, AHashSet};
 pub use async_recursion;
 pub use bytes::*;
 pub use derivative;
+pub use derive_where;
 pub use faststr::FastStr;
 pub use lazy_static;
 pub use ordered_float::OrderedFloat;

--- a/pilota/src/lib.rs
+++ b/pilota/src/lib.rs
@@ -10,8 +10,6 @@ pub mod thrift;
 pub use ahash::{AHashMap, AHashSet};
 pub use async_recursion;
 pub use bytes::*;
-pub use derivative;
-pub use derive_where;
 pub use faststr::FastStr;
 pub use lazy_static;
 pub use ordered_float::OrderedFloat;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

fixes #293

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

the `derivative` crate has been marked as unmaintained by a GitHub bot, and all repositories depending on `pilota` have received a warning issue regarding this.

this PR removes the dependency on `derivative` by using the `#[derive(Default)]` attribute [from the Rust stdlib](https://rust-lang.github.io/rfcs/3107-derive-default-enum.html) for unit enum variants. and manually generated `impl Default` for enums with non-unit variants (e.g., `Ok(String)`).