### PR TITLE
feat: support generate Arc<Req> for service

### DIFF
--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -271,11 +271,7 @@ impl ThriftLower {
                 fields: f
                     .arguments
                     .iter()
-                    .map(|a| {
-                        let mut tags = self.extract_tags(&a.annotations);
-                        tags.remove::<RustWrapperArc>();
-                        self.lower_field_with_tags(a, tags)
-                    })
+                    .map(|a| self.lower_field_with_tags(a, self.extract_tags(&a.annotations)))
                     .collect(),
             });
             related_items.push(name.clone());

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -269,7 +269,7 @@ pub mod wrapper_arc {
         }
         #[derive(Debug, Default, Clone, PartialEq)]
         pub struct TestServiceTestArgsRecv {
-            pub req: Test,
+            pub req: ::std::sync::Arc<Test>,
         }
         impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -314,7 +314,9 @@ pub mod wrapper_arc {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_1 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
@@ -373,12 +375,12 @@ pub mod wrapper_arc {
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_1 = Some(
+                                    var_1 = Some(::std::sync::Arc::new(
                                         <Test as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/message_TestServiceTestArgsRecv_2.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/message_TestServiceTestArgsRecv_2.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct TestServiceTestArgsRecv {
-    pub req: Test,
+    pub req: ::std::sync::Arc<Test>,
 }
 impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
     fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -43,7 +43,9 @@ impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
                 __pilota_decoding_field_id = field_ident.id;
                 match field_ident.id {
                     Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
-                        var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                        var_1 = Some(::std::sync::Arc::new(::pilota::thrift::Message::decode(
+                            __protocol,
+                        )?));
                     }
                     _ => {
                         __protocol.skip(field_ident.field_type)?;
@@ -102,10 +104,10 @@ impl ::pilota::thrift::Message for TestServiceTestArgsRecv {
                     __pilota_decoding_field_id = field_ident.id;
                     match field_ident.id {
                         Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
-                            var_1 = Some(
+                            var_1 = Some(::std::sync::Arc::new(
                                 <Test as ::pilota::thrift::Message>::decode_async(__protocol)
                                     .await?,
-                            );
+                            ));
                         }
                         _ => {
                             __protocol.skip(field_ident.field_type).await?;

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/message_testServiceTestArgsRecv.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/message_testServiceTestArgsRecv.rs
@@ -1,6 +1,6 @@
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct testServiceTestArgsRecv {
-    pub req: Test,
+    pub req: ::std::sync::Arc<Test>,
 }
 impl ::pilota::thrift::Message for testServiceTestArgsRecv {
     fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -43,7 +43,9 @@ impl ::pilota::thrift::Message for testServiceTestArgsRecv {
                 __pilota_decoding_field_id = field_ident.id;
                 match field_ident.id {
                     Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
-                        var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                        var_1 = Some(::std::sync::Arc::new(::pilota::thrift::Message::decode(
+                            __protocol,
+                        )?));
                     }
                     _ => {
                         __protocol.skip(field_ident.field_type)?;
@@ -102,10 +104,10 @@ impl ::pilota::thrift::Message for testServiceTestArgsRecv {
                     __pilota_decoding_field_id = field_ident.id;
                     match field_ident.id {
                         Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
-                            var_1 = Some(
+                            var_1 = Some(::std::sync::Arc::new(
                                 <Test as ::pilota::thrift::Message>::decode_async(__protocol)
                                     .await?,
-                            );
+                            ));
                         }
                         _ => {
                             __protocol.skip(field_ident.field_type).await?;


### PR DESCRIPTION
## Motivation

Using Arc in request and response can reduce the size of stack future, and thus reduce memmove costs.

## Solution

Support wrap request in Arc.