### PR TITLE
fix(pilota-build): use absolute path for generated Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.28"
+version = "0.11.29"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.28"
+version = "0.11.29"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -397,7 +397,7 @@ impl ThriftBackend {
                     format! {
                         r#"unsafe {{
                             let list_ident = {read_list_begin};
-                            let mut val: Vec<{ty_rust_name}> = Vec::with_capacity(list_ident.size);
+                            let mut val: ::std::vec::Vec<{ty_rust_name}> = ::std::vec::Vec::with_capacity(list_ident.size);
                             for i in 0..list_ident.size {{
                                 val.as_mut_ptr().offset(i as isize).write({read_el});
                             }};
@@ -411,7 +411,7 @@ impl ThriftBackend {
                     format! {
                         r#"{{
                             let list_ident = {read_list_begin};
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {{
                                 val.push({read_el});
                             }};

--- a/pilota-build/test_data/thrift/apache.rs
+++ b/pilota-build/test_data/thrift/apache.rs
@@ -274,7 +274,8 @@ pub mod apache {
                             {
                                 var_4000 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<i32> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<i32> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -394,7 +395,7 @@ pub mod apache {
                 },Some(4000) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_4000 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(__protocol.read_i32().await?);
                             };
@@ -3402,7 +3403,8 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<i32> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<i32> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -3476,7 +3478,8 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(__protocol.read_i32().await?);
                                         }
@@ -3980,8 +3983,8 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::pilota::AHashSet<i32>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<::pilota::AHashSet<i32>> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write({
                                             let list_ident = __protocol.read_set_begin()?;
@@ -4022,12 +4025,12 @@ pub mod apache {
                             Some(3) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_3 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<
+                                    let mut val: ::std::vec::Vec<
                                         ::pilota::AHashMap<
                                             i32,
                                             ::pilota::AHashSet<::pilota::FastStr>,
                                         >,
-                                    > = Vec::with_capacity(list_ident.size);
+                                    > = ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write({
                                             let map_ident = __protocol.read_map_begin()?;
@@ -4115,7 +4118,8 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push({
                                                 let list_ident =
@@ -4164,7 +4168,8 @@ pub mod apache {
                                 {
                                     var_3 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push({
                                                 let map_ident = __protocol.read_map_begin().await?;
@@ -7027,13 +7032,13 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::std::vec::Vec<i32>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<::std::vec::Vec<i32>> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write(unsafe {
                                             let list_ident = __protocol.read_list_begin()?;
-                                            let mut val: Vec<i32> =
-                                                Vec::with_capacity(list_ident.size);
+                                            let mut val: ::std::vec::Vec<i32> =
+                                                ::std::vec::Vec::with_capacity(list_ident.size);
                                             for i in 0..list_ident.size {
                                                 val.as_mut_ptr()
                                                     .offset(i as isize)
@@ -7103,12 +7108,14 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push({
                                                 let list_ident =
                                                     __protocol.read_list_begin().await?;
-                                                let mut val = Vec::with_capacity(list_ident.size);
+                                                let mut val =
+                                                    ::std::vec::Vec::with_capacity(list_ident.size);
                                                 for _ in 0..list_ident.size {
                                                     val.push(__protocol.read_i32().await?);
                                                 }
@@ -7373,7 +7380,8 @@ pub mod apache {
                             if ret.is_none() {
                                 let field_ident = unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<i32> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<i32> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -7439,7 +7447,8 @@ pub mod apache {
                                 if ret.is_none() {
                                     let field_ident = {
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(__protocol.read_i32().await?);
                                         }
@@ -8328,7 +8337,8 @@ pub mod apache {
                             Some(2) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_2 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<Xtruct> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<Xtruct> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -8410,7 +8420,7 @@ pub mod apache {
                 },Some(2) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_2 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(<Xtruct as ::pilota::thrift::Message>::decode_async(__protocol).await?);
                             };
@@ -9157,8 +9167,8 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::pilota::FastStr> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<::pilota::FastStr> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -9232,7 +9242,8 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(__protocol.read_faststr().await?);
                                         }
@@ -9750,7 +9761,8 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<Bonk> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<Bonk> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -9815,7 +9827,8 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(
                                                 <Bonk as ::pilota::thrift::Message>::decode_async(
@@ -9926,7 +9939,8 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<i32> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<i32> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -9995,7 +10009,8 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(__protocol.read_i32().await?);
                                         }
@@ -13052,19 +13067,22 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::std::vec::Vec<::std::vec::Vec<i32>>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<
+                                        ::std::vec::Vec<::std::vec::Vec<i32>>,
+                                    > = ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write(unsafe {
                                             let list_ident = __protocol.read_list_begin()?;
-                                            let mut val: Vec<::std::vec::Vec<i32>> =
-                                                Vec::with_capacity(list_ident.size);
+                                            let mut val: ::std::vec::Vec<::std::vec::Vec<i32>> =
+                                                ::std::vec::Vec::with_capacity(list_ident.size);
                                             for i in 0..list_ident.size {
                                                 val.as_mut_ptr().offset(i as isize).write(unsafe {
                                                     let list_ident =
                                                         __protocol.read_list_begin()?;
-                                                    let mut val: Vec<i32> =
-                                                        Vec::with_capacity(list_ident.size);
+                                                    let mut val: ::std::vec::Vec<i32> =
+                                                        ::std::vec::Vec::with_capacity(
+                                                            list_ident.size,
+                                                        );
                                                     for i in 0..list_ident.size {
                                                         val.as_mut_ptr()
                                                             .offset(i as isize)
@@ -13139,18 +13157,22 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push({
                                                 let list_ident =
                                                     __protocol.read_list_begin().await?;
-                                                let mut val = Vec::with_capacity(list_ident.size);
+                                                let mut val =
+                                                    ::std::vec::Vec::with_capacity(list_ident.size);
                                                 for _ in 0..list_ident.size {
                                                     val.push({
                                                         let list_ident =
                                                             __protocol.read_list_begin().await?;
                                                         let mut val =
-                                                            Vec::with_capacity(list_ident.size);
+                                                            ::std::vec::Vec::with_capacity(
+                                                                list_ident.size,
+                                                            );
                                                         for _ in 0..list_ident.size {
                                                             val.push(__protocol.read_i32().await?);
                                                         }
@@ -14799,7 +14821,7 @@ pub mod apache {
                             Some(3) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_3 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<
+                                    let mut val: ::std::vec::Vec<
                                         ::std::collections::BTreeMap<
                                             ::std::collections::BTreeSet<i32>,
                                             ::std::collections::BTreeMap<
@@ -14814,7 +14836,7 @@ pub mod apache {
                                                 >,
                                             >,
                                         >,
-                                    > = Vec::with_capacity(list_ident.size);
+                                    > = ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write({
                         let map_ident = __protocol.read_map_begin()?;
@@ -14835,7 +14857,7 @@ pub mod apache {
                     for _ in 0..list_ident.size {
                         val.insert(unsafe {
                             let list_ident = __protocol.read_list_begin()?;
-                            let mut val: Vec<::std::collections::BTreeMap<Insanity, ::pilota::FastStr>> = Vec::with_capacity(list_ident.size);
+                            let mut val: ::std::vec::Vec<::std::collections::BTreeMap<Insanity, ::pilota::FastStr>> = ::std::vec::Vec::with_capacity(list_ident.size);
                             for i in 0..list_ident.size {
                                 val.as_mut_ptr().offset(i as isize).write({
                         let map_ident = __protocol.read_map_begin()?;
@@ -14961,7 +14983,7 @@ pub mod apache {
                 },Some(3) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_3 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push({
                         let map_ident = __protocol.read_map_begin().await?;
@@ -14982,7 +15004,7 @@ pub mod apache {
                     for _ in 0..list_ident.size {
                         val.insert({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push({
                         let map_ident = __protocol.read_map_begin().await?;
@@ -16857,19 +16879,22 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::std::vec::Vec<::std::vec::Vec<Bonk>>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<
+                                        ::std::vec::Vec<::std::vec::Vec<Bonk>>,
+                                    > = ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write(unsafe {
                                             let list_ident = __protocol.read_list_begin()?;
-                                            let mut val: Vec<::std::vec::Vec<Bonk>> =
-                                                Vec::with_capacity(list_ident.size);
+                                            let mut val: ::std::vec::Vec<::std::vec::Vec<Bonk>> =
+                                                ::std::vec::Vec::with_capacity(list_ident.size);
                                             for i in 0..list_ident.size {
                                                 val.as_mut_ptr().offset(i as isize).write(unsafe {
                                                     let list_ident =
                                                         __protocol.read_list_begin()?;
-                                                    let mut val: Vec<Bonk> =
-                                                        Vec::with_capacity(list_ident.size);
+                                                    let mut val: ::std::vec::Vec<Bonk> =
+                                                        ::std::vec::Vec::with_capacity(
+                                                            list_ident.size,
+                                                        );
                                                     for i in 0..list_ident.size {
                                                         val.as_mut_ptr().offset(i as isize).write(
                                                             ::pilota::thrift::Message::decode(
@@ -16948,15 +16973,15 @@ pub mod apache {
                     Some(1) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_1 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(<Bonk as ::pilota::thrift::Message>::decode_async(__protocol).await?);
                             };
@@ -17227,7 +17252,8 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<i32> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<i32> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -17296,7 +17322,8 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(__protocol.read_i32().await?);
                                         }
@@ -18929,7 +18956,8 @@ pub mod apache {
                             Some(8) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_8 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<i32> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<i32> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -19091,7 +19119,8 @@ pub mod apache {
                                 {
                                     var_8 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(__protocol.read_i32().await?);
                                         }
@@ -20024,13 +20053,13 @@ pub mod apache {
                             Some(1) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_1 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::std::vec::Vec<f64>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<::std::vec::Vec<f64>> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write(unsafe {
                                             let list_ident = __protocol.read_list_begin()?;
-                                            let mut val: Vec<f64> =
-                                                Vec::with_capacity(list_ident.size);
+                                            let mut val: ::std::vec::Vec<f64> =
+                                                ::std::vec::Vec::with_capacity(list_ident.size);
                                             for i in 0..list_ident.size {
                                                 val.as_mut_ptr()
                                                     .offset(i as isize)
@@ -20100,12 +20129,14 @@ pub mod apache {
                                 {
                                     var_1 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push({
                                                 let list_ident =
                                                     __protocol.read_list_begin().await?;
-                                                let mut val = Vec::with_capacity(list_ident.size);
+                                                let mut val =
+                                                    ::std::vec::Vec::with_capacity(list_ident.size);
                                                 for _ in 0..list_ident.size {
                                                     val.push(__protocol.read_double().await?);
                                                 }
@@ -20220,7 +20251,8 @@ pub mod apache {
                             if ret.is_none() {
                                 let field_ident = unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<i32> = Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<i32> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -20286,7 +20318,8 @@ pub mod apache {
                                 if ret.is_none() {
                                     let field_ident = {
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(__protocol.read_i32().await?);
                                         }

--- a/pilota-build/test_data/thrift/btree.rs
+++ b/pilota-build/test_data/thrift/btree.rs
@@ -394,8 +394,8 @@ pub mod btree {
                                     for _ in 0..map_ident.size {
                                         val.insert(__protocol.read_i32()?, unsafe {
                                             let list_ident = __protocol.read_list_begin()?;
-                                            let mut val: Vec<::std::sync::Arc<A>> =
-                                                Vec::with_capacity(list_ident.size);
+                                            let mut val: ::std::vec::Vec<::std::sync::Arc<A>> =
+                                                ::std::vec::Vec::with_capacity(list_ident.size);
                                             for i in 0..list_ident.size {
                                                 val.as_mut_ptr().offset(i as isize).write(
                                                     ::std::sync::Arc::new(
@@ -433,12 +433,12 @@ pub mod btree {
                                         val.insert(
                                             unsafe {
                                                 let list_ident = __protocol.read_list_begin()?;
-                                                let mut val: Vec<
+                                                let mut val: ::std::vec::Vec<
                                                     ::std::collections::BTreeMap<
                                                         ::std::collections::BTreeSet<i32>,
                                                         i32,
                                                     >,
-                                                > = Vec::with_capacity(list_ident.size);
+                                                > = ::std::vec::Vec::with_capacity(list_ident.size);
                                                 for i in 0..list_ident.size {
                                                     val.as_mut_ptr().offset(i as isize).write({
                         let map_ident = __protocol.read_map_begin()?;
@@ -560,7 +560,7 @@ pub mod btree {
                         for _ in 0..map_ident.size {
                             val.insert(__protocol.read_i32().await?, {
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(::std::sync::Arc::new(<A as ::pilota::thrift::Message>::decode_async(__protocol).await?));
                             };
@@ -588,7 +588,7 @@ pub mod btree {
                         for _ in 0..map_ident.size {
                             val.insert({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push({
                         let map_ident = __protocol.read_map_begin().await?;
@@ -732,6 +732,125 @@ pub mod btree {
                             )
                         },
                     )
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct Vec {}
+        impl ::pilota::thrift::Message for Vec {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Vec" };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{thrift::TLengthProtocolExt, Buf};
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `Vec` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let data = Self {};
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `Vec` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let data = Self {};
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Vec" })
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/btree.thrift
+++ b/pilota-build/test_data/thrift/btree.thrift
@@ -23,3 +23,7 @@ const map<Index, string> TEST_MAP = {
 }(pilota.rust_type = "btree")
 
 typedef map<set<i32>, string> TypeA(pilota.rust_type = "btree")
+
+struct Vec {
+    
+}

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -378,8 +378,8 @@ pub mod normal {
                             Some(3) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_3 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<SubMessage> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<SubMessage> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -519,7 +519,7 @@ pub mod normal {
                 },Some(3) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_3 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(<SubMessage as ::pilota::thrift::Message>::decode_async(__protocol).await?);
                             };
@@ -2299,8 +2299,8 @@ pub mod normal {
                             Some(3) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_3 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<SubMessage> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<SubMessage> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -2379,7 +2379,7 @@ pub mod normal {
                 },Some(3) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_3 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(<SubMessage as ::pilota::thrift::Message>::decode_async(__protocol).await?);
                             };

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -662,13 +662,14 @@ pub mod wrapper_arc {
                             Some(2) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_2 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::std::vec::Vec<::std::sync::Arc<A>>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<
+                                        ::std::vec::Vec<::std::sync::Arc<A>>,
+                                    > = ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write(unsafe {
                                             let list_ident = __protocol.read_list_begin()?;
-                                            let mut val: Vec<::std::sync::Arc<A>> =
-                                                Vec::with_capacity(list_ident.size);
+                                            let mut val: ::std::vec::Vec<::std::sync::Arc<A>> =
+                                                ::std::vec::Vec::with_capacity(list_ident.size);
                                             for i in 0..list_ident.size {
                                                 val.as_mut_ptr().offset(i as isize).write(
                                                     ::std::sync::Arc::new(
@@ -695,8 +696,8 @@ pub mod wrapper_arc {
                                     for _ in 0..map_ident.size {
                                         val.insert(__protocol.read_i32()?, unsafe {
                                             let list_ident = __protocol.read_list_begin()?;
-                                            let mut val: Vec<::std::sync::Arc<A>> =
-                                                Vec::with_capacity(list_ident.size);
+                                            let mut val: ::std::vec::Vec<::std::sync::Arc<A>> =
+                                                ::std::vec::Vec::with_capacity(list_ident.size);
                                             for i in 0..list_ident.size {
                                                 val.as_mut_ptr().offset(i as isize).write(
                                                     ::std::sync::Arc::new(
@@ -799,11 +800,11 @@ pub mod wrapper_arc {
                 },Some(2) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_2 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(::std::sync::Arc::new(<A as ::pilota::thrift::Message>::decode_async(__protocol).await?));
                             };
@@ -822,7 +823,7 @@ pub mod wrapper_arc {
                         for _ in 0..map_ident.size {
                             val.insert(__protocol.read_i32().await?, {
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(::std::sync::Arc::new(<A as ::pilota::thrift::Message>::decode_async(__protocol).await?));
                             };

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/message_TEST.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/message_TEST.rs
@@ -89,13 +89,13 @@ impl ::pilota::thrift::Message for Test {
                     Some(2) if field_ident.field_type == ::pilota::thrift::TType::List => {
                         var_2 = Some(unsafe {
                             let list_ident = __protocol.read_list_begin()?;
-                            let mut val: Vec<::std::vec::Vec<::std::sync::Arc<A>>> =
-                                Vec::with_capacity(list_ident.size);
+                            let mut val: ::std::vec::Vec<::std::vec::Vec<::std::sync::Arc<A>>> =
+                                ::std::vec::Vec::with_capacity(list_ident.size);
                             for i in 0..list_ident.size {
                                 val.as_mut_ptr().offset(i as isize).write(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::std::sync::Arc<A>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<::std::sync::Arc<A>> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write(
                                             ::std::sync::Arc::new(
@@ -120,8 +120,8 @@ impl ::pilota::thrift::Message for Test {
                             for _ in 0..map_ident.size {
                                 val.insert(__protocol.read_i32()?, unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::std::sync::Arc<A>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<::std::sync::Arc<A>> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write(
                                             ::std::sync::Arc::new(
@@ -218,11 +218,12 @@ impl ::pilota::thrift::Message for Test {
                         Some(2) if field_ident.field_type == ::pilota::thrift::TType::List => {
                             var_2 = Some({
                                 let list_ident = __protocol.read_list_begin().await?;
-                                let mut val = Vec::with_capacity(list_ident.size);
+                                let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                                 for _ in 0..list_ident.size {
                                     val.push({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(::std::sync::Arc::new(
                                                 <A as ::pilota::thrift::Message>::decode_async(
@@ -246,7 +247,8 @@ impl ::pilota::thrift::Message for Test {
                                 for _ in 0..map_ident.size {
                                     val.insert(__protocol.read_i32().await?, {
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push(::std::sync::Arc::new(
                                                 <A as ::pilota::thrift::Message>::decode_async(

--- a/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
@@ -1095,8 +1095,8 @@ pub mod gen {
                             Some(6) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_6 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::common::article::image::Image> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<::common::article::image::Image> =
+                                        ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr()
                                             .offset(i as isize)
@@ -1240,7 +1240,7 @@ pub mod gen {
                 },Some(6) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_6 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(<::common::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?);
                             };

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/message_Article.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/message_Article.rs
@@ -90,8 +90,8 @@ impl ::pilota::thrift::Message for Article {
                     Some(6) if field_ident.field_type == ::pilota::thrift::TType::List => {
                         var_6 = Some(unsafe {
                             let list_ident = __protocol.read_list_begin()?;
-                            let mut val: Vec<::common::article::image::Image> =
-                                Vec::with_capacity(list_ident.size);
+                            let mut val: ::std::vec::Vec<::common::article::image::Image> =
+                                ::std::vec::Vec::with_capacity(list_ident.size);
                             for i in 0..list_ident.size {
                                 val.as_mut_ptr()
                                     .offset(i as isize)
@@ -233,7 +233,7 @@ impl ::pilota::thrift::Message for Article {
                 },Some(6) if field_ident.field_type == ::pilota::thrift::TType::List  => {
                     var_6 = Some({
                             let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = Vec::with_capacity(list_ident.size);
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
                                 val.push(<::common::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?);
                             };

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -977,13 +977,14 @@ pub mod unknown_fields {
                             Some(3) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_3 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: Vec<::std::vec::Vec<::pilota::FastStr>> =
-                                        Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<
+                                        ::std::vec::Vec<::pilota::FastStr>,
+                                    > = ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
                                         val.as_mut_ptr().offset(i as isize).write(unsafe {
                                             let list_ident = __protocol.read_list_begin()?;
-                                            let mut val: Vec<::pilota::FastStr> =
-                                                Vec::with_capacity(list_ident.size);
+                                            let mut val: ::std::vec::Vec<::pilota::FastStr> =
+                                                ::std::vec::Vec::with_capacity(list_ident.size);
                                             for i in 0..list_ident.size {
                                                 val.as_mut_ptr()
                                                     .offset(i as isize)
@@ -1095,12 +1096,14 @@ pub mod unknown_fields {
                                 {
                                     var_3 = Some({
                                         let list_ident = __protocol.read_list_begin().await?;
-                                        let mut val = Vec::with_capacity(list_ident.size);
+                                        let mut val =
+                                            ::std::vec::Vec::with_capacity(list_ident.size);
                                         for _ in 0..list_ident.size {
                                             val.push({
                                                 let list_ident =
                                                     __protocol.read_list_begin().await?;
-                                                let mut val = Vec::with_capacity(list_ident.size);
+                                                let mut val =
+                                                    ::std::vec::Vec::with_capacity(list_ident.size);
                                                 for _ in 0..list_ident.size {
                                                     val.push(__protocol.read_faststr().await?);
                                                 }
@@ -3247,13 +3250,13 @@ pub mod unknown_fields {
                 use ::pilota::{thrift::TLengthProtocolExt, Buf};
                 ::std::result::Result::Ok(Td(unsafe {
                     let list_ident = __protocol.read_list_begin()?;
-                    let mut val: Vec<::std::vec::Vec<::pilota::FastStr>> =
-                        Vec::with_capacity(list_ident.size);
+                    let mut val: ::std::vec::Vec<::std::vec::Vec<::pilota::FastStr>> =
+                        ::std::vec::Vec::with_capacity(list_ident.size);
                     for i in 0..list_ident.size {
                         val.as_mut_ptr().offset(i as isize).write(unsafe {
                             let list_ident = __protocol.read_list_begin()?;
-                            let mut val: Vec<::pilota::FastStr> =
-                                Vec::with_capacity(list_ident.size);
+                            let mut val: ::std::vec::Vec<::pilota::FastStr> =
+                                ::std::vec::Vec::with_capacity(list_ident.size);
                             for i in 0..list_ident.size {
                                 val.as_mut_ptr()
                                     .offset(i as isize)
@@ -3283,11 +3286,11 @@ pub mod unknown_fields {
                 ::std::boxed::Box::pin(async move {
                     ::std::result::Result::Ok(Td({
                         let list_ident = __protocol.read_list_begin().await?;
-                        let mut val = Vec::with_capacity(list_ident.size);
+                        let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                         for _ in 0..list_ident.size {
                             val.push({
                                 let list_ident = __protocol.read_list_begin().await?;
-                                let mut val = Vec::with_capacity(list_ident.size);
+                                let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                                 for _ in 0..list_ident.size {
                                     val.push(__protocol.read_faststr().await?);
                                 }


### PR DESCRIPTION
Use absolute path for generated Vec, prevent conflicting with user defined struct named as Vec.