### PR TITLE
chore: migrate to rust 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -282,19 +281,6 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -340,41 +326,10 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
- "ahash",
- "anyhow",
- "criterion",
- "dashmap 5.5.3",
- "diffy",
- "faststr",
- "heck 0.5.0",
- "itertools 0.13.0",
- "linkedbytes",
- "normpath",
- "paste",
- "petgraph",
- "phf",
  "pilota",
  "pilota-build",
- "pilota-thrift-parser",
- "proc-macro2",
- "protobuf-parse2",
- "protobuf2",
- "quote",
- "rand",
- "rayon",
- "rustc-hash",
- "salsa",
- "scoped-tls",
- "serde",
- "serde_yaml",
- "syn 2.0.87",
- "tempfile",
- "tokio",
- "toml",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -857,7 +812,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "criterion",
- "dashmap 6.1.0",
+ "dashmap",
  "diffy",
  "faststr",
  "heck 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.11.8"
+version = "0.11.9"
 dependencies = [
  "ahash",
  "anyhow",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.29"
+version = "0.11.30"
 dependencies = [
  "ahash",
  "anyhow",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["pilota", "pilota-build", "pilota-thrift-parser", "examples"]
-resolver = "2"
+resolver = "3"
 
 [profile.bench]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,70 @@
 members = ["pilota", "pilota-build", "pilota-thrift-parser", "examples"]
 resolver = "3"
 
+[workspace.package]
+authors = ["Pilota Team <pilota@cloudwego.io>"]
+edition = "2024"
+homepage = "https://cloudwego.io/docs/pilota/"
+repository = "https://github.com/cloudwego/pilota"
+license = "MIT OR Apache-2.0"
+rust-version = "1.85.0"
+
+[workspace.dependencies]
+ahash = "0.8"
+anyhow = "1"
+async-recursion = "1"
+bytes = { version = "1", features = ["serde"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+dashmap = "6"
+diffy = "0.4"
+faststr = "0.2"
+heck = "0.5"
+integer-encoding = { version = "4", features = ["tokio", "tokio_async"] }
+itertools = "0.13"
+lazy_static = "1"
+linkedbytes = "0.1"
+nom = "7"
+normpath = "1"
+ordered-float = { version = "4", features = ["serde"] }
+paste = "1"
+petgraph = "0.6"
+phf = { version = "0.11", features = ["macros"] }
+proc-macro2 = "1"
+proptest = "1"
+quote = "1"
+rand = "0.8"
+rayon = "1"
+rustc-hash = "1"
+salsa = { version = "0.17.0-pre.2" }
+scoped-tls = "1"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+smallvec = "1"
+syn = "2"
+tempfile = "3"
+thiserror = "1"
+tokio = { version = "1", features = ["io-util"] }
+toml = "0.8"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# The official rust-protobuf parser currently has some bug.
+# We will switch to the official one when https://github.com/stepancheg/rust-protobuf/pull/646 is fixed.
+protobuf-parse = { package = "protobuf-parse2", version = "4.0.0-alpha.4" }
+protobuf = { package = "protobuf2", version = "4.0.0-alpha.2" }
+
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'unwind'
+incremental = false
+overflow-checks = false
+
 [profile.bench]
 opt-level = 3
 debug = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "examples"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 homepage = "https://cloudwego.io/docs/pilota/"
 repository = "https://github.com/cloudwego/pilota"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "examples"
-version = "0.1.0"
-edition = "2024"
-description = "Compile thrift and protobuf idl into rust code at compile-time."
-homepage = "https://cloudwego.io/docs/pilota/"
-repository = "https://github.com/cloudwego/pilota"
-license = "MIT OR Apache-2.0"
-authors = ["Pilota Team <pilota@cloudwego.io>"]
-keywords = ["serialization", "thrift", "protobuf", "volo"]
+version = "0.0.0"
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+authors.workspace = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,41 +16,3 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 pilota = { path = "../pilota", features = ["pb-encode-default-value"] }
 pilota-build = { path = "../pilota-build" }
-pilota-thrift-parser = { path = "../pilota-thrift-parser", version = "0.11" }
-
-ahash = "0.8"
-anyhow = "1"
-dashmap = "5"
-heck = "0.5"
-itertools = "0.13"
-normpath = "1"
-paste = "1"
-petgraph = "0.6"
-phf = { version = "0.11", features = ["macros"] }
-proc-macro2 = "1"
-quote = "1"
-rayon = "1"
-rustc-hash = "1"
-salsa = { version = "0.17.0-pre.2" }
-scoped-tls = "1"
-serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
-syn = "2"
-toml = "0.8"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-# The official rust-protobuf parser currently has some bug.
-# We will switch to the official one when https://github.com/stepancheg/rust-protobuf/pull/646 is fixed.
-protobuf-parse = { package = "protobuf-parse2", version = "4.0.0-alpha.4" }
-protobuf = { package = "protobuf2", version = "4.0.0-alpha.2" }
-faststr = "0.2"
-
-[dev-dependencies]
-
-tokio = { version = "1", features = ["io-util"] }
-tempfile = "3"
-diffy = "0.4"
-criterion = { version = "0.5", features = ["html_reports"] }
-rand = "0.8"
-linkedbytes = "0.1"

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.29"
+version = "0.11.30"
 edition = "2021"
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "pilota-build"
 version = "0.11.30"
-edition = "2021"
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
 description = "Compile thrift and protobuf idl into rust code at compile-time."
 documentation = "https://docs.rs/pilota-build"
 readme = "README.md"
-homepage = "https://cloudwego.io/docs/pilota/"
-repository = "https://github.com/cloudwego/pilota"
-license = "MIT OR Apache-2.0"
-authors = ["Pilota Team <pilota@cloudwego.io>"]
 keywords = ["serialization", "thrift", "protobuf", "volo"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -19,42 +20,40 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 pilota-thrift-parser = { path = "../pilota-thrift-parser", version = "0.11" }
 
-ahash = "0.8"
-anyhow = "1"
-dashmap = "6"
-heck = "0.5"
-itertools = "0.13"
-normpath = "1"
-paste = "1"
-petgraph = "0.6"
-phf = { version = "0.11", features = ["macros"] }
-proc-macro2 = "1"
-quote = "1"
-rayon = "1"
-rustc-hash = "1"
-salsa = { version = "0.17.0-pre.2" }
-scoped-tls = "1"
-serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
-syn = "2"
-toml = "0.8"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+ahash.workspace = true
+anyhow.workspace = true
+dashmap.workspace = true
+faststr.workspace = true
+heck.workspace = true
+itertools.workspace = true
+normpath.workspace = true
+paste.workspace = true
+petgraph.workspace = true
+phf.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+rayon.workspace = true
+rustc-hash.workspace = true
+salsa.workspace = true
+scoped-tls.workspace = true
+serde.workspace = true
+serde_yaml.workspace = true
+syn.workspace = true
+toml.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
-# The official rust-protobuf parser currently has some bug.
-# We will switch to the official one when https://github.com/stepancheg/rust-protobuf/pull/646 is fixed.
-protobuf-parse = { package = "protobuf-parse2", version = "4.0.0-alpha.4" }
-protobuf = { package = "protobuf2", version = "4.0.0-alpha.2" }
-faststr = "0.2"
+protobuf-parse.workspace = true
+protobuf.workspace = true
 
 [dev-dependencies]
 pilota = { path = "../pilota" }
-tokio = { version = "1", features = ["io-util"] }
-tempfile = "3"
-diffy = "0.4"
-criterion = { version = "0.5", features = ["html_reports"] }
-rand = "0.8"
-linkedbytes = "0.1"
+tokio.workspace = true
+tempfile.workspace = true
+diffy.workspace = true
+criterion.workspace = true
+rand.workspace = true
+linkedbytes.workspace = true
 
 [[bench]]
 name = "codegen"

--- a/pilota-build/benches/codegen.rs
+++ b/pilota-build/benches/codegen.rs
@@ -1,7 +1,7 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use pilota::{
     prost::bytes::BytesMut,
-    thrift::{binary::TBinaryProtocol, Message},
+    thrift::{Message, binary::TBinaryProtocol},
 };
 
 include!("../test_data/thrift/default_value.rs");

--- a/pilota-build/benches/unknown.rs
+++ b/pilota-build/benches/unknown.rs
@@ -1,14 +1,14 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use faststr::FastStr;
 use pilota::{
     prost::bytes::BytesMut,
     thrift::{
+        Message,
         binary::TBinaryProtocol,
         binary_unsafe::{TBinaryUnsafeInputProtocol, TBinaryUnsafeOutputProtocol},
-        Message,
     },
 };
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{Rng, distributions::Alphanumeric};
 
 include!("../test_data/thrift/normal.rs");
 include!("../test_data/unknown_fields.rs");

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -622,7 +622,7 @@ where
         fmt_file(file_name)
     }
 
-    pub fn gen(self) -> anyhow::Result<()> {
+    pub fn r#gen(self) -> anyhow::Result<()> {
         match &*self.mode.clone() {
             Mode::Workspace(info) => self.write_workspace(info.dir.clone()),
             Mode::SingleFile { file_path: p } => {

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use ahash::{AHashMap, AHashSet};
-use dashmap::{mapref::one::RefMut, DashMap};
+use dashmap::{DashMap, mapref::one::RefMut};
 use faststr::FastStr;
 use itertools::Itertools;
 use normpath::PathExt;
@@ -17,17 +17,17 @@ use traits::CodegenBackend;
 
 use self::workspace::Workspace;
 use crate::{
+    Context, Symbol,
     db::RirDatabase,
     dedup::def_id_equal,
     fmt::fmt_file,
     middle::{
         self,
-        context::{tls::CUR_ITEM, Mode},
+        context::{Mode, tls::CUR_ITEM},
         rir,
     },
     rir::{Item, NodeKind},
     symbol::{DefId, EnumRepr, FileId},
-    Context, Symbol,
 };
 
 pub(crate) mod pkg_tree;

--- a/pilota-build/src/codegen/protobuf/mod.rs
+++ b/pilota-build/src/codegen/protobuf/mod.rs
@@ -6,12 +6,12 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 
 use crate::{
+    CodegenBackend, Context, DefId,
     db::RirDatabase,
     middle::ty::{self},
     rir::{self, Field, FieldKind, Item, NodeKind},
     tags::protobuf::{OneOf, ProstType},
     ty::Ty,
-    CodegenBackend, Context, DefId,
 };
 
 #[derive(Clone)]

--- a/pilota-build/src/codegen/protobuf/mod.rs
+++ b/pilota-build/src/codegen/protobuf/mod.rs
@@ -6,12 +6,12 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 
 use crate::{
-    CodegenBackend, Context, DefId,
     db::RirDatabase,
     middle::ty::{self},
     rir::{self, Field, FieldKind, Item, NodeKind},
     tags::protobuf::{OneOf, ProstType},
     ty::Ty,
+    CodegenBackend, Context, DefId,
 };
 
 #[derive(Clone)]

--- a/pilota-build/src/codegen/protobuf/mod.rs
+++ b/pilota-build/src/codegen/protobuf/mod.rs
@@ -6,12 +6,12 @@ use proc_macro2::{Ident, Span};
 use quote::quote;
 
 use crate::{
+    CodegenBackend, Context, DefId,
     db::RirDatabase,
     middle::ty::{self},
     rir::{self, Field, FieldKind, Item, NodeKind},
     tags::protobuf::{OneOf, ProstType},
     ty::Ty,
-    CodegenBackend, Context, DefId,
 };
 
 #[derive(Clone)]
@@ -280,7 +280,7 @@ impl ProtobufBackend {
         }
     }
 
-    fn field_tags(&self, field: &Field) -> impl Iterator<Item = u32> {
+    fn field_tags(&self, field: &Field) -> impl Iterator<Item = u32> + use<> {
         if let ty::TyKind::Path(path) = &field.ty.kind {
             if let Some(node) = &self.cx.node(path.did) {
                 if self.cx.contains_tag::<OneOf>(node.tags) {
@@ -496,7 +496,7 @@ impl CodegenBackend for ProtobufBackend {
             format! {
                 r#"{tag} => {{
                     match field {{
-                        ::core::option::Option::Some({name}::{variant_name}(ref mut value)) => {{
+                        ::core::option::Option::Some({name}::{variant_name}(value)) => {{
                             {merge}?;
                         }},
                         _ => {{

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -1,11 +1,11 @@
 use faststr::FastStr;
 
-use super::{decode_helper::DecodeHelper, ThriftBackend};
+use super::{ThriftBackend, decode_helper::DecodeHelper};
 use crate::{
+    DefId,
     db::RirDatabase,
     middle::{rir, ty, ty::Ty},
     symbol::EnumRepr,
-    DefId,
 };
 
 impl ThriftBackend {

--- a/pilota-build/src/codegen/traits.rs
+++ b/pilota-build/src/codegen/traits.rs
@@ -1,7 +1,7 @@
 use crate::{
+    Context,
     middle::rir::{self, Method},
     symbol::DefId,
-    Context,
 };
 
 pub trait CodegenBackend: Clone {

--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -219,7 +219,7 @@ where
 
         let mut lib_rs_stream = String::default();
         lib_rs_stream.push_str("include!(\"gen.rs\");\n");
-        lib_rs_stream.push_str("pub use gen::*;\n\n");
+        lib_rs_stream.push_str("pub use r#gen::*;\n\n");
 
         if let Some(user_gen) = info.user_gen {
             if !user_gen.is_empty() {
@@ -254,7 +254,7 @@ where
                 main_mod_path.iter().map(|item| item.to_string()).join("::")
             ));
         }
-        gen_rs_stream = format! {r#"pub mod gen {{
+        gen_rs_stream = format! {r#"pub mod r#gen {{
             #![allow(warnings, clippy::all)]
             {gen_rs_stream}
         }}"#};

--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -8,8 +8,8 @@ use rustc_hash::FxHashMap;
 
 use super::CodegenItem;
 use crate::{
-    fmt::fmt_file, middle::context::DefLocation, rir::ItemPath, Codegen, CodegenBackend, Context,
-    DefId,
+    Codegen, CodegenBackend, Context, DefId, fmt::fmt_file, middle::context::DefLocation,
+    rir::ItemPath,
 };
 
 #[derive(Clone)]

--- a/pilota-build/src/db.rs
+++ b/pilota-build/src/db.rs
@@ -3,6 +3,7 @@ use std::{fmt, path::PathBuf, sync::Arc};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
+    TagId,
     middle::{
         context::{CrateId, DefLocation},
         rir,
@@ -12,7 +13,6 @@ use crate::{
     },
     symbol::{DefId, FileId},
     tags::Tags,
-    TagId,
 };
 
 #[derive(Default)]

--- a/pilota-build/src/dedup.rs
+++ b/pilota-build/src/dedup.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use rustc_hash::FxHashMap;
 
 use crate::{
+    DefId,
     rir::{Arg, EnumVariant, Field, Item, Method, Node},
     ty::{Ty, TyKind},
-    DefId,
 };
 
 type Nodes = Arc<FxHashMap<DefId, Node>>;

--- a/pilota-build/src/fmt.rs
+++ b/pilota-build/src/fmt.rs
@@ -1,7 +1,7 @@
 use std::{
     io::Write,
     path::Path,
-    process::{exit, Command},
+    process::{Command, exit},
 };
 
 pub fn fmt_file<P: AsRef<Path>>(file: P) {

--- a/pilota-build/src/index.rs
+++ b/pilota-build/src/index.rs
@@ -56,7 +56,7 @@ macro_rules! newtype_index {
     (@derives      [$($derives:ident,)*]
      @attrs        [$(#[$attrs:meta])*]
      @type         [$type:ident]
-     @max          [$max:expr]
+     @max          [$max:expr_2021]
      @vis          [$v:vis]
      @debug_format [$debug_format:tt]) => (
         $(#[$attrs])*
@@ -229,7 +229,7 @@ macro_rules! newtype_index {
 
     (@attrs        [$(#[$attrs:meta])*]
      @type         [$type:ident]
-     @max          [$max:expr]
+     @max          [$max:expr_2021]
      @vis          [$v:vis]
      @debug_format [$debug_format:tt]
                    $($tokens:tt)*) => (

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -26,11 +26,11 @@ mod dedup;
 pub mod plugin;
 
 pub use codegen::{
-    protobuf::ProtobufBackend, thrift::ThriftBackend, traits::CodegenBackend, Codegen,
+    Codegen, protobuf::ProtobufBackend, thrift::ThriftBackend, traits::CodegenBackend,
 };
 use db::{RirDatabase, RootDatabase};
 use middle::{
-    context::{tls::CONTEXT, CollectMode, ContextBuilder, Mode, WorkspaceInfo},
+    context::{CollectMode, ContextBuilder, Mode, WorkspaceInfo, tls::CONTEXT},
     rir::NodeKind,
     type_graph::TypeGraph,
     workspace_graph::WorkspaceGraph,
@@ -39,7 +39,7 @@ pub use middle::{
     context::{Context, SourceType},
     rir, ty,
 };
-use parser::{protobuf::ProtobufParser, thrift::ThriftParser, ParseResult, Parser};
+use parser::{ParseResult, Parser, protobuf::ProtobufParser, thrift::ThriftParser};
 use plugin::{AutoDerivePlugin, BoxedPlugin, ImplDefaultPlugin, PredicateResult, WithAttrsPlugin};
 pub use plugin::{BoxClonePlugin, ClonePlugin, Plugin};
 use resolve::{ResolveResult, Resolver};

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -295,11 +295,11 @@ where
 
         db.set_files_with_durability(Arc::new(files), Durability::HIGH);
         let items = nodes.iter().filter_map(|(k, v)| {
-            if let NodeKind::Item(item) = &v.kind {
+            match &v.kind { NodeKind::Item(item) => {
                 Some((*k, item.clone()))
-            } else {
+            } _ => {
                 None
-            }
+            }}
         });
 
         let type_graph = Arc::from(TypeGraph::from_items(items.clone()));
@@ -429,7 +429,7 @@ where
 
             pool.install(move || {
                 let cg = Codegen::new(self.mk_backend.make_backend(cx));
-                cg.gen().unwrap();
+                cg.r#gen().unwrap();
             });
 
             Ok::<_, rayon::ThreadPoolBuildError>(())

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -294,12 +294,9 @@ where
         } = Resolver::default().resolve_files(&files);
 
         db.set_files_with_durability(Arc::new(files), Durability::HIGH);
-        let items = nodes.iter().filter_map(|(k, v)| {
-            match &v.kind { NodeKind::Item(item) => {
-                Some((*k, item.clone()))
-            } _ => {
-                None
-            }}
+        let items = nodes.iter().filter_map(|(k, v)| match &v.kind {
+            NodeKind::Item(item) => Some((*k, item.clone())),
+            _ => None,
         });
 
         let type_graph = Arc::from(TypeGraph::from_items(items.clone()));

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -15,12 +15,12 @@ use super::{
     rir::NodeKind,
 };
 use crate::{
+    Plugin,
     db::{RirDatabase, RootDatabase},
     rir::{self, Field, Item, ItemPath, Literal},
-    symbol::{DefId, FileId, IdentName, Symbol, SPECIAL_NAMINGS},
+    symbol::{DefId, FileId, IdentName, SPECIAL_NAMINGS, Symbol},
     tags::{TagId, Tags},
     ty::{AdtDef, AdtKind, CodegenTy, Visitor},
-    Plugin,
 };
 
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
@@ -735,11 +735,7 @@ impl Context {
                                 Literal::String(s) => s,
                                 _ => panic!(),
                             };
-                            if **k == **f.name {
-                                Some(v)
-                            } else {
-                                None
-                            }
+                            if **k == **f.name { Some(v) } else { None }
                         });
 
                         let name = self.rust_name(f.did);

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -121,17 +121,17 @@ impl ContextBuilder {
         match mode {
             CollectMode::All => {
                 let nodes = self.db.nodes();
-                self.codegen_items.extend(nodes.iter().filter_map(|(k, v)| {
-                    match &v.kind { NodeKind::Item(i) => {
-                        if !matches!(&**i, Item::Mod(_)) {
-                            Some(k)
-                        } else {
-                            None
+                self.codegen_items
+                    .extend(nodes.iter().filter_map(|(k, v)| match &v.kind {
+                        NodeKind::Item(i) => {
+                            if !matches!(&**i, Item::Mod(_)) {
+                                Some(k)
+                            } else {
+                                None
+                            }
                         }
-                    } _ => {
-                        None
-                    }}
-                }));
+                        _ => None,
+                    }));
             }
             CollectMode::OnlyUsed { touches } => {
                 let extra_def_ids = touches

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -122,15 +122,15 @@ impl ContextBuilder {
             CollectMode::All => {
                 let nodes = self.db.nodes();
                 self.codegen_items.extend(nodes.iter().filter_map(|(k, v)| {
-                    if let NodeKind::Item(i) = &v.kind {
+                    match &v.kind { NodeKind::Item(i) => {
                         if !matches!(&**i, Item::Mod(_)) {
                             Some(k)
                         } else {
                             None
                         }
-                    } else {
+                    } _ => {
                         None
-                    }
+                    }}
                 }));
             }
             CollectMode::OnlyUsed { touches } => {

--- a/pilota-build/src/middle/resolver.rs
+++ b/pilota-build/src/middle/resolver.rs
@@ -43,16 +43,19 @@ impl PathResolver for DefaultPathResolver {
     fn mod_prefix(&self, cx: &Context, def_id: DefId) -> Arc<[Symbol]> {
         fn calc_item_path(cx: &Context, def_id: DefId, segs: &mut Vec<Symbol>) {
             let node = cx.node(def_id).unwrap();
-            match node.parent { Some(parent) => {
-                tracing::debug!("the parent of {:?} is {:?} ", def_id, parent);
-                calc_item_path(cx, parent, segs)
-            } _ => {
-                let file = cx.file(node.file_id).unwrap();
-                let package = &file.package;
-                if package.len() != 1 || !package.first().unwrap().0.is_empty() {
-                    segs.extend(package.iter().map(|s| (&*s.0).mod_ident().into()))
+            match node.parent {
+                Some(parent) => {
+                    tracing::debug!("the parent of {:?} is {:?} ", def_id, parent);
+                    calc_item_path(cx, parent, segs)
                 }
-            }}
+                _ => {
+                    let file = cx.file(node.file_id).unwrap();
+                    let package = &file.package;
+                    if package.len() != 1 || !package.first().unwrap().0.is_empty() {
+                        segs.extend(package.iter().map(|s| (&*s.0).mod_ident().into()))
+                    }
+                }
+            }
 
             if let NodeKind::Item(item) = node.kind {
                 if let crate::rir::Item::Mod(_) = &*item {

--- a/pilota-build/src/middle/resolver.rs
+++ b/pilota-build/src/middle/resolver.rs
@@ -43,16 +43,16 @@ impl PathResolver for DefaultPathResolver {
     fn mod_prefix(&self, cx: &Context, def_id: DefId) -> Arc<[Symbol]> {
         fn calc_item_path(cx: &Context, def_id: DefId, segs: &mut Vec<Symbol>) {
             let node = cx.node(def_id).unwrap();
-            if let Some(parent) = node.parent {
+            match node.parent { Some(parent) => {
                 tracing::debug!("the parent of {:?} is {:?} ", def_id, parent);
                 calc_item_path(cx, parent, segs)
-            } else {
+            } _ => {
                 let file = cx.file(node.file_id).unwrap();
                 let package = &file.package;
                 if package.len() != 1 || !package.first().unwrap().0.is_empty() {
                     segs.extend(package.iter().map(|s| (&*s.0).mod_ident().into()))
                 }
-            }
+            }}
 
             if let NodeKind::Item(item) = node.kind {
                 if let crate::rir::Item::Mod(_) = &*item {

--- a/pilota-build/src/middle/resolver.rs
+++ b/pilota-build/src/middle/resolver.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use faststr::FastStr;
 use itertools::Itertools;
 
-use crate::{db::RirDatabase, rir::NodeKind, symbol::Symbol, Context, DefId, IdentName};
+use crate::{Context, DefId, IdentName, db::RirDatabase, rir::NodeKind, symbol::Symbol};
 
 pub trait PathResolver: Sync + Send {
     fn path_for_def_id(&self, cx: &Context, def_id: DefId) -> Arc<[Symbol]> {

--- a/pilota-build/src/middle/ty.rs
+++ b/pilota-build/src/middle/ty.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 pub use std::sync::Arc;
 
-use itertools::Itertools;
 pub use TyKind::*;
+use itertools::Itertools;
 
 use super::context::tls::with_cx;
 pub use super::rir::Path;

--- a/pilota-build/src/middle/type_graph.rs
+++ b/pilota-build/src/middle/type_graph.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use petgraph::{algo::has_path_connecting, graph::NodeIndex, Graph};
+use petgraph::{Graph, algo::has_path_connecting, graph::NodeIndex};
 use rustc_hash::FxHashMap;
 
 use super::{

--- a/pilota-build/src/middle/workspace_graph.rs
+++ b/pilota-build/src/middle/workspace_graph.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use petgraph::{algo::has_path_connecting, graph::NodeIndex, Graph};
+use petgraph::{Graph, algo::has_path_connecting, graph::NodeIndex};
 use rustc_hash::FxHashMap;
 
 use super::{

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -5,21 +5,21 @@ use faststr::FastStr;
 use itertools::Itertools;
 use normpath::PathExt;
 use protobuf::descriptor::{
-    field_descriptor_proto::{Label, Type},
     DescriptorProto, EnumDescriptorProto, ServiceDescriptorProto,
+    field_descriptor_proto::{Label, Type},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::Parser;
 use crate::{
+    IdentName,
     index::Idx,
     ir::{self, FieldKind, Item, Path, TyKind},
     symbol::{EnumRepr, FileId, Ident},
     tags::{
-        protobuf::{ClientStreaming, OneOf, ProstType, Repeated, ServerStreaming},
         PilotaName, Tags,
+        protobuf::{ClientStreaming, OneOf, ProstType, Repeated, ServerStreaming},
     },
-    IdentName,
 };
 
 #[derive(Default)]

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -11,12 +11,12 @@ use salsa::ParallelDatabase;
 use thrift_parser::Annotations;
 
 use crate::{
+    IdentName,
     index::Idx,
     ir::{self, Arg, Enum, EnumVariant, FieldKind, File, Item, ItemKind, Path},
     symbol::{EnumRepr, FileId, Ident},
     tags::{Annotation, PilotaName, RustWrapperArc, Tags},
     util::error_abort,
-    IdentName,
 };
 
 #[salsa::query_group(SourceDatabaseStorage)]

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -350,15 +350,15 @@ impl Plugin for ImplDefaultPlugin {
                         .map(|f| {
                             let name = cx.rust_name(f.did);
                             let default = cx.default_val(f).map(|v| v.0);
-                            if let Some(default) = default {
+                            match default { Some(default) => {
                                 let mut val = default;
                                 if f.is_optional() {
                                     val = format!("Some({val})").into()
                                 }
                                 format!("{name}: {val}")
-                            } else {
+                            } _ => {
                                 format!("{name}: ::std::default::Default::default()")
-                            }
+                            }}
                         })
                         .join(",\n");
 

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -5,12 +5,12 @@ use itertools::Itertools;
 use rustc_hash::FxHashMap;
 
 use crate::{
+    Context,
     db::RirDatabase,
     middle::context::tls::CUR_ITEM,
     rir::{EnumVariant, Field, Item, NodeKind},
     symbol::DefId,
     ty::{self, Ty, Visitor},
-    Context,
 };
 
 mod serde;

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -350,15 +350,18 @@ impl Plugin for ImplDefaultPlugin {
                         .map(|f| {
                             let name = cx.rust_name(f.did);
                             let default = cx.default_val(f).map(|v| v.0);
-                            match default { Some(default) => {
-                                let mut val = default;
-                                if f.is_optional() {
-                                    val = format!("Some({val})").into()
+                            match default {
+                                Some(default) => {
+                                    let mut val = default;
+                                    if f.is_optional() {
+                                        val = format!("Some({val})").into()
+                                    }
+                                    format!("{name}: {val}")
                                 }
-                                format!("{name}: {val}")
-                            } _ => {
-                                format!("{name}: ::std::default::Default::default()")
-                            }}
+                                _ => {
+                                    format!("{name}: ::std::default::Default::default()")
+                                }
+                            }
                         })
                         .join(",\n");
 

--- a/pilota-build/src/plugin/workspace.rs
+++ b/pilota-build/src/plugin/workspace.rs
@@ -31,8 +31,8 @@ impl Plugin for _WorkspacePlugin {
     ) {
         if let Item::Service(s) = &*item {
             if let Some(loc) = cx.location_map.get(&def_id) {
-                if let Some(mut gen) = cx.plugin_gen.get_mut(loc) {
-                    gen.push_str(&format!("pub struct {};", s.name.sym));
+                if let Some(mut r#gen) = cx.plugin_gen.get_mut(loc) {
+                    r#gen.push_str(&format!("pub struct {};", s.name.sym));
                 }
             };
         }

--- a/pilota-build/src/plugin/workspace.rs
+++ b/pilota-build/src/plugin/workspace.rs
@@ -1,8 +1,8 @@
 use crate::{
+    Plugin,
     db::RirDatabase,
     middle::context::tls::CUR_ITEM,
     rir::{Item, NodeKind},
-    Plugin,
 };
 
 #[derive(Clone, Copy)]

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -534,11 +534,10 @@ impl Resolver {
             Namespace::Mod => unreachable!(),
         };
         {
-            let segs = match segs.strip_prefix(&*cur_file.package.segments) { Some(segs) => {
-                segs
-            } _ => {
-                segs
-            }};
+            let segs = match segs.strip_prefix(&*cur_file.package.segments) {
+                Some(segs) => segs,
+                _ => segs,
+            };
 
             let def_id = self.blocks.iter().rev().find_map(|b| {
                 let b = unsafe { b.as_ref() };
@@ -558,13 +557,12 @@ impl Resolver {
         let def_id = cur_file
             .uses
             .iter()
-            .find_map(|f| {
-                match path.segments.strip_prefix(&*f.0.segments) { Some(rest) => {
+            .find_map(|f| match path.segments.strip_prefix(&*f.0.segments) {
+                Some(rest) => {
                     let file = &self.file_sym_map[&f.1];
                     self.find_path_in_table(rest, ns, file)
-                } _ => {
-                    None
-                }}
+                }
+                _ => None,
             })
             .unwrap_or_else(|| {
                 panic!(

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -534,11 +534,11 @@ impl Resolver {
             Namespace::Mod => unreachable!(),
         };
         {
-            let segs = if let Some(segs) = segs.strip_prefix(&*cur_file.package.segments) {
+            let segs = match segs.strip_prefix(&*cur_file.package.segments) { Some(segs) => {
                 segs
-            } else {
+            } _ => {
                 segs
-            };
+            }};
 
             let def_id = self.blocks.iter().rev().find_map(|b| {
                 let b = unsafe { b.as_ref() };
@@ -559,12 +559,12 @@ impl Resolver {
             .uses
             .iter()
             .find_map(|f| {
-                if let Some(rest) = path.segments.strip_prefix(&*f.0.segments) {
+                match path.segments.strip_prefix(&*f.0.segments) { Some(rest) => {
                     let file = &self.file_sym_map[&f.1];
                     self.find_path_in_table(rest, ns, file)
-                } else {
+                } _ => {
                     None
-                }
+                }}
             })
             .unwrap_or_else(|| {
                 panic!(

--- a/pilota-build/src/symbol.rs
+++ b/pilota-build/src/symbol.rs
@@ -20,7 +20,7 @@ static KEYWORDS_SET: phf::Set<&'static str> = phf_set![
     "return", "Self", "self", "static", "struct", "super", "trait", "true", "type", "unsafe",
     "where", "while", "abstract", "alignof", "become", "box", "do", "final", "macro", "offsetof",
     "override", "priv", "proc", "pure", "sizeof", "typeof", "unsized", "virtual", "yield", "dyn",
-    "async", "await", "try"
+    "async", "await", "try", "gen"
 ];
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug, PartialOrd, Ord)]

--- a/pilota-build/src/tags.rs
+++ b/pilota-build/src/tags.rs
@@ -62,7 +62,7 @@ impl DerefMut for Tags {
 #[macro_export]
 macro_rules! tags {
     {
-        $($value: expr),*
+        $($value: expr_2021),*
     } => {
         {
             let mut tags = $crate::tags::Tags::default();

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -4,7 +4,7 @@ use std::{fs, fs::File, path::Path, process::Command};
 
 use tempfile::tempdir;
 
-use crate::{plugin::SerdePlugin, IdlService};
+use crate::{IdlService, plugin::SerdePlugin};
 
 fn diff_file(old: impl AsRef<Path>, new: impl AsRef<Path>) {
     let old_content =
@@ -497,7 +497,7 @@ fn test_unknown_fields() {
 mod tests {
     use pilota::{
         prost::bytes::BytesMut,
-        thrift::{binary::TBinaryProtocol, Message},
+        thrift::{Message, binary::TBinaryProtocol},
     };
 
     use self::decode_error::decode_error::A;

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -145,7 +145,7 @@ pub mod oneof {
             {
                 match tag {
                     6 => match field {
-                        ::core::option::Option::Some(Test::A(ref mut value)) => {
+                        ::core::option::Option::Some(Test::A(value)) => {
                             ::pilota::prost::encoding::faststr::merge(wire_type, value, buf, ctx)?;
                         }
                         _ => {
@@ -156,7 +156,7 @@ pub mod oneof {
                         }
                     },
                     8 => match field {
-                        ::core::option::Option::Some(Test::B(ref mut value)) => {
+                        ::core::option::Option::Some(Test::B(value)) => {
                             ::pilota::prost::encoding::int32::merge(wire_type, value, buf, ctx)?;
                         }
                         _ => {
@@ -218,7 +218,7 @@ pub mod oneof {
             {
                 match tag {
                     2 => match field {
-                        ::core::option::Option::Some(Type::S(ref mut value)) => {
+                        ::core::option::Option::Some(Type::S(value)) => {
                             ::pilota::prost::encoding::faststr::merge(wire_type, value, buf, ctx)?;
                         }
                         _ => {
@@ -229,7 +229,7 @@ pub mod oneof {
                         }
                     },
                     4 => match field {
-                        ::core::option::Option::Some(Type::I(ref mut value)) => {
+                        ::core::option::Option::Some(Type::I(value)) => {
                             ::pilota::prost::encoding::int32::merge(wire_type, value, buf, ctx)?;
                         }
                         _ => {

--- a/pilota-build/test_data/thrift/apache.rs
+++ b/pilota-build/test_data/thrift/apache.rs
@@ -843,10 +843,10 @@ pub mod apache {
                     name: "ThriftTestTestMultiExceptionException",
                 })?;
                 match self {
-                    ThriftTestTestMultiExceptionException::Err1(ref value) => {
+                    ThriftTestTestMultiExceptionException::Err1(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ThriftTestTestMultiExceptionException::Err2(ref value) => {
+                    ThriftTestTestMultiExceptionException::Err2(value) => {
                         __protocol.write_struct_field(2, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -998,10 +998,10 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMultiExceptionException",
                 }) + match self {
-                    ThriftTestTestMultiExceptionException::Err1(ref value) => {
+                    ThriftTestTestMultiExceptionException::Err1(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
-                    ThriftTestTestMultiExceptionException::Err2(ref value) => {
+                    ThriftTestTestMultiExceptionException::Err2(value) => {
                         __protocol.struct_field_len(Some(2), value)
                     }
                 } + __protocol.field_stop_len()
@@ -1300,7 +1300,7 @@ pub mod apache {
                     name: "ThriftTestTestMultiResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestMultiResultRecv::Ok(ref value) => {
+                    ThriftTestTestMultiResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -1416,7 +1416,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMultiResultRecv",
                 }) + match self {
-                    ThriftTestTestMultiResultRecv::Ok(ref value) => {
+                    ThriftTestTestMultiResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -1762,7 +1762,7 @@ pub mod apache {
                     name: "ThriftTestTestEnumResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestEnumResultRecv::Ok(ref value) => {
+                    ThriftTestTestEnumResultRecv::Ok(value) => {
                         __protocol.write_i32_field(0, (value).inner())?;
                     }
                 }
@@ -1878,7 +1878,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestEnumResultRecv",
                 }) + match self {
-                    ThriftTestTestEnumResultRecv::Ok(ref value) => {
+                    ThriftTestTestEnumResultRecv::Ok(value) => {
                         __protocol.i32_field_len(Some(0), (value).inner())
                     }
                 } + __protocol.field_stop_len()
@@ -1906,7 +1906,7 @@ pub mod apache {
                     name: "ThriftTestTestOnewayResultSend",
                 })?;
                 match self {
-                    ThriftTestTestOnewayResultSend::Ok(ref value) => {}
+                    ThriftTestTestOnewayResultSend::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -1984,7 +1984,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestOnewayResultSend",
                 }) + match self {
-                    ThriftTestTestOnewayResultSend::Ok(ref value) => 0,
+                    ThriftTestTestOnewayResultSend::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -2160,7 +2160,7 @@ pub mod apache {
                     name: "ThriftTestTestMapResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestMapResultRecv::Ok(ref value) => {
+                    ThriftTestTestMapResultRecv::Ok(value) => {
                         __protocol.write_map_field(
                             0,
                             ::pilota::thrift::TType::I32,
@@ -2311,7 +2311,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMapResultRecv",
                 }) + match self {
-                    ThriftTestTestMapResultRecv::Ok(ref value) => __protocol.map_field_len(
+                    ThriftTestTestMapResultRecv::Ok(value) => __protocol.map_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I32,
                         ::pilota::thrift::TType::I32,
@@ -2554,7 +2554,7 @@ pub mod apache {
                     name: "ThriftTestTestBinaryResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestBinaryResultRecv::Ok(ref value) => {
+                    ThriftTestTestBinaryResultRecv::Ok(value) => {
                         __protocol.write_bytes_field(0, (value).clone())?;
                     }
                 }
@@ -2666,7 +2666,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestBinaryResultRecv",
                 }) + match self {
-                    ThriftTestTestBinaryResultRecv::Ok(ref value) => {
+                    ThriftTestTestBinaryResultRecv::Ok(value) => {
                         __protocol.bytes_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -2694,7 +2694,7 @@ pub mod apache {
                     name: "SecondServiceSecondtestStringResultSend",
                 })?;
                 match self {
-                    SecondServiceSecondtestStringResultSend::Ok(ref value) => {
+                    SecondServiceSecondtestStringResultSend::Ok(value) => {
                         __protocol.write_faststr_field(0, (value).clone())?;
                     }
                 }
@@ -2809,7 +2809,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "SecondServiceSecondtestStringResultSend",
                 }) + match self {
-                    SecondServiceSecondtestStringResultSend::Ok(ref value) => {
+                    SecondServiceSecondtestStringResultSend::Ok(value) => {
                         __protocol.faststr_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -2837,7 +2837,7 @@ pub mod apache {
                     name: "ThriftTestTestByteResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestByteResultRecv::Ok(ref value) => {
+                    ThriftTestTestByteResultRecv::Ok(value) => {
                         __protocol.write_i8_field(0, *value)?;
                     }
                 }
@@ -2949,7 +2949,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestByteResultRecv",
                 }) + match self {
-                    ThriftTestTestByteResultRecv::Ok(ref value) => {
+                    ThriftTestTestByteResultRecv::Ok(value) => {
                         __protocol.i8_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -3127,7 +3127,7 @@ pub mod apache {
                     name: "ThriftTestTestMapMapResultSend",
                 })?;
                 match self {
-                    ThriftTestTestMapMapResultSend::Ok(ref value) => {
+                    ThriftTestTestMapMapResultSend::Ok(value) => {
                         __protocol.write_map_field(
                             0,
                             ::pilota::thrift::TType::I32,
@@ -3320,7 +3320,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMapMapResultSend",
                 }) + match self {
-                    ThriftTestTestMapMapResultSend::Ok(ref value) => __protocol.map_field_len(
+                    ThriftTestTestMapMapResultSend::Ok(value) => __protocol.map_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I32,
                         ::pilota::thrift::TType::Map,
@@ -3560,7 +3560,7 @@ pub mod apache {
                     name: "ThriftTestTestSetResultSend",
                 })?;
                 match self {
-                    ThriftTestTestSetResultSend::Ok(ref value) => {
+                    ThriftTestTestSetResultSend::Ok(value) => {
                         __protocol.write_set_field(
                             0,
                             ::pilota::thrift::TType::I32,
@@ -3702,7 +3702,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestSetResultSend",
                 }) + match self {
-                    ThriftTestTestSetResultSend::Ok(ref value) => __protocol.set_field_len(
+                    ThriftTestTestSetResultSend::Ok(value) => __protocol.set_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I32,
                         value,
@@ -3733,7 +3733,7 @@ pub mod apache {
                     name: "ThriftTestTestStructResultSend",
                 })?;
                 match self {
-                    ThriftTestTestStructResultSend::Ok(ref value) => {
+                    ThriftTestTestStructResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -3849,7 +3849,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestStructResultSend",
                 }) + match self {
-                    ThriftTestTestStructResultSend::Ok(ref value) => {
+                    ThriftTestTestStructResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -4310,7 +4310,7 @@ pub mod apache {
                     name: "ThriftTestTestI64ResultSend",
                 })?;
                 match self {
-                    ThriftTestTestI64ResultSend::Ok(ref value) => {
+                    ThriftTestTestI64ResultSend::Ok(value) => {
                         __protocol.write_i64_field(0, *value)?;
                     }
                 }
@@ -4422,7 +4422,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestI64ResultSend",
                 }) + match self {
-                    ThriftTestTestI64ResultSend::Ok(ref value) => {
+                    ThriftTestTestI64ResultSend::Ok(value) => {
                         __protocol.i64_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -4637,7 +4637,7 @@ pub mod apache {
                     name: "ThriftTestTestStringResultSend",
                 })?;
                 match self {
-                    ThriftTestTestStringResultSend::Ok(ref value) => {
+                    ThriftTestTestStringResultSend::Ok(value) => {
                         __protocol.write_faststr_field(0, (value).clone())?;
                     }
                 }
@@ -4749,7 +4749,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestStringResultSend",
                 }) + match self {
-                    ThriftTestTestStringResultSend::Ok(ref value) => {
+                    ThriftTestTestStringResultSend::Ok(value) => {
                         __protocol.faststr_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -6752,7 +6752,7 @@ pub mod apache {
                     name: "ThriftTestTestInsanityResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestInsanityResultRecv::Ok(ref value) => {
+                    ThriftTestTestInsanityResultRecv::Ok(value) => {
                         __protocol.write_map_field(
                             0,
                             ::pilota::thrift::TType::I64,
@@ -6948,7 +6948,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestInsanityResultRecv",
                 }) + match self {
-                    ThriftTestTestInsanityResultRecv::Ok(ref value) => __protocol.map_field_len(
+                    ThriftTestTestInsanityResultRecv::Ok(value) => __protocol.map_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I64,
                         ::pilota::thrift::TType::Map,
@@ -7343,7 +7343,7 @@ pub mod apache {
                     name: "ThriftTestTestListResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestListResultRecv::Ok(ref value) => {
+                    ThriftTestTestListResultRecv::Ok(value) => {
                         __protocol.write_list_field(
                             0,
                             ::pilota::thrift::TType::I32,
@@ -7488,7 +7488,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestListResultRecv",
                 }) + match self {
-                    ThriftTestTestListResultRecv::Ok(ref value) => __protocol.list_field_len(
+                    ThriftTestTestListResultRecv::Ok(value) => __protocol.list_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I32,
                         value,
@@ -7635,7 +7635,7 @@ pub mod apache {
                     name: "ThriftTestTestNestResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestNestResultRecv::Ok(ref value) => {
+                    ThriftTestTestNestResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -7751,7 +7751,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestNestResultRecv",
                 }) + match self {
-                    ThriftTestTestNestResultRecv::Ok(ref value) => {
+                    ThriftTestTestNestResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -7990,7 +7990,7 @@ pub mod apache {
                     name: "ThriftTestTestDoubleResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestDoubleResultRecv::Ok(ref value) => {
+                    ThriftTestTestDoubleResultRecv::Ok(value) => {
                         __protocol.write_double_field(0, *value)?;
                     }
                 }
@@ -8102,7 +8102,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestDoubleResultRecv",
                 }) + match self {
-                    ThriftTestTestDoubleResultRecv::Ok(ref value) => {
+                    ThriftTestTestDoubleResultRecv::Ok(value) => {
                         __protocol.double_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -8130,7 +8130,7 @@ pub mod apache {
                     name: "ThriftTestTestBoolResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestBoolResultRecv::Ok(ref value) => {
+                    ThriftTestTestBoolResultRecv::Ok(value) => {
                         __protocol.write_bool_field(0, *value)?;
                     }
                 }
@@ -8242,7 +8242,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestBoolResultRecv",
                 }) + match self {
-                    ThriftTestTestBoolResultRecv::Ok(ref value) => {
+                    ThriftTestTestBoolResultRecv::Ok(value) => {
                         __protocol.bool_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -8504,7 +8504,7 @@ pub mod apache {
                     name: "ThriftTestTestTypedefResultSend",
                 })?;
                 match self {
-                    ThriftTestTestTypedefResultSend::Ok(ref value) => {
+                    ThriftTestTestTypedefResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::I64)?;
                     }
                 }
@@ -8620,7 +8620,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestTypedefResultSend",
                 }) + match self {
-                    ThriftTestTestTypedefResultSend::Ok(ref value) => {
+                    ThriftTestTestTypedefResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -8648,7 +8648,7 @@ pub mod apache {
                     name: "ThriftTestTestStringMapResultSend",
                 })?;
                 match self {
-                    ThriftTestTestStringMapResultSend::Ok(ref value) => {
+                    ThriftTestTestStringMapResultSend::Ok(value) => {
                         __protocol.write_map_field(
                             0,
                             ::pilota::thrift::TType::Binary,
@@ -8802,7 +8802,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestStringMapResultSend",
                 }) + match self {
-                    ThriftTestTestStringMapResultSend::Ok(ref value) => __protocol.map_field_len(
+                    ThriftTestTestStringMapResultSend::Ok(value) => __protocol.map_field_len(
                         Some(0),
                         ::pilota::thrift::TType::Binary,
                         ::pilota::thrift::TType::Binary,
@@ -8985,7 +8985,7 @@ pub mod apache {
                     name: "ThriftTestTestUuidResultSend",
                 })?;
                 match self {
-                    ThriftTestTestUuidResultSend::Ok(ref value) => {
+                    ThriftTestTestUuidResultSend::Ok(value) => {
                         __protocol.write_uuid_field(0, *value)?;
                     }
                 }
@@ -9097,7 +9097,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestUuidResultSend",
                 }) + match self {
-                    ThriftTestTestUuidResultSend::Ok(ref value) => {
+                    ThriftTestTestUuidResultSend::Ok(value) => {
                         __protocol.uuid_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -9324,7 +9324,7 @@ pub mod apache {
                     name: "ThriftTestTestI32ResultSend",
                 })?;
                 match self {
-                    ThriftTestTestI32ResultSend::Ok(ref value) => {
+                    ThriftTestTestI32ResultSend::Ok(value) => {
                         __protocol.write_i32_field(0, *value)?;
                     }
                 }
@@ -9436,7 +9436,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestI32ResultSend",
                 }) + match self {
-                    ThriftTestTestI32ResultSend::Ok(ref value) => {
+                    ThriftTestTestI32ResultSend::Ok(value) => {
                         __protocol.i32_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -9464,7 +9464,7 @@ pub mod apache {
                     name: "ThriftTestTestVoidResultSend",
                 })?;
                 match self {
-                    ThriftTestTestVoidResultSend::Ok(ref value) => {}
+                    ThriftTestTestVoidResultSend::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -9542,7 +9542,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestVoidResultSend",
                 }) + match self {
-                    ThriftTestTestVoidResultSend::Ok(ref value) => 0,
+                    ThriftTestTestVoidResultSend::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -10085,7 +10085,7 @@ pub mod apache {
                     name: "ThriftTestTestOnewayResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestOnewayResultRecv::Ok(ref value) => {}
+                    ThriftTestTestOnewayResultRecv::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -10163,7 +10163,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestOnewayResultRecv",
                 }) + match self {
-                    ThriftTestTestOnewayResultRecv::Ok(ref value) => 0,
+                    ThriftTestTestOnewayResultRecv::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -11209,7 +11209,7 @@ pub mod apache {
                     name: "SecondServiceSecondtestStringResultRecv",
                 })?;
                 match self {
-                    SecondServiceSecondtestStringResultRecv::Ok(ref value) => {
+                    SecondServiceSecondtestStringResultRecv::Ok(value) => {
                         __protocol.write_faststr_field(0, (value).clone())?;
                     }
                 }
@@ -11324,7 +11324,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "SecondServiceSecondtestStringResultRecv",
                 }) + match self {
-                    SecondServiceSecondtestStringResultRecv::Ok(ref value) => {
+                    SecondServiceSecondtestStringResultRecv::Ok(value) => {
                         __protocol.faststr_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -11685,7 +11685,7 @@ pub mod apache {
                     name: "ThriftTestTestExceptionException",
                 })?;
                 match self {
-                    ThriftTestTestExceptionException::Err1(ref value) => {
+                    ThriftTestTestExceptionException::Err1(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -11801,7 +11801,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestExceptionException",
                 }) + match self {
-                    ThriftTestTestExceptionException::Err1(ref value) => {
+                    ThriftTestTestExceptionException::Err1(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -11979,7 +11979,7 @@ pub mod apache {
                     name: "ThriftTestTestMapMapResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestMapMapResultRecv::Ok(ref value) => {
+                    ThriftTestTestMapMapResultRecv::Ok(value) => {
                         __protocol.write_map_field(
                             0,
                             ::pilota::thrift::TType::I32,
@@ -12172,7 +12172,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMapMapResultRecv",
                 }) + match self {
-                    ThriftTestTestMapMapResultRecv::Ok(ref value) => __protocol.map_field_len(
+                    ThriftTestTestMapMapResultRecv::Ok(value) => __protocol.map_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I32,
                         ::pilota::thrift::TType::Map,
@@ -12551,7 +12551,7 @@ pub mod apache {
                     name: "ThriftTestTestSetResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestSetResultRecv::Ok(ref value) => {
+                    ThriftTestTestSetResultRecv::Ok(value) => {
                         __protocol.write_set_field(
                             0,
                             ::pilota::thrift::TType::I32,
@@ -12693,7 +12693,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestSetResultRecv",
                 }) + match self {
-                    ThriftTestTestSetResultRecv::Ok(ref value) => __protocol.set_field_len(
+                    ThriftTestTestSetResultRecv::Ok(value) => __protocol.set_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I32,
                         value,
@@ -12872,7 +12872,7 @@ pub mod apache {
                     name: "ThriftTestTestStructResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestStructResultRecv::Ok(ref value) => {
+                    ThriftTestTestStructResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -12988,7 +12988,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestStructResultRecv",
                 }) + match self {
-                    ThriftTestTestStructResultRecv::Ok(ref value) => {
+                    ThriftTestTestStructResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -13263,7 +13263,7 @@ pub mod apache {
                     name: "ThriftTestTestI64ResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestI64ResultRecv::Ok(ref value) => {
+                    ThriftTestTestI64ResultRecv::Ok(value) => {
                         __protocol.write_i64_field(0, *value)?;
                     }
                 }
@@ -13375,7 +13375,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestI64ResultRecv",
                 }) + match self {
-                    ThriftTestTestI64ResultRecv::Ok(ref value) => {
+                    ThriftTestTestI64ResultRecv::Ok(value) => {
                         __protocol.i64_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -13403,7 +13403,7 @@ pub mod apache {
                     name: "ThriftTestTestStringResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestStringResultRecv::Ok(ref value) => {
+                    ThriftTestTestStringResultRecv::Ok(value) => {
                         __protocol.write_faststr_field(0, (value).clone())?;
                     }
                 }
@@ -13515,7 +13515,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestStringResultRecv",
                 }) + match self {
-                    ThriftTestTestStringResultRecv::Ok(ref value) => {
+                    ThriftTestTestStringResultRecv::Ok(value) => {
                         __protocol.faststr_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -13543,7 +13543,7 @@ pub mod apache {
                     name: "ThriftTestTestMultiResultSend",
                 })?;
                 match self {
-                    ThriftTestTestMultiResultSend::Ok(ref value) => {
+                    ThriftTestTestMultiResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -13659,7 +13659,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMultiResultSend",
                 }) + match self {
-                    ThriftTestTestMultiResultSend::Ok(ref value) => {
+                    ThriftTestTestMultiResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -14046,7 +14046,7 @@ pub mod apache {
                     name: "ThriftTestTestEnumResultSend",
                 })?;
                 match self {
-                    ThriftTestTestEnumResultSend::Ok(ref value) => {
+                    ThriftTestTestEnumResultSend::Ok(value) => {
                         __protocol.write_i32_field(0, (value).inner())?;
                     }
                 }
@@ -14162,7 +14162,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestEnumResultSend",
                 }) + match self {
-                    ThriftTestTestEnumResultSend::Ok(ref value) => {
+                    ThriftTestTestEnumResultSend::Ok(value) => {
                         __protocol.i32_field_len(Some(0), (value).inner())
                     }
                 } + __protocol.field_stop_len()
@@ -14341,7 +14341,7 @@ pub mod apache {
                     name: "ThriftTestTestMapResultSend",
                 })?;
                 match self {
-                    ThriftTestTestMapResultSend::Ok(ref value) => {
+                    ThriftTestTestMapResultSend::Ok(value) => {
                         __protocol.write_map_field(
                             0,
                             ::pilota::thrift::TType::I32,
@@ -14492,7 +14492,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMapResultSend",
                 }) + match self {
-                    ThriftTestTestMapResultSend::Ok(ref value) => __protocol.map_field_len(
+                    ThriftTestTestMapResultSend::Ok(value) => __protocol.map_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I32,
                         ::pilota::thrift::TType::I32,
@@ -14527,8 +14527,8 @@ pub mod apache {
                     name: "ThriftTestTestExceptionResultSend",
                 })?;
                 match self {
-                    ThriftTestTestExceptionResultSend::Ok(ref value) => {}
-                    ThriftTestTestExceptionResultSend::Err1(ref value) => {
+                    ThriftTestTestExceptionResultSend::Ok(value) => {}
+                    ThriftTestTestExceptionResultSend::Err1(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -14639,8 +14639,8 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestExceptionResultSend",
                 }) + match self {
-                    ThriftTestTestExceptionResultSend::Ok(ref value) => 0,
-                    ThriftTestTestExceptionResultSend::Err1(ref value) => {
+                    ThriftTestTestExceptionResultSend::Ok(value) => 0,
+                    ThriftTestTestExceptionResultSend::Err1(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -15183,7 +15183,7 @@ pub mod apache {
                     name: "ThriftTestTestBinaryResultSend",
                 })?;
                 match self {
-                    ThriftTestTestBinaryResultSend::Ok(ref value) => {
+                    ThriftTestTestBinaryResultSend::Ok(value) => {
                         __protocol.write_bytes_field(0, (value).clone())?;
                     }
                 }
@@ -15295,7 +15295,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestBinaryResultSend",
                 }) + match self {
-                    ThriftTestTestBinaryResultSend::Ok(ref value) => {
+                    ThriftTestTestBinaryResultSend::Ok(value) => {
                         __protocol.bytes_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -15473,7 +15473,7 @@ pub mod apache {
                     name: "ThriftTestTestByteResultSend",
                 })?;
                 match self {
-                    ThriftTestTestByteResultSend::Ok(ref value) => {
+                    ThriftTestTestByteResultSend::Ok(value) => {
                         __protocol.write_i8_field(0, *value)?;
                     }
                 }
@@ -15585,7 +15585,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestByteResultSend",
                 }) + match self {
-                    ThriftTestTestByteResultSend::Ok(ref value) => {
+                    ThriftTestTestByteResultSend::Ok(value) => {
                         __protocol.i8_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -15617,13 +15617,13 @@ pub mod apache {
                     name: "ThriftTestTestMultiExceptionResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestMultiExceptionResultRecv::Ok(ref value) => {
+                    ThriftTestTestMultiExceptionResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ThriftTestTestMultiExceptionResultRecv::Err1(ref value) => {
+                    ThriftTestTestMultiExceptionResultRecv::Err1(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ThriftTestTestMultiExceptionResultRecv::Err2(ref value) => {
+                    ThriftTestTestMultiExceptionResultRecv::Err2(value) => {
                         __protocol.write_struct_field(2, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -15807,13 +15807,13 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMultiExceptionResultRecv",
                 }) + match self {
-                    ThriftTestTestMultiExceptionResultRecv::Ok(ref value) => {
+                    ThriftTestTestMultiExceptionResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
-                    ThriftTestTestMultiExceptionResultRecv::Err1(ref value) => {
+                    ThriftTestTestMultiExceptionResultRecv::Err1(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
-                    ThriftTestTestMultiExceptionResultRecv::Err2(ref value) => {
+                    ThriftTestTestMultiExceptionResultRecv::Err2(value) => {
                         __protocol.struct_field_len(Some(2), value)
                     }
                 } + __protocol.field_stop_len()
@@ -17705,8 +17705,8 @@ pub mod apache {
                     name: "ThriftTestTestExceptionResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestExceptionResultRecv::Ok(ref value) => {}
-                    ThriftTestTestExceptionResultRecv::Err1(ref value) => {
+                    ThriftTestTestExceptionResultRecv::Ok(value) => {}
+                    ThriftTestTestExceptionResultRecv::Err1(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -17817,8 +17817,8 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestExceptionResultRecv",
                 }) + match self {
-                    ThriftTestTestExceptionResultRecv::Ok(ref value) => 0,
-                    ThriftTestTestExceptionResultRecv::Err1(ref value) => {
+                    ThriftTestTestExceptionResultRecv::Ok(value) => 0,
+                    ThriftTestTestExceptionResultRecv::Err1(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -18190,7 +18190,7 @@ pub mod apache {
                     name: "ThriftTestTestTypedefResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestTypedefResultRecv::Ok(ref value) => {
+                    ThriftTestTestTypedefResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::I64)?;
                     }
                 }
@@ -18306,7 +18306,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestTypedefResultRecv",
                 }) + match self {
-                    ThriftTestTestTypedefResultRecv::Ok(ref value) => {
+                    ThriftTestTestTypedefResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -18481,7 +18481,7 @@ pub mod apache {
                     name: "ThriftTestTestStringMapResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestStringMapResultRecv::Ok(ref value) => {
+                    ThriftTestTestStringMapResultRecv::Ok(value) => {
                         __protocol.write_map_field(
                             0,
                             ::pilota::thrift::TType::Binary,
@@ -18635,7 +18635,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestStringMapResultRecv",
                 }) + match self {
-                    ThriftTestTestStringMapResultRecv::Ok(ref value) => __protocol.map_field_len(
+                    ThriftTestTestStringMapResultRecv::Ok(value) => __protocol.map_field_len(
                         Some(0),
                         ::pilota::thrift::TType::Binary,
                         ::pilota::thrift::TType::Binary,
@@ -18668,7 +18668,7 @@ pub mod apache {
                     name: "ThriftTestTestUuidResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestUuidResultRecv::Ok(ref value) => {
+                    ThriftTestTestUuidResultRecv::Ok(value) => {
                         __protocol.write_uuid_field(0, *value)?;
                     }
                 }
@@ -18780,7 +18780,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestUuidResultRecv",
                 }) + match self {
-                    ThriftTestTestUuidResultRecv::Ok(ref value) => {
+                    ThriftTestTestUuidResultRecv::Ok(value) => {
                         __protocol.uuid_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -19301,7 +19301,7 @@ pub mod apache {
                     name: "ThriftTestTestI32ResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestI32ResultRecv::Ok(ref value) => {
+                    ThriftTestTestI32ResultRecv::Ok(value) => {
                         __protocol.write_i32_field(0, *value)?;
                     }
                 }
@@ -19413,7 +19413,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestI32ResultRecv",
                 }) + match self {
-                    ThriftTestTestI32ResultRecv::Ok(ref value) => {
+                    ThriftTestTestI32ResultRecv::Ok(value) => {
                         __protocol.i32_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -19445,13 +19445,13 @@ pub mod apache {
                     name: "ThriftTestTestMultiExceptionResultSend",
                 })?;
                 match self {
-                    ThriftTestTestMultiExceptionResultSend::Ok(ref value) => {
+                    ThriftTestTestMultiExceptionResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ThriftTestTestMultiExceptionResultSend::Err1(ref value) => {
+                    ThriftTestTestMultiExceptionResultSend::Err1(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ThriftTestTestMultiExceptionResultSend::Err2(ref value) => {
+                    ThriftTestTestMultiExceptionResultSend::Err2(value) => {
                         __protocol.write_struct_field(2, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -19635,13 +19635,13 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestMultiExceptionResultSend",
                 }) + match self {
-                    ThriftTestTestMultiExceptionResultSend::Ok(ref value) => {
+                    ThriftTestTestMultiExceptionResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
-                    ThriftTestTestMultiExceptionResultSend::Err1(ref value) => {
+                    ThriftTestTestMultiExceptionResultSend::Err1(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
-                    ThriftTestTestMultiExceptionResultSend::Err2(ref value) => {
+                    ThriftTestTestMultiExceptionResultSend::Err2(value) => {
                         __protocol.struct_field_len(Some(2), value)
                     }
                 } + __protocol.field_stop_len()
@@ -19669,7 +19669,7 @@ pub mod apache {
                     name: "ThriftTestTestVoidResultRecv",
                 })?;
                 match self {
-                    ThriftTestTestVoidResultRecv::Ok(ref value) => {}
+                    ThriftTestTestVoidResultRecv::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -19747,7 +19747,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestVoidResultRecv",
                 }) + match self {
-                    ThriftTestTestVoidResultRecv::Ok(ref value) => 0,
+                    ThriftTestTestVoidResultRecv::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -19773,7 +19773,7 @@ pub mod apache {
                     name: "ThriftTestTestInsanityResultSend",
                 })?;
                 match self {
-                    ThriftTestTestInsanityResultSend::Ok(ref value) => {
+                    ThriftTestTestInsanityResultSend::Ok(value) => {
                         __protocol.write_map_field(
                             0,
                             ::pilota::thrift::TType::I64,
@@ -19969,7 +19969,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestInsanityResultSend",
                 }) + match self {
-                    ThriftTestTestInsanityResultSend::Ok(ref value) => __protocol.map_field_len(
+                    ThriftTestTestInsanityResultSend::Ok(value) => __protocol.map_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I64,
                         ::pilota::thrift::TType::Map,
@@ -20214,7 +20214,7 @@ pub mod apache {
                     name: "ThriftTestTestListResultSend",
                 })?;
                 match self {
-                    ThriftTestTestListResultSend::Ok(ref value) => {
+                    ThriftTestTestListResultSend::Ok(value) => {
                         __protocol.write_list_field(
                             0,
                             ::pilota::thrift::TType::I32,
@@ -20359,7 +20359,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestListResultSend",
                 }) + match self {
-                    ThriftTestTestListResultSend::Ok(ref value) => __protocol.list_field_len(
+                    ThriftTestTestListResultSend::Ok(value) => __protocol.list_field_len(
                         Some(0),
                         ::pilota::thrift::TType::I32,
                         value,
@@ -20577,7 +20577,7 @@ pub mod apache {
                     name: "ThriftTestTestNestResultSend",
                 })?;
                 match self {
-                    ThriftTestTestNestResultSend::Ok(ref value) => {
+                    ThriftTestTestNestResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -20693,7 +20693,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestNestResultSend",
                 }) + match self {
-                    ThriftTestTestNestResultSend::Ok(ref value) => {
+                    ThriftTestTestNestResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -21012,7 +21012,7 @@ pub mod apache {
                     name: "ThriftTestTestDoubleResultSend",
                 })?;
                 match self {
-                    ThriftTestTestDoubleResultSend::Ok(ref value) => {
+                    ThriftTestTestDoubleResultSend::Ok(value) => {
                         __protocol.write_double_field(0, *value)?;
                     }
                 }
@@ -21124,7 +21124,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestDoubleResultSend",
                 }) + match self {
-                    ThriftTestTestDoubleResultSend::Ok(ref value) => {
+                    ThriftTestTestDoubleResultSend::Ok(value) => {
                         __protocol.double_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -21303,7 +21303,7 @@ pub mod apache {
                     name: "ThriftTestTestBoolResultSend",
                 })?;
                 match self {
-                    ThriftTestTestBoolResultSend::Ok(ref value) => {
+                    ThriftTestTestBoolResultSend::Ok(value) => {
                         __protocol.write_bool_field(0, *value)?;
                     }
                 }
@@ -21415,7 +21415,7 @@ pub mod apache {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ThriftTestTestBoolResultSend",
                 }) + match self {
-                    ThriftTestTestBoolResultSend::Ok(ref value) => {
+                    ThriftTestTestBoolResultSend::Ok(value) => {
                         __protocol.bool_field_len(Some(0), *value)
                     }
                 } + __protocol.field_stop_len()
@@ -21451,7 +21451,7 @@ pub mod apache {
                     name: "SomeUnion",
                 })?;
                 match self {
-                    SomeUnion::MapThing(ref value) => {
+                    SomeUnion::MapThing(value) => {
                         __protocol.write_map_field(
                             1,
                             ::pilota::thrift::TType::I32,
@@ -21467,16 +21467,16 @@ pub mod apache {
                             },
                         )?;
                     }
-                    SomeUnion::StringThing(ref value) => {
+                    SomeUnion::StringThing(value) => {
                         __protocol.write_faststr_field(2, (value).clone())?;
                     }
-                    SomeUnion::I32Thing(ref value) => {
+                    SomeUnion::I32Thing(value) => {
                         __protocol.write_i32_field(3, *value)?;
                     }
-                    SomeUnion::XtructThing(ref value) => {
+                    SomeUnion::XtructThing(value) => {
                         __protocol.write_struct_field(4, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    SomeUnion::InsanityThing(ref value) => {
+                    SomeUnion::InsanityThing(value) => {
                         __protocol.write_struct_field(5, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -21726,7 +21726,7 @@ pub mod apache {
                 __protocol
                     .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "SomeUnion" })
                     + match self {
-                        SomeUnion::MapThing(ref value) => __protocol.map_field_len(
+                        SomeUnion::MapThing(value) => __protocol.map_field_len(
                             Some(1),
                             ::pilota::thrift::TType::I32,
                             ::pilota::thrift::TType::I64,
@@ -21734,14 +21734,14 @@ pub mod apache {
                             |__protocol, key| __protocol.struct_len(key),
                             |__protocol, val| __protocol.struct_len(val),
                         ),
-                        SomeUnion::StringThing(ref value) => {
+                        SomeUnion::StringThing(value) => {
                             __protocol.faststr_field_len(Some(2), value)
                         }
-                        SomeUnion::I32Thing(ref value) => __protocol.i32_field_len(Some(3), *value),
-                        SomeUnion::XtructThing(ref value) => {
+                        SomeUnion::I32Thing(value) => __protocol.i32_field_len(Some(3), *value),
+                        SomeUnion::XtructThing(value) => {
                             __protocol.struct_field_len(Some(4), value)
                         }
-                        SomeUnion::InsanityThing(ref value) => {
+                        SomeUnion::InsanityThing(value) => {
                             __protocol.struct_field_len(Some(5), value)
                         }
                     }

--- a/pilota-build/test_data/thrift/auto_name.rs
+++ b/pilota-build/test_data/thrift/auto_name.rs
@@ -178,7 +178,7 @@ pub mod auto_name {
                     name: "serviceTest2ResultRecv",
                 })?;
                 match self {
-                    serviceTest2ResultRecv::Ok(ref value) => {
+                    serviceTest2ResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -294,7 +294,7 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "serviceTest2ResultRecv",
                 }) + match self {
-                    serviceTest2ResultRecv::Ok(ref value) => {
+                    serviceTest2ResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -763,10 +763,10 @@ pub mod auto_name {
                     name: "servicetestResultSend",
                 })?;
                 match self {
-                    servicetestResultSend::Ok(ref value) => {
+                    servicetestResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    servicetestResultSend::E(ref value) => {
+                    servicetestResultSend::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -912,12 +912,8 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "servicetestResultSend",
                 }) + match self {
-                    servicetestResultSend::Ok(ref value) => {
-                        __protocol.struct_field_len(Some(0), value)
-                    }
-                    servicetestResultSend::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    servicetestResultSend::Ok(value) => __protocol.struct_field_len(Some(0), value),
+                    servicetestResultSend::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -1259,7 +1255,7 @@ pub mod auto_name {
                     name: "ServicetestException",
                 })?;
                 match self {
-                    ServicetestException::E(ref value) => {
+                    ServicetestException::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -1375,9 +1371,7 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ServicetestException",
                 }) + match self {
-                    ServicetestException::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    ServicetestException::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -1405,10 +1399,10 @@ pub mod auto_name {
                     name: "ServicetestResultRecv",
                 })?;
                 match self {
-                    ServicetestResultRecv::Ok(ref value) => {
+                    ServicetestResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ServicetestResultRecv::E(ref value) => {
+                    ServicetestResultRecv::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -1554,12 +1548,8 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ServicetestResultRecv",
                 }) + match self {
-                    ServicetestResultRecv::Ok(ref value) => {
-                        __protocol.struct_field_len(Some(0), value)
-                    }
-                    ServicetestResultRecv::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    ServicetestResultRecv::Ok(value) => __protocol.struct_field_len(Some(0), value),
+                    ServicetestResultRecv::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -1586,7 +1576,7 @@ pub mod auto_name {
                     name: "serviceTest2ResultSend",
                 })?;
                 match self {
-                    serviceTest2ResultSend::Ok(ref value) => {
+                    serviceTest2ResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -1702,7 +1692,7 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "serviceTest2ResultSend",
                 }) + match self {
-                    serviceTest2ResultSend::Ok(ref value) => {
+                    serviceTest2ResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -1730,7 +1720,7 @@ pub mod auto_name {
                     name: "serviceTestException",
                 })?;
                 match self {
-                    serviceTestException::E(ref value) => {
+                    serviceTestException::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -1846,9 +1836,7 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "serviceTestException",
                 }) + match self {
-                    serviceTestException::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    serviceTestException::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -1876,10 +1864,10 @@ pub mod auto_name {
                     name: "serviceTestResultRecv",
                 })?;
                 match self {
-                    serviceTestResultRecv::Ok(ref value) => {
+                    serviceTestResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    serviceTestResultRecv::E(ref value) => {
+                    serviceTestResultRecv::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -2025,12 +2013,8 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "serviceTestResultRecv",
                 }) + match self {
-                    serviceTestResultRecv::Ok(ref value) => {
-                        __protocol.struct_field_len(Some(0), value)
-                    }
-                    serviceTestResultRecv::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    serviceTestResultRecv::Ok(value) => __protocol.struct_field_len(Some(0), value),
+                    serviceTestResultRecv::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -2374,10 +2358,10 @@ pub mod auto_name {
                     name: "ServiceTestResultSend",
                 })?;
                 match self {
-                    ServiceTestResultSend::Ok(ref value) => {
+                    ServiceTestResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ServiceTestResultSend::E(ref value) => {
+                    ServiceTestResultSend::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -2523,12 +2507,8 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ServiceTestResultSend",
                 }) + match self {
-                    ServiceTestResultSend::Ok(ref value) => {
-                        __protocol.struct_field_len(Some(0), value)
-                    }
-                    ServiceTestResultSend::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    ServiceTestResultSend::Ok(value) => __protocol.struct_field_len(Some(0), value),
+                    ServiceTestResultSend::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -2746,7 +2726,7 @@ pub mod auto_name {
                     name: "ServiceTest2ResultRecv",
                 })?;
                 match self {
-                    ServiceTest2ResultRecv::Ok(ref value) => {
+                    ServiceTest2ResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -2862,7 +2842,7 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ServiceTest2ResultRecv",
                 }) + match self {
-                    ServiceTest2ResultRecv::Ok(ref value) => {
+                    ServiceTest2ResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -3495,7 +3475,7 @@ pub mod auto_name {
                     name: "servicetestException",
                 })?;
                 match self {
-                    servicetestException::E(ref value) => {
+                    servicetestException::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -3611,9 +3591,7 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "servicetestException",
                 }) + match self {
-                    servicetestException::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    servicetestException::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -3641,10 +3619,10 @@ pub mod auto_name {
                     name: "servicetestResultRecv",
                 })?;
                 match self {
-                    servicetestResultRecv::Ok(ref value) => {
+                    servicetestResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    servicetestResultRecv::E(ref value) => {
+                    servicetestResultRecv::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -3790,12 +3768,8 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "servicetestResultRecv",
                 }) + match self {
-                    servicetestResultRecv::Ok(ref value) => {
-                        __protocol.struct_field_len(Some(0), value)
-                    }
-                    servicetestResultRecv::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    servicetestResultRecv::Ok(value) => __protocol.struct_field_len(Some(0), value),
+                    servicetestResultRecv::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -4023,10 +3997,10 @@ pub mod auto_name {
                     name: "ServicetestResultSend",
                 })?;
                 match self {
-                    ServicetestResultSend::Ok(ref value) => {
+                    ServicetestResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ServicetestResultSend::E(ref value) => {
+                    ServicetestResultSend::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -4172,12 +4146,8 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ServicetestResultSend",
                 }) + match self {
-                    ServicetestResultSend::Ok(ref value) => {
-                        __protocol.struct_field_len(Some(0), value)
-                    }
-                    ServicetestResultSend::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    ServicetestResultSend::Ok(value) => __protocol.struct_field_len(Some(0), value),
+                    ServicetestResultSend::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -4521,10 +4491,10 @@ pub mod auto_name {
                     name: "serviceTestResultSend",
                 })?;
                 match self {
-                    serviceTestResultSend::Ok(ref value) => {
+                    serviceTestResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    serviceTestResultSend::E(ref value) => {
+                    serviceTestResultSend::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -4670,12 +4640,8 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "serviceTestResultSend",
                 }) + match self {
-                    serviceTestResultSend::Ok(ref value) => {
-                        __protocol.struct_field_len(Some(0), value)
-                    }
-                    serviceTestResultSend::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    serviceTestResultSend::Ok(value) => __protocol.struct_field_len(Some(0), value),
+                    serviceTestResultSend::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -4701,7 +4667,7 @@ pub mod auto_name {
                     name: "ServiceTest2ResultSend",
                 })?;
                 match self {
-                    ServiceTest2ResultSend::Ok(ref value) => {
+                    ServiceTest2ResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -4817,7 +4783,7 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ServiceTest2ResultSend",
                 }) + match self {
-                    ServiceTest2ResultSend::Ok(ref value) => {
+                    ServiceTest2ResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -4845,7 +4811,7 @@ pub mod auto_name {
                     name: "ServiceTestException",
                 })?;
                 match self {
-                    ServiceTestException::E(ref value) => {
+                    ServiceTestException::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -4961,9 +4927,7 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ServiceTestException",
                 }) + match self {
-                    ServiceTestException::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    ServiceTestException::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -4991,10 +4955,10 @@ pub mod auto_name {
                     name: "ServiceTestResultRecv",
                 })?;
                 match self {
-                    ServiceTestResultRecv::Ok(ref value) => {
+                    ServiceTestResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    ServiceTestResultRecv::E(ref value) => {
+                    ServiceTestResultRecv::E(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -5140,12 +5104,8 @@ pub mod auto_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ServiceTestResultRecv",
                 }) + match self {
-                    ServiceTestResultRecv::Ok(ref value) => {
-                        __protocol.struct_field_len(Some(0), value)
-                    }
-                    ServiceTestResultRecv::E(ref value) => {
-                        __protocol.struct_field_len(Some(1), value)
-                    }
+                    ServiceTestResultRecv::Ok(value) => __protocol.struct_field_len(Some(0), value),
+                    ServiceTestResultRecv::E(value) => __protocol.struct_field_len(Some(1), value),
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -659,7 +659,7 @@ pub mod enum_test {
                     name: "TestTestEnumVarTypeNameConflictResultSend",
                 })?;
                 match self {
-                    TestTestEnumVarTypeNameConflictResultSend::Ok(ref value) => {
+                    TestTestEnumVarTypeNameConflictResultSend::Ok(value) => {
                         __protocol.write_i32_field(0, (value).inner())?;
                     }
                 }
@@ -779,7 +779,7 @@ pub mod enum_test {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestEnumVarTypeNameConflictResultSend",
                 }) + match self {
-                    TestTestEnumVarTypeNameConflictResultSend::Ok(ref value) => {
+                    TestTestEnumVarTypeNameConflictResultSend::Ok(value) => {
                         __protocol.i32_field_len(Some(0), (value).inner())
                     }
                 } + __protocol.field_stop_len()
@@ -960,7 +960,7 @@ pub mod enum_test {
                     name: "TestTestEnumResultSend",
                 })?;
                 match self {
-                    TestTestEnumResultSend::Ok(ref value) => {
+                    TestTestEnumResultSend::Ok(value) => {
                         __protocol.write_i32_field(0, (value).inner())?;
                     }
                 }
@@ -1076,7 +1076,7 @@ pub mod enum_test {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestEnumResultSend",
                 }) + match self {
-                    TestTestEnumResultSend::Ok(ref value) => {
+                    TestTestEnumResultSend::Ok(value) => {
                         __protocol.i32_field_len(Some(0), (value).inner())
                     }
                 } + __protocol.field_stop_len()
@@ -1405,7 +1405,7 @@ pub mod enum_test {
                     name: "TestTestEnumVarTypeNameConflictResultRecv",
                 })?;
                 match self {
-                    TestTestEnumVarTypeNameConflictResultRecv::Ok(ref value) => {
+                    TestTestEnumVarTypeNameConflictResultRecv::Ok(value) => {
                         __protocol.write_i32_field(0, (value).inner())?;
                     }
                 }
@@ -1525,7 +1525,7 @@ pub mod enum_test {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestEnumVarTypeNameConflictResultRecv",
                 }) + match self {
-                    TestTestEnumVarTypeNameConflictResultRecv::Ok(ref value) => {
+                    TestTestEnumVarTypeNameConflictResultRecv::Ok(value) => {
                         __protocol.i32_field_len(Some(0), (value).inner())
                     }
                 } + __protocol.field_stop_len()
@@ -1553,7 +1553,7 @@ pub mod enum_test {
                     name: "TestTestEnumResultRecv",
                 })?;
                 match self {
-                    TestTestEnumResultRecv::Ok(ref value) => {
+                    TestTestEnumResultRecv::Ok(value) => {
                         __protocol.write_i32_field(0, (value).inner())?;
                     }
                 }
@@ -1669,7 +1669,7 @@ pub mod enum_test {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestEnumResultRecv",
                 }) + match self {
-                    TestTestEnumResultRecv::Ok(ref value) => {
+                    TestTestEnumResultRecv::Ok(value) => {
                         __protocol.i32_field_len(Some(0), (value).inner())
                     }
                 } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -1083,7 +1083,7 @@ pub mod normal {
                     name: "TestTest123ResultSend",
                 })?;
                 match self {
-                    TestTest123ResultSend::Ok(ref value) => {}
+                    TestTest123ResultSend::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -1161,7 +1161,7 @@ pub mod normal {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTest123ResultSend",
                 }) + match self {
-                    TestTest123ResultSend::Ok(ref value) => 0,
+                    TestTest123ResultSend::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -1630,7 +1630,7 @@ pub mod normal {
                     name: "TestTestExceptionException",
                 })?;
                 match self {
-                    TestTestExceptionException::StException(ref value) => {
+                    TestTestExceptionException::StException(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -1747,7 +1747,7 @@ pub mod normal {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestExceptionException",
                 }) + match self {
-                    TestTestExceptionException::StException(ref value) => {
+                    TestTestExceptionException::StException(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -1777,10 +1777,10 @@ pub mod normal {
                     name: "TestTestExceptionResultSend",
                 })?;
                 match self {
-                    TestTestExceptionResultSend::Ok(ref value) => {
+                    TestTestExceptionResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    TestTestExceptionResultSend::StException(ref value) => {
+                    TestTestExceptionResultSend::StException(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -1927,10 +1927,10 @@ pub mod normal {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestExceptionResultSend",
                 }) + match self {
-                    TestTestExceptionResultSend::Ok(ref value) => {
+                    TestTestExceptionResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
-                    TestTestExceptionResultSend::StException(ref value) => {
+                    TestTestExceptionResultSend::StException(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -1960,10 +1960,10 @@ pub mod normal {
                     name: "TestTestExceptionResultRecv",
                 })?;
                 match self {
-                    TestTestExceptionResultRecv::Ok(ref value) => {
+                    TestTestExceptionResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    TestTestExceptionResultRecv::StException(ref value) => {
+                    TestTestExceptionResultRecv::StException(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -2110,10 +2110,10 @@ pub mod normal {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestExceptionResultRecv",
                 }) + match self {
-                    TestTestExceptionResultRecv::Ok(ref value) => {
+                    TestTestExceptionResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
-                    TestTestExceptionResultRecv::StException(ref value) => {
+                    TestTestExceptionResultRecv::StException(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -2141,7 +2141,7 @@ pub mod normal {
                     name: "TestTest123ResultRecv",
                 })?;
                 match self {
-                    TestTest123ResultRecv::Ok(ref value) => {}
+                    TestTest123ResultRecv::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -2219,7 +2219,7 @@ pub mod normal {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTest123ResultRecv",
                 }) + match self {
-                    TestTest123ResultRecv::Ok(ref value) => 0,
+                    TestTest123ResultRecv::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -331,7 +331,7 @@ pub mod pilota_name {
                     name: "TestServiceTestResultSend",
                 })?;
                 match self {
-                    TestServiceTestResultSend::Ok(ref value) => {
+                    TestServiceTestResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -447,7 +447,7 @@ pub mod pilota_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestServiceTestResultSend",
                 }) + match self {
-                    TestServiceTestResultSend::Ok(ref value) => {
+                    TestServiceTestResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -823,7 +823,7 @@ pub mod pilota_name {
                     name: "TestServiceTestResultRecv",
                 })?;
                 match self {
-                    TestServiceTestResultRecv::Ok(ref value) => {
+                    TestServiceTestResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -939,7 +939,7 @@ pub mod pilota_name {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestServiceTestResultRecv",
                 }) + match self {
-                    TestServiceTestResultRecv::Ok(ref value) => {
+                    TestServiceTestResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift/underscore.rs
+++ b/pilota-build/test_data/thrift/underscore.rs
@@ -24,7 +24,7 @@ pub mod underscore {
                     name: "Test_UnderscoredResultRecv",
                 })?;
                 match self {
-                    Test_UnderscoredResultRecv::Ok(ref value) => {
+                    Test_UnderscoredResultRecv::Ok(value) => {
                         __protocol.write_faststr_field(0, (value).clone())?;
                     }
                 }
@@ -136,7 +136,7 @@ pub mod underscore {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "Test_UnderscoredResultRecv",
                 }) + match self {
-                    Test_UnderscoredResultRecv::Ok(ref value) => {
+                    Test_UnderscoredResultRecv::Ok(value) => {
                         __protocol.faststr_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -464,7 +464,7 @@ pub mod underscore {
                     name: "Test_UnderscoredResultSend",
                 })?;
                 match self {
-                    Test_UnderscoredResultSend::Ok(ref value) => {
+                    Test_UnderscoredResultSend::Ok(value) => {
                         __protocol.write_faststr_field(0, (value).clone())?;
                     }
                 }
@@ -576,7 +576,7 @@ pub mod underscore {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "Test_UnderscoredResultSend",
                 }) + match self {
-                    Test_UnderscoredResultSend::Ok(ref value) => {
+                    Test_UnderscoredResultSend::Ok(value) => {
                         __protocol.faststr_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift/union.rs
+++ b/pilota-build/test_data/thrift/union.rs
@@ -25,10 +25,10 @@ pub mod union {
                 __protocol
                     .write_struct_begin(&::pilota::thrift::TStructIdentifier { name: "Union" })?;
                 match self {
-                    Union::A(ref value) => {
+                    Union::A(value) => {
                         __protocol.write_faststr_field(1, (value).clone())?;
                     }
-                    Union::B(ref value) => {
+                    Union::B(value) => {
                         __protocol.write_bytes_field(2, (value).clone())?;
                     }
                 }
@@ -165,8 +165,8 @@ pub mod union {
                 use ::pilota::thrift::TLengthProtocolExt;
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Union" })
                     + match self {
-                        Union::A(ref value) => __protocol.faststr_field_len(Some(1), value),
-                        Union::B(ref value) => __protocol.bytes_field_len(Some(2), value),
+                        Union::A(value) => __protocol.faststr_field_len(Some(1), value),
+                        Union::B(value) => __protocol.bytes_field_len(Some(2), value),
                     }
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()

--- a/pilota-build/test_data/thrift/void.rs
+++ b/pilota-build/test_data/thrift/void.rs
@@ -24,7 +24,7 @@ pub mod void {
                     name: "TestTest123ResultRecv",
                 })?;
                 match self {
-                    TestTest123ResultRecv::Ok(ref value) => {}
+                    TestTest123ResultRecv::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -102,7 +102,7 @@ pub mod void {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTest123ResultRecv",
                 }) + match self {
-                    TestTest123ResultRecv::Ok(ref value) => 0,
+                    TestTest123ResultRecv::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -366,7 +366,7 @@ pub mod void {
                     name: "TestTest123ResultSend",
                 })?;
                 match self {
-                    TestTest123ResultSend::Ok(ref value) => {}
+                    TestTest123ResultSend::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -444,7 +444,7 @@ pub mod void {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTest123ResultSend",
                 }) + match self {
-                    TestTest123ResultSend::Ok(ref value) => 0,
+                    TestTest123ResultSend::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -144,7 +144,7 @@ pub mod wrapper_arc {
                     name: "TestServiceTestResultRecv",
                 })?;
                 match self {
-                    TestServiceTestResultRecv::Ok(ref value) => {
+                    TestServiceTestResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -260,7 +260,7 @@ pub mod wrapper_arc {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestServiceTestResultRecv",
                 }) + match self {
-                    TestServiceTestResultRecv::Ok(ref value) => {
+                    TestServiceTestResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -443,7 +443,7 @@ pub mod wrapper_arc {
                     name: "TestServiceTestResultSend",
                 })?;
                 match self {
-                    TestServiceTestResultSend::Ok(ref value) => {
+                    TestServiceTestResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -562,7 +562,7 @@ pub mod wrapper_arc {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestServiceTestResultSend",
                 }) + match self {
-                    TestServiceTestResultSend::Ok(ref value) => {
+                    TestServiceTestResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultRecv.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultRecv.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for TestServiceTestResultRecv {
             name: "TestServiceTestResultRecv",
         })?;
         match self {
-            TestServiceTestResultRecv::Ok(ref value) => {
+            TestServiceTestResultRecv::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -136,7 +136,7 @@ impl ::pilota::thrift::Message for TestServiceTestResultRecv {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "TestServiceTestResultRecv",
         }) + match self {
-            TestServiceTestResultRecv::Ok(ref value) => __protocol.struct_field_len(Some(0), value),
+            TestServiceTestResultRecv::Ok(value) => __protocol.struct_field_len(Some(0), value),
         } + __protocol.field_stop_len()
             + __protocol.struct_end_len()
     }

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultSend_2.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultSend_2.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for TestServiceTestResultSend {
             name: "TestServiceTestResultSend",
         })?;
         match self {
-            TestServiceTestResultSend::Ok(ref value) => {
+            TestServiceTestResultSend::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -138,7 +138,7 @@ impl ::pilota::thrift::Message for TestServiceTestResultSend {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "TestServiceTestResultSend",
         }) + match self {
-            TestServiceTestResultSend::Ok(ref value) => __protocol.struct_field_len(Some(0), value),
+            TestServiceTestResultSend::Ok(value) => __protocol.struct_field_len(Some(0), value),
         } + __protocol.field_stop_len()
             + __protocol.struct_end_len()
     }

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultRecv_2.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultRecv_2.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for testServiceTestResultRecv {
             name: "testServiceTestResultRecv",
         })?;
         match self {
-            testServiceTestResultRecv::Ok(ref value) => {
+            testServiceTestResultRecv::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -136,7 +136,7 @@ impl ::pilota::thrift::Message for testServiceTestResultRecv {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "testServiceTestResultRecv",
         }) + match self {
-            testServiceTestResultRecv::Ok(ref value) => __protocol.struct_field_len(Some(0), value),
+            testServiceTestResultRecv::Ok(value) => __protocol.struct_field_len(Some(0), value),
         } + __protocol.field_stop_len()
             + __protocol.struct_end_len()
     }

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultSend.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultSend.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for testServiceTestResultSend {
             name: "testServiceTestResultSend",
         })?;
         match self {
-            testServiceTestResultSend::Ok(ref value) => {
+            testServiceTestResultSend::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -138,7 +138,7 @@ impl ::pilota::thrift::Message for testServiceTestResultSend {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "testServiceTestResultSend",
         }) + match self {
-            testServiceTestResultSend::Ok(ref value) => __protocol.struct_field_len(Some(0), value),
+            testServiceTestResultSend::Ok(value) => __protocol.struct_field_len(Some(0), value),
         } + __protocol.field_stop_len()
             + __protocol.struct_end_len()
     }

--- a/pilota-build/test_data/thrift_workspace/output/article/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace/output/article/Cargo.toml
@@ -14,6 +14,6 @@ workspace = true
 workspace = true
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "article"
 version = "0.1.0"

--- a/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
@@ -1,4 +1,4 @@
-pub mod gen {
+pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {
@@ -265,7 +265,7 @@ pub mod gen {
                     name: "ArticleServiceGetArticleResultSend",
                 })?;
                 match self {
-                    ArticleServiceGetArticleResultSend::Ok(ref value) => {
+                    ArticleServiceGetArticleResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -377,7 +377,7 @@ pub mod gen {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ArticleServiceGetArticleResultSend",
                 }) + match self {
-                    ArticleServiceGetArticleResultSend::Ok(ref value) => {
+                    ArticleServiceGetArticleResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -874,7 +874,7 @@ pub mod gen {
                     name: "ArticleServiceGetArticleResultRecv",
                 })?;
                 match self {
-                    ArticleServiceGetArticleResultRecv::Ok(ref value) => {
+                    ArticleServiceGetArticleResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -986,7 +986,7 @@ pub mod gen {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "ArticleServiceGetArticleResultRecv",
                 }) + match self {
-                    ArticleServiceGetArticleResultRecv::Ok(ref value) => {
+                    ArticleServiceGetArticleResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace/output/article/src/lib.rs
+++ b/pilota-build/test_data/thrift_workspace/output/article/src/lib.rs
@@ -1,2 +1,2 @@
 include!("gen.rs");
-pub use gen::*;
+pub use r#gen::*;

--- a/pilota-build/test_data/thrift_workspace/output/author/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace/output/author/Cargo.toml
@@ -14,6 +14,6 @@ workspace = true
 workspace = true
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "author"
 version = "0.1.0"

--- a/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
@@ -1,4 +1,4 @@
-pub mod gen {
+pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {
@@ -36,7 +36,7 @@ pub mod gen {
                     name: "AuthorServiceGetAuthorResultRecv",
                 })?;
                 match self {
-                    AuthorServiceGetAuthorResultRecv::Ok(ref value) => {
+                    AuthorServiceGetAuthorResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -148,7 +148,7 @@ pub mod gen {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "AuthorServiceGetAuthorResultRecv",
                 }) + match self {
-                    AuthorServiceGetAuthorResultRecv::Ok(ref value) => {
+                    AuthorServiceGetAuthorResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()
@@ -329,7 +329,7 @@ pub mod gen {
                     name: "AuthorServiceGetAuthorResultSend",
                 })?;
                 match self {
-                    AuthorServiceGetAuthorResultSend::Ok(ref value) => {
+                    AuthorServiceGetAuthorResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -441,7 +441,7 @@ pub mod gen {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "AuthorServiceGetAuthorResultSend",
                 }) + match self {
-                    AuthorServiceGetAuthorResultSend::Ok(ref value) => {
+                    AuthorServiceGetAuthorResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
                 } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace/output/author/src/lib.rs
+++ b/pilota-build/test_data/thrift_workspace/output/author/src/lib.rs
@@ -1,2 +1,2 @@
 include!("gen.rs");
-pub use gen::*;
+pub use r#gen::*;

--- a/pilota-build/test_data/thrift_workspace/output/common/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace/output/common/Cargo.toml
@@ -11,6 +11,6 @@ workspace = true
 workspace = true
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "common"
 version = "0.1.0"

--- a/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
@@ -1,4 +1,4 @@
-pub mod gen {
+pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {

--- a/pilota-build/test_data/thrift_workspace/output/common/src/lib.rs
+++ b/pilota-build/test_data/thrift_workspace/output/common/src/lib.rs
@@ -1,2 +1,2 @@
 include!("gen.rs");
-pub use gen::*;
+pub use r#gen::*;

--- a/pilota-build/test_data/thrift_workspace/output/image/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace/output/image/Cargo.toml
@@ -14,6 +14,6 @@ workspace = true
 workspace = true
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "image"
 version = "0.1.0"

--- a/pilota-build/test_data/thrift_workspace/output/image/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/image/src/gen.rs
@@ -1,4 +1,4 @@
-pub mod gen {
+pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {
@@ -185,7 +185,7 @@ pub mod gen {
                         name: "ImageServiceGetImageResultSend",
                     })?;
                     match self {
-                        ImageServiceGetImageResultSend::Ok(ref value) => {
+                        ImageServiceGetImageResultSend::Ok(value) => {
                             __protocol.write_struct_field(
                                 0,
                                 value,
@@ -304,7 +304,7 @@ pub mod gen {
                     __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                         name: "ImageServiceGetImageResultSend",
                     }) + match self {
-                        ImageServiceGetImageResultSend::Ok(ref value) => {
+                        ImageServiceGetImageResultSend::Ok(value) => {
                             __protocol.struct_field_len(Some(0), value)
                         }
                     } + __protocol.field_stop_len()
@@ -820,7 +820,7 @@ pub mod gen {
                         name: "ImageServiceGetImageResultRecv",
                     })?;
                     match self {
-                        ImageServiceGetImageResultRecv::Ok(ref value) => {
+                        ImageServiceGetImageResultRecv::Ok(value) => {
                             __protocol.write_struct_field(
                                 0,
                                 value,
@@ -939,7 +939,7 @@ pub mod gen {
                     __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                         name: "ImageServiceGetImageResultRecv",
                     }) + match self {
-                        ImageServiceGetImageResultRecv::Ok(ref value) => {
+                        ImageServiceGetImageResultRecv::Ok(value) => {
                             __protocol.struct_field_len(Some(0), value)
                         }
                     } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace/output/image/src/lib.rs
+++ b/pilota-build/test_data/thrift_workspace/output/image/src/lib.rs
@@ -1,2 +1,2 @@
 include!("gen.rs");
-pub use gen::*;
+pub use r#gen::*;

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/Cargo.toml
@@ -14,6 +14,6 @@ workspace = true
 workspace = true
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "article"
 version = "0.1.0"

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultRecv.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for ArticleServiceGetArticleResultRecv {
             name: "ArticleServiceGetArticleResultRecv",
         })?;
         match self {
-            ArticleServiceGetArticleResultRecv::Ok(ref value) => {
+            ArticleServiceGetArticleResultRecv::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -138,7 +138,7 @@ impl ::pilota::thrift::Message for ArticleServiceGetArticleResultRecv {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "ArticleServiceGetArticleResultRecv",
         }) + match self {
-            ArticleServiceGetArticleResultRecv::Ok(ref value) => {
+            ArticleServiceGetArticleResultRecv::Ok(value) => {
                 __protocol.struct_field_len(Some(0), value)
             }
         } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/enum_ArticleServiceGetArticleResultSend.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for ArticleServiceGetArticleResultSend {
             name: "ArticleServiceGetArticleResultSend",
         })?;
         match self {
-            ArticleServiceGetArticleResultSend::Ok(ref value) => {
+            ArticleServiceGetArticleResultSend::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -138,7 +138,7 @@ impl ::pilota::thrift::Message for ArticleServiceGetArticleResultSend {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "ArticleServiceGetArticleResultSend",
         }) + match self {
-            ArticleServiceGetArticleResultSend::Ok(ref value) => {
+            ArticleServiceGetArticleResultSend::Ok(value) => {
                 __protocol.struct_field_len(Some(0), value)
             }
         } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/gen.rs
@@ -1,4 +1,4 @@
-pub mod gen {
+pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/lib.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/lib.rs
@@ -1,2 +1,2 @@
 include!("gen.rs");
-pub use gen::*;
+pub use r#gen::*;

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/Cargo.toml
@@ -14,6 +14,6 @@ workspace = true
 workspace = true
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "author"
 version = "0.1.0"

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultRecv.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for AuthorServiceGetAuthorResultRecv {
             name: "AuthorServiceGetAuthorResultRecv",
         })?;
         match self {
-            AuthorServiceGetAuthorResultRecv::Ok(ref value) => {
+            AuthorServiceGetAuthorResultRecv::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -138,7 +138,7 @@ impl ::pilota::thrift::Message for AuthorServiceGetAuthorResultRecv {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "AuthorServiceGetAuthorResultRecv",
         }) + match self {
-            AuthorServiceGetAuthorResultRecv::Ok(ref value) => {
+            AuthorServiceGetAuthorResultRecv::Ok(value) => {
                 __protocol.struct_field_len(Some(0), value)
             }
         } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultSend.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for AuthorServiceGetAuthorResultSend {
             name: "AuthorServiceGetAuthorResultSend",
         })?;
         match self {
-            AuthorServiceGetAuthorResultSend::Ok(ref value) => {
+            AuthorServiceGetAuthorResultSend::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -138,7 +138,7 @@ impl ::pilota::thrift::Message for AuthorServiceGetAuthorResultSend {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "AuthorServiceGetAuthorResultSend",
         }) + match self {
-            AuthorServiceGetAuthorResultSend::Ok(ref value) => {
+            AuthorServiceGetAuthorResultSend::Ok(value) => {
                 __protocol.struct_field_len(Some(0), value)
             }
         } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/gen.rs
@@ -1,4 +1,4 @@
-pub mod gen {
+pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/lib.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/lib.rs
@@ -1,2 +1,2 @@
 include!("gen.rs");
-pub use gen::*;
+pub use r#gen::*;

--- a/pilota-build/test_data/thrift_workspace_with_split/output/common/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/common/Cargo.toml
@@ -11,6 +11,6 @@ workspace = true
 workspace = true
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "common"
 version = "0.1.0"

--- a/pilota-build/test_data/thrift_workspace_with_split/output/common/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/common/src/gen.rs
@@ -1,4 +1,4 @@
-pub mod gen {
+pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {

--- a/pilota-build/test_data/thrift_workspace_with_split/output/common/src/lib.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/common/src/lib.rs
@@ -1,2 +1,2 @@
 include!("gen.rs");
-pub use gen::*;
+pub use r#gen::*;

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/Cargo.toml
@@ -14,6 +14,6 @@ workspace = true
 workspace = true
 
 [package]
-edition = "2021"
+edition = "2024"
 name = "image"
 version = "0.1.0"

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultRecv.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for ImageServiceGetImageResultRecv {
             name: "ImageServiceGetImageResultRecv",
         })?;
         match self {
-            ImageServiceGetImageResultRecv::Ok(ref value) => {
+            ImageServiceGetImageResultRecv::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -138,7 +138,7 @@ impl ::pilota::thrift::Message for ImageServiceGetImageResultRecv {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "ImageServiceGetImageResultRecv",
         }) + match self {
-            ImageServiceGetImageResultRecv::Ok(ref value) => {
+            ImageServiceGetImageResultRecv::Ok(value) => {
                 __protocol.struct_field_len(Some(0), value)
             }
         } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultSend.rs
@@ -20,7 +20,7 @@ impl ::pilota::thrift::Message for ImageServiceGetImageResultSend {
             name: "ImageServiceGetImageResultSend",
         })?;
         match self {
-            ImageServiceGetImageResultSend::Ok(ref value) => {
+            ImageServiceGetImageResultSend::Ok(value) => {
                 __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
             }
         }
@@ -138,7 +138,7 @@ impl ::pilota::thrift::Message for ImageServiceGetImageResultSend {
         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
             name: "ImageServiceGetImageResultSend",
         }) + match self {
-            ImageServiceGetImageResultSend::Ok(ref value) => {
+            ImageServiceGetImageResultSend::Ok(value) => {
                 __protocol.struct_field_len(Some(0), value)
             }
         } + __protocol.field_stop_len()

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/gen.rs
@@ -1,4 +1,4 @@
-pub mod gen {
+pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
     pub mod article {

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/lib.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/lib.rs
@@ -1,2 +1,2 @@
 include!("gen.rs");
-pub use gen::*;
+pub use r#gen::*;

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -2017,13 +2017,13 @@ pub mod unknown_fields {
                     name: "TestUnion",
                 })?;
                 match self {
-                    TestUnion::A(ref value) => {
+                    TestUnion::A(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    TestUnion::B(ref value) => {
+                    TestUnion::B(value) => {
                         __protocol.write_struct_field(2, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    TestUnion::_UnknownFields(ref value) => {
+                    TestUnion::_UnknownFields(value) => {
                         for bytes in value.list.iter() {
                             __protocol.write_bytes_without_len(bytes.clone());
                         }
@@ -2187,9 +2187,9 @@ pub mod unknown_fields {
                 __protocol
                     .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "TestUnion" })
                     + match self {
-                        TestUnion::A(ref value) => __protocol.struct_field_len(Some(1), value),
-                        TestUnion::B(ref value) => __protocol.struct_field_len(Some(2), value),
-                        TestUnion::_UnknownFields(ref value) => value.size(),
+                        TestUnion::A(value) => __protocol.struct_field_len(Some(1), value),
+                        TestUnion::B(value) => __protocol.struct_field_len(Some(2), value),
+                        TestUnion::_UnknownFields(value) => value.size(),
                     }
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
@@ -2226,7 +2226,7 @@ pub mod unknown_fields {
                     name: "TestTestExceptionException",
                 })?;
                 match self {
-                    TestTestExceptionException::StException(ref value) => {
+                    TestTestExceptionException::StException(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -2343,7 +2343,7 @@ pub mod unknown_fields {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestExceptionException",
                 }) + match self {
-                    TestTestExceptionException::StException(ref value) => {
+                    TestTestExceptionException::StException(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -2383,10 +2383,10 @@ pub mod unknown_fields {
                     name: "TestTestExceptionResultRecv",
                 })?;
                 match self {
-                    TestTestExceptionResultRecv::Ok(ref value) => {
+                    TestTestExceptionResultRecv::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    TestTestExceptionResultRecv::StException(ref value) => {
+                    TestTestExceptionResultRecv::StException(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -2533,10 +2533,10 @@ pub mod unknown_fields {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestExceptionResultRecv",
                 }) + match self {
-                    TestTestExceptionResultRecv::Ok(ref value) => {
+                    TestTestExceptionResultRecv::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
-                    TestTestExceptionResultRecv::StException(ref value) => {
+                    TestTestExceptionResultRecv::StException(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -2574,7 +2574,7 @@ pub mod unknown_fields {
                     name: "TestTest123ResultRecv",
                 })?;
                 match self {
-                    TestTest123ResultRecv::Ok(ref value) => {}
+                    TestTest123ResultRecv::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -2652,7 +2652,7 @@ pub mod unknown_fields {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTest123ResultRecv",
                 }) + match self {
-                    TestTest123ResultRecv::Ok(ref value) => 0,
+                    TestTest123ResultRecv::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -3107,7 +3107,7 @@ pub mod unknown_fields {
                     name: "TestTest123ResultSend",
                 })?;
                 match self {
-                    TestTest123ResultSend::Ok(ref value) => {}
+                    TestTest123ResultSend::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -3185,7 +3185,7 @@ pub mod unknown_fields {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTest123ResultSend",
                 }) + match self {
-                    TestTest123ResultSend::Ok(ref value) => 0,
+                    TestTest123ResultSend::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -3513,10 +3513,10 @@ pub mod unknown_fields {
                     name: "TestTestExceptionResultSend",
                 })?;
                 match self {
-                    TestTestExceptionResultSend::Ok(ref value) => {
+                    TestTestExceptionResultSend::Ok(value) => {
                         __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
                     }
-                    TestTestExceptionResultSend::StException(ref value) => {
+                    TestTestExceptionResultSend::StException(value) => {
                         __protocol.write_struct_field(1, value, ::pilota::thrift::TType::Struct)?;
                     }
                 }
@@ -3663,10 +3663,10 @@ pub mod unknown_fields {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTestExceptionResultSend",
                 }) + match self {
-                    TestTestExceptionResultSend::Ok(ref value) => {
+                    TestTestExceptionResultSend::Ok(value) => {
                         __protocol.struct_field_len(Some(0), value)
                     }
-                    TestTestExceptionResultSend::StException(ref value) => {
+                    TestTestExceptionResultSend::StException(value) => {
                         __protocol.struct_field_len(Some(1), value)
                     }
                 } + __protocol.field_stop_len()
@@ -3717,7 +3717,7 @@ pub mod unknown_fields {
                     name: "TestTest123ResultRecv",
                 })?;
                 match self {
-                    TestTest123ResultRecv::Ok(ref value) => {}
+                    TestTest123ResultRecv::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -3795,7 +3795,7 @@ pub mod unknown_fields {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTest123ResultRecv",
                 }) + match self {
-                    TestTest123ResultRecv::Ok(ref value) => 0,
+                    TestTest123ResultRecv::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }
@@ -3831,7 +3831,7 @@ pub mod unknown_fields {
                     name: "TestTest123ResultSend",
                 })?;
                 match self {
-                    TestTest123ResultSend::Ok(ref value) => {}
+                    TestTest123ResultSend::Ok(value) => {}
                 }
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
@@ -3909,7 +3909,7 @@ pub mod unknown_fields {
                 __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                     name: "TestTest123ResultSend",
                 }) + match self {
-                    TestTest123ResultSend::Ok(ref value) => 0,
+                    TestTest123ResultSend::Ok(value) => 0,
                 } + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "pilota-thrift-parser"
 version = "0.11.6"
-edition = "2024"
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
 description = "Pilota thrift Parser."
-documentation = "https://docs.rs/pilota"
+documentation = "https://docs.rs/pilota-thrift-parser"
 readme = "README.md"
-homepage = "https://cloudwego.io/docs/pilota/"
-repository = "https://github.com/cloudwego/pilota"
-license = "MIT OR Apache-2.0"
-authors = ["Pilota Team <pilota@cloudwego.io>"]
 categories = ["encoding"]
 keywords = ["serialization", "thrift", "parser"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -17,4 +18,4 @@ keywords = ["serialization", "thrift", "parser"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-nom = "7"
+nom.workspace = true

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.11.5"
-edition = "2021"
+version = "0.11.6"
+edition = "2024"
 description = "Pilota thrift Parser."
 documentation = "https://docs.rs/pilota"
 readme = "README.md"

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -1,10 +1,10 @@
 use nom::{
+    IResult,
     bytes::complete::{tag, take_while},
     character::complete::satisfy,
     combinator::{map, opt, recognize},
     multi::many1,
     sequence::tuple,
-    IResult,
 };
 
 use crate::{

--- a/pilota-thrift-parser/src/parser/constant.rs
+++ b/pilota-thrift-parser/src/parser/constant.rs
@@ -1,13 +1,13 @@
 use std::{num::ParseIntError, str::FromStr};
 
 use nom::{
+    IResult,
     branch::alt,
     bytes::complete::{tag, tag_no_case},
     character::complete::{digit1, hex_digit1},
     combinator::{map, map_res, opt, recognize},
     multi::many0,
     sequence::{delimited, preceded, tuple},
-    IResult,
 };
 
 use super::super::{

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -1,8 +1,8 @@
 use nom::{
+    IResult,
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::tuple,
-    IResult,
 };
 
 use super::super::{

--- a/pilota-thrift-parser/src/parser/field.rs
+++ b/pilota-thrift-parser/src/parser/field.rs
@@ -1,10 +1,10 @@
 use nom::{
+    IResult,
     branch::alt,
     bytes::complete::tag,
     character::complete::digit1,
     combinator::{map, opt},
     sequence::tuple,
-    IResult,
 };
 
 use super::super::{

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -1,15 +1,15 @@
 use nom::{
+    IResult,
     bytes::complete::tag,
     combinator::{map, opt},
     multi::many1,
     sequence::tuple,
-    IResult,
 };
 
 use super::super::{
-    descriptor::{Annotations, Field, Function, Ident, Type},
-    parser::{blank, list_separator, Parser},
     Attribute,
+    descriptor::{Annotations, Field, Function, Ident, Type},
+    parser::{Parser, blank, list_separator},
 };
 
 impl Parser for Function {

--- a/pilota-thrift-parser/src/parser/identifier.rs
+++ b/pilota-thrift-parser/src/parser/identifier.rs
@@ -1,6 +1,6 @@
 use nom::{
-    bytes::complete::take_while, character::complete::satisfy, combinator::recognize,
-    sequence::tuple, IResult,
+    IResult, bytes::complete::take_while, character::complete::satisfy, combinator::recognize,
+    sequence::tuple,
 };
 
 use super::super::{descriptor::Ident, parser::*};

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -1,8 +1,8 @@
 use nom::{
+    IResult,
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::tuple,
-    IResult,
 };
 
 use super::super::{

--- a/pilota-thrift-parser/src/parser/literal.rs
+++ b/pilota-thrift-parser/src/parser/literal.rs
@@ -1,10 +1,10 @@
 use nom::{
+    IResult,
     branch::alt,
     bytes::complete::{escaped, tag},
     character::complete::none_of,
     combinator::map,
     sequence::delimited,
-    IResult,
 };
 
 use super::super::{descriptor::Literal, parser::*};

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -20,13 +20,13 @@ mod typedef;
 use std::sync::Arc;
 
 use nom::{
+    IResult,
     branch::alt,
     bytes::complete::{tag, take_till, take_until},
     character::complete::{multispace1, one_of, satisfy},
     combinator::{map, opt},
     multi::{many0, many1, separated_list1},
     sequence::{preceded, terminated, tuple},
-    IResult,
 };
 
 use super::descriptor::{Ident, Path};

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -1,9 +1,9 @@
 use nom::{
+    IResult,
     branch::alt,
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::{preceded, tuple},
-    IResult,
 };
 
 use super::super::{descriptor::Annotations, parser::*};

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -1,8 +1,8 @@
 use nom::{
+    IResult,
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::tuple,
-    IResult,
 };
 
 use super::super::{

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -1,7 +1,7 @@
 use nom::{
+    IResult,
     bytes::complete::tag,
     combinator::{map, opt},
-    IResult,
 };
 
 use super::super::{

--- a/pilota-thrift-parser/src/parser/thrift.rs
+++ b/pilota-thrift-parser/src/parser/thrift.rs
@@ -1,10 +1,10 @@
 use nom::{
+    IResult,
     bytes::complete::take_while,
     character::complete::satisfy,
     combinator::{eof, map, opt, peek, recognize},
     multi::many_till,
     sequence::tuple,
-    IResult,
 };
 
 use super::super::{

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use nom::{
-    self,
+    self, IResult,
     branch::{alt, permutation},
     bytes::complete::tag,
     combinator::{map, not, opt, peek},
     sequence::{preceded, tuple},
-    IResult,
 };
 
 use super::super::{

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -1,8 +1,8 @@
 use nom::{
+    IResult,
     bytes::complete::tag,
     combinator::{map, opt},
     sequence::tuple,
-    IResult,
 };
 
 use super::super::{

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pilota"
-version = "0.11.8"
-edition = "2021"
+version = "0.11.9"
+edition = "2024"
 description = "Pilota is a thrift and protobuf implementation in pure rust with high performance and extensibility."
 documentation = "https://docs.rs/pilota"
 readme = "README.md"

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "pilota"
 version = "0.11.9"
-edition = "2024"
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+authors.workspace = true
+rust-version.workspace = true
 description = "Pilota is a thrift and protobuf implementation in pure rust with high performance and extensibility."
 documentation = "https://docs.rs/pilota"
 readme = "README.md"
-homepage = "https://cloudwego.io/docs/pilota/"
-repository = "https://github.com/cloudwego/pilota"
-license = "MIT OR Apache-2.0"
-authors = ["Pilota Team <pilota@cloudwego.io>"]
 categories = ["encoding"]
 keywords = ["serialization", "thrift", "protobuf"]
 
@@ -18,25 +19,25 @@ keywords = ["serialization", "thrift", "protobuf"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-ahash = { version = "0.8", features = ["serde"] }
-paste = "1"
-bytes = { version = "1", features = ["serde"] }
-async-recursion = "1"
-tokio = { version = "1", features = ["io-util"] }
-lazy_static = "1"
-linkedbytes = "0.1"
-anyhow = "1"
-thiserror = "1"
-faststr = { version = "0.2", features = ["serde"] }
-integer-encoding = { version = "4", features = ["tokio", "tokio_async"] }
-serde = { version = "1", features = ["derive"] }
-smallvec = "1"
-ordered-float = { version = "4", features = ["serde"] }
+ahash.workspace = true
+anyhow.workspace = true
+async-recursion.workspace = true
+bytes.workspace = true
+faststr.workspace = true
+integer-encoding.workspace = true
+lazy_static.workspace = true
+linkedbytes.workspace = true
+ordered-float.workspace = true
+paste.workspace = true
+smallvec.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
-criterion = "0.5"
-proptest = "1"
-rand = "0.8"
+criterion.workspace = true
+proptest.workspace = true
+rand.workspace = true
 
 [features]
 unstable = []

--- a/pilota/benches/skip.rs
+++ b/pilota/benches/skip.rs
@@ -1,10 +1,10 @@
 use ahash::{AHashMap, AHashSet};
 use bytes::{Bytes, BytesMut};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use faststr::FastStr;
 use pilota::thrift::{
-    binary_unsafe::TBinaryUnsafeInputProtocol, TInputProtocol, TOutputProtocol, TOutputProtocolExt,
-    TStructIdentifier, TType, ThriftException,
+    TInputProtocol, TOutputProtocol, TOutputProtocolExt, TStructIdentifier, TType, ThriftException,
+    binary_unsafe::TBinaryUnsafeInputProtocol,
 };
 use rand::Rng;
 

--- a/pilota/benches/skip.rs
+++ b/pilota/benches/skip.rs
@@ -45,7 +45,7 @@ fn skip_bench(c: &mut Criterion) {
 fn generate_list_i32() -> Bytes {
     let mut rng = rand::thread_rng();
     let vec_size: usize = 100;
-    let v: Vec<i32> = (0..vec_size).map(|_| rng.gen()).collect();
+    let v: Vec<i32> = (0..vec_size).map(|_| rng.r#gen()).collect();
 
     let mut buf = BytesMut::new();
 

--- a/pilota/benches/thrift_binary.rs
+++ b/pilota/benches/thrift_binary.rs
@@ -13,7 +13,7 @@ fn binary_bench(c: &mut criterion::Criterion) {
     let mut group = c.benchmark_group("Bench Thrift Binary");
     let mut v: Vec<i64> = Vec::with_capacity(size);
     for _ in 0..size {
-        v.push(rand::thread_rng().gen());
+        v.push(rand::thread_rng().r#gen());
     }
     let mut buf = BytesMut::new();
 

--- a/pilota/benches/ttype.rs
+++ b/pilota/benches/ttype.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::redundant_clone)]
 
 use criterion::{black_box, criterion_group, criterion_main};
-use pilota::thrift::{new_protocol_exception, ProtocolExceptionKind, TType, ThriftException};
+use pilota::thrift::{ProtocolExceptionKind, TType, ThriftException, new_protocol_exception};
 
 fn ttype_bench(c: &mut criterion::Criterion) {
     let mut group = c.benchmark_group("Bench Thrift TType");

--- a/pilota/src/prost/encoding.rs
+++ b/pilota/src/prost/encoding.rs
@@ -431,7 +431,7 @@ macro_rules! encode_repeated {
 /// Helper macro which emits a `merge_repeated` function for the numeric type.
 macro_rules! merge_repeated_numeric {
     ($ty:ty,
-     $wire_type:expr,
+     $wire_type:expr_2021,
      $merge:ident,
      $merge_repeated:ident) => {
         pub fn $merge_repeated<B>(
@@ -476,8 +476,8 @@ macro_rules! varint {
 
     ($ty:ty,
      $proto_ty:ident,
-     to_uint64($to_uint64_value:ident) $to_uint64:expr,
-     from_uint64($from_uint64_value:ident) $from_uint64:expr) => (
+     to_uint64($to_uint64_value:ident) $to_uint64:expr_2021,
+     from_uint64($from_uint64_value:ident) $from_uint64:expr_2021) => (
 
          pub mod $proto_ty {
             use crate::prost::encoding::*;
@@ -719,8 +719,8 @@ from_uint64(value) {
 /// fixed width numeric type.
 macro_rules! fixed_width {
     ($ty:ty,
-     $width:expr,
-     $wire_type:expr,
+     $width:expr_2021,
+     $wire_type:expr_2021,
      $proto_ty:ident,
      $put:ident,
      $get:ident) => {

--- a/pilota/src/prost/message.rs
+++ b/pilota/src/prost/message.rs
@@ -6,8 +6,8 @@ use core::{fmt::Debug, usize};
 use bytes::{Buf, BufMut};
 
 use super::{
-    encoding::{decode_key, encode_varint, encoded_len_varint, message, DecodeContext, WireType},
     DecodeError, EncodeError,
+    encoding::{DecodeContext, WireType, decode_key, encode_varint, encoded_len_varint, message},
 };
 
 /// A Protocol Buffers message.

--- a/pilota/src/prost/types.rs
+++ b/pilota/src/prost/types.rs
@@ -11,11 +11,11 @@ use alloc::{string::String, vec::Vec};
 use ::bytes::{Buf, BufMut, Bytes};
 
 use super::{
-    encoding::{
-        bool, bytes, double, float, int32, int64, skip_field, string, uint32, uint64,
-        DecodeContext, WireType,
-    },
     DecodeError, Message,
+    encoding::{
+        DecodeContext, WireType, bool, bytes, double, float, int32, int64, skip_field, string,
+        uint32, uint64,
+    },
 };
 
 /// `google.protobuf.BoolValue`
@@ -45,11 +45,7 @@ impl Message for bool {
         }
     }
     fn encoded_len(&self) -> usize {
-        if *self {
-            2
-        } else {
-            0
-        }
+        if *self { 2 } else { 0 }
     }
 }
 

--- a/pilota/src/thrift/binary.rs
+++ b/pilota/src/thrift/binary.rs
@@ -6,12 +6,12 @@ use linkedbytes::LinkedBytes;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use super::{
-    error::ProtocolExceptionKind,
-    new_protocol_exception,
-    rw_ext::{ReadExt, WriteExt},
     ProtocolException, TAsyncInputProtocol, TFieldIdentifier, TInputProtocol, TLengthProtocol,
     TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TOutputProtocol,
     TSetIdentifier, TStructIdentifier, TType, ThriftException, ZERO_COPY_THRESHOLD,
+    error::ProtocolExceptionKind,
+    new_protocol_exception,
+    rw_ext::{ReadExt, WriteExt},
 };
 
 static VERSION_1: u32 = 0x80010000;

--- a/pilota/src/thrift/binary_le.rs
+++ b/pilota/src/thrift/binary_le.rs
@@ -6,12 +6,12 @@ use linkedbytes::LinkedBytes;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use super::{
-    error::ProtocolExceptionKind,
-    new_protocol_exception,
-    rw_ext::{ReadExt, WriteExt},
     ProtocolException, TAsyncInputProtocol, TFieldIdentifier, TInputProtocol, TLengthProtocol,
     TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TOutputProtocol,
     TSetIdentifier, TStructIdentifier, TType, ThriftException, ZERO_COPY_THRESHOLD,
+    error::ProtocolExceptionKind,
+    new_protocol_exception,
+    rw_ext::{ReadExt, WriteExt},
 };
 
 const VERSION_LE: u32 = 0x88880000;

--- a/pilota/src/thrift/binary_unsafe.rs
+++ b/pilota/src/thrift/binary_unsafe.rs
@@ -6,10 +6,10 @@ use linkedbytes::LinkedBytes;
 use smallvec::SmallVec;
 
 use super::{
-    error::ProtocolExceptionKind, new_protocol_exception, ProtocolException, TFieldIdentifier,
-    TInputProtocol, TLengthProtocol, TListIdentifier, TMapIdentifier, TMessageIdentifier,
-    TMessageType, TOutputProtocol, TSetIdentifier, TStructIdentifier, TType, ThriftException,
-    BINARY_BASIC_TYPE_FIXED_SIZE, ZERO_COPY_THRESHOLD,
+    BINARY_BASIC_TYPE_FIXED_SIZE, ProtocolException, TFieldIdentifier, TInputProtocol,
+    TLengthProtocol, TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType,
+    TOutputProtocol, TSetIdentifier, TStructIdentifier, TType, ThriftException,
+    ZERO_COPY_THRESHOLD, error::ProtocolExceptionKind, new_protocol_exception,
 };
 
 static VERSION_1: u32 = 0x80010000;
@@ -741,14 +741,16 @@ impl<'a> TBinaryUnsafeInputProtocol<'a> {
     ///
     /// The 'trans' MUST have enough capacity to read from or write to.
     #[inline]
-    pub unsafe fn new(trans: &'a mut Bytes) -> Self { unsafe {
-        let buf = slice::from_raw_parts(trans.as_ptr(), trans.len());
-        Self {
-            trans,
-            buf,
-            index: 0,
+    pub unsafe fn new(trans: &'a mut Bytes) -> Self {
+        unsafe {
+            let buf = slice::from_raw_parts(trans.as_ptr(), trans.len());
+            Self {
+                trans,
+                buf,
+                index: 0,
+            }
         }
-    }}
+    }
 
     #[doc(hidden)]
     pub fn index(&self) -> usize {
@@ -1303,7 +1305,7 @@ impl<'a> TInputProtocol for TBinaryUnsafeInputProtocol<'a> {
                     return Err(new_protocol_exception(
                         ProtocolExceptionKind::DepthLimit,
                         format!("cannot skip field type {:?}", &u),
-                    ))
+                    ));
                 }
             };
 

--- a/pilota/src/thrift/binary_unsafe.rs
+++ b/pilota/src/thrift/binary_unsafe.rs
@@ -741,14 +741,14 @@ impl<'a> TBinaryUnsafeInputProtocol<'a> {
     ///
     /// The 'trans' MUST have enough capacity to read from or write to.
     #[inline]
-    pub unsafe fn new(trans: &'a mut Bytes) -> Self {
+    pub unsafe fn new(trans: &'a mut Bytes) -> Self { unsafe {
         let buf = slice::from_raw_parts(trans.as_ptr(), trans.len());
         Self {
             trans,
             buf,
             index: 0,
         }
-    }
+    }}
 
     #[doc(hidden)]
     pub fn index(&self) -> usize {
@@ -895,7 +895,7 @@ struct SkipData {
 }
 
 macro_rules! skip_stack_pop {
-    ($stack: expr) => {
+    ($stack: expr_2021) => {
         let top: &mut SkipData = $stack.last_mut().unwrap();
         top.len -= 1;
         if (top.len == 0) {

--- a/pilota/src/thrift/compact.rs
+++ b/pilota/src/thrift/compact.rs
@@ -11,13 +11,13 @@ use linkedbytes::LinkedBytes;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use super::{
+    ProtocolException, TAsyncInputProtocol, TFieldIdentifier, TInputProtocol, TLengthProtocol,
+    TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TOutputProtocol,
+    TSetIdentifier, TStructIdentifier, TType, ThriftException, ZERO_COPY_THRESHOLD,
     error::ProtocolExceptionKind,
     new_protocol_exception,
     rw_ext::{ReadExt, WriteExt},
     varint_ext::VarIntProcessor,
-    ProtocolException, TAsyncInputProtocol, TFieldIdentifier, TInputProtocol, TLengthProtocol,
-    TListIdentifier, TMapIdentifier, TMessageIdentifier, TMessageType, TOutputProtocol,
-    TSetIdentifier, TStructIdentifier, TType, ThriftException, ZERO_COPY_THRESHOLD,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/pilota/src/thrift/compact.rs
+++ b/pilota/src/thrift/compact.rs
@@ -182,7 +182,7 @@ impl<T> TCompactOutputProtocol<T> {
 }
 
 macro_rules! write_field_header_len {
-    ($self:expr, $ax:expr, $field_type:expr, $id:expr) => {
+    ($self:expr_2021, $ax:expr_2021, $field_type:expr_2021, $id:expr_2021) => {
         let field_delta = $id - $self.last_write_field_id;
         if field_delta > 0 && field_delta < 15 {
             $ax += $self.byte_len(0);
@@ -1300,7 +1300,7 @@ impl TCompactInputProtocol<&mut Bytes> {
 }
 
 macro_rules! read_field_header_len {
-    ($self:expr, $ax:expr, $field_type:expr, $id:expr) => {
+    ($self:expr_2021, $ax:expr_2021, $field_type:expr_2021, $id:expr_2021) => {
         let field_delta = $id - $self.last_read_field_id;
         if field_delta > 0 && field_delta < 15 {
             $ax += $self.byte_len(0);
@@ -1774,7 +1774,7 @@ mod tests {
 
     #[cfg(test)]
     macro_rules! assert_success {
-        ($e: expr) => {{
+        ($e: expr_2021) => {{
             let res = $e;
             assert!(res.is_ok());
             res.unwrap()
@@ -1799,7 +1799,7 @@ mod tests {
         let mut trans = BytesMut::new();
         let mut o_prot = test_output_prot_bytesmut(&mut trans);
         macro_rules! mteq {
-            ($o:expr, $exp:expr) => {
+            ($o:expr_2021, $exp:expr_2021) => {
                 assert_eq!($exp, $o.trans.len());
                 $o.trans.clear();
             };

--- a/pilota/src/thrift/mod.rs
+++ b/pilota/src/thrift/mod.rs
@@ -19,7 +19,7 @@ pub use error::*;
 use faststr::FastStr;
 
 pub use self::{binary::TAsyncBinaryProtocol, compact::TAsyncCompactProtocol};
-use crate::{assert_remaining, thrift::rw_ext::IOError, AHashMap, AHashSet};
+use crate::{AHashMap, AHashSet, assert_remaining, thrift::rw_ext::IOError};
 
 const MAXIMUM_SKIP_DEPTH: i8 = 64;
 
@@ -248,7 +248,7 @@ pub trait TInputProtocol: TLengthProtocol {
                 return Err(new_protocol_exception(
                     ProtocolExceptionKind::DepthLimit,
                     format!("cannot skip field type {:?}", &u),
-                ))
+                ));
             }
         };
 
@@ -649,7 +649,7 @@ pub trait TOutputProtocol: TLengthProtocol {
     fn write_message_end(&mut self) -> Result<(), ThriftException>;
     /// Write the beginning of a Thrift struct.
     fn write_struct_begin(&mut self, identifier: &TStructIdentifier)
-        -> Result<(), ThriftException>;
+    -> Result<(), ThriftException>;
     /// Write the end of a Thrift struct.
     fn write_struct_end(&mut self) -> Result<(), ThriftException>;
     /// Write the beginning of a Thrift field.

--- a/pilota/src/thrift/rw_ext.rs
+++ b/pilota/src/thrift/rw_ext.rs
@@ -41,7 +41,7 @@ macro_rules! io_read_impl {
             return Ok($typ::$conv(buf));
         }
     }};
-    (le => $this:ident, $typ:tt, $len_to_read:expr) => {{
+    (le => $this:ident, $typ:tt, $len_to_read:expr_2021) => {{
         debug_assert!(mem::size_of::<$typ>() >= $len_to_read);
 
         // The same trick as above does not improve the best case speed.
@@ -50,7 +50,7 @@ macro_rules! io_read_impl {
         $this.copy_to_slice(&mut buf[..($len_to_read)]);
         return Ok($typ::from_le_bytes(buf));
     }};
-    (be => $this:ident, $typ:tt, $len_to_read:expr) => {{
+    (be => $this:ident, $typ:tt, $len_to_read:expr_2021) => {{
         debug_assert!(mem::size_of::<$typ>() >= $len_to_read);
 
         let mut buf = [0; (mem::size_of::<$typ>())];
@@ -61,7 +61,7 @@ macro_rules! io_read_impl {
 
 #[macro_export]
 macro_rules! assert_remaining {
-    ($cond: expr, $($arg:tt)+) => {
+    ($cond: expr_2021, $($arg:tt)+) => {
         #[cfg(not(feature = "unstable"))]
         if !$cond {
             return Err(IOError::NoRemaining(format!($($arg)+)))?;
@@ -71,7 +71,7 @@ macro_rules! assert_remaining {
             return Err(IOError::NoRemaining(format!($($arg)+)))?;
         }
     };
-    ($cond: expr) => {
+    ($cond: expr_2021) => {
         #[cfg(not(feature = "unstable"))]
         if !$cond {
             return Err(IOError::NoRemaining(String::new()))?;

--- a/pilota/src/thrift/rw_ext.rs
+++ b/pilota/src/thrift/rw_ext.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 use bytes::{Buf as _, BufMut, BytesMut};
 
-use super::{new_protocol_exception, ThriftException};
+use super::{ThriftException, new_protocol_exception};
 
 #[derive(thiserror::Error, Debug)]
 pub enum IOError {


### PR DESCRIPTION
This pull request introduces necessary changes to ensure compatibility with the Rust 2024 edition. 

As part of our transition to accommodate the Rust 2024 edition, we have also updated our Minimum Supported Rust Version (MSRV) to Rust 1.85.0

https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html