### PR TITLE
fix: receive any non-space word for thrift idl namespace scope item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.30"
+version = "0.11.31"
 dependencies = [
  "ahash",
  "anyhow",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.11.6"
+version = "0.11.8"
 dependencies = [
  "nom",
 ]

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.11.7"
+version = "0.11.8"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
 Since the namespace scope might be more than the values in [thrift namespace scope enum](https://thrift.apache.org/docs/idl#namespace), such as cocoa. We should change the rule of thrift namespace scope.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We will accept a non-space word for scope rather than the values in previous enum.
