### PR TITLE
feat(pilota-build): support sevice level annotation for arc wrapper of method args and result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.11.31"
+version = "0.11.32"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.11.31"
+version = "0.11.32"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/test_data/thrift/auto_name.rs
+++ b/pilota-build/test_data/thrift/auto_name.rs
@@ -920,7 +920,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct ServiceTest2ArgsSend {
-            pub r#type: TEST,
+            pub r#type: ::std::sync::Arc<TEST>,
         }
         impl ::pilota::thrift::Message for ServiceTest2ArgsSend {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -965,7 +965,9 @@ pub mod auto_name {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_1 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
@@ -1027,12 +1029,12 @@ pub mod auto_name {
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_1 = Some(
+                                    var_1 = Some(::std::sync::Arc::new(
                                         <TEST as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
@@ -1078,7 +1080,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct ServiceTestArgsSend {
-            pub req: TEST,
+            pub req: ::std::sync::Arc<TEST>,
         }
         impl ::pilota::thrift::Message for ServiceTestArgsSend {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -1123,7 +1125,9 @@ pub mod auto_name {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_1 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
@@ -1185,12 +1189,12 @@ pub mod auto_name {
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_1 = Some(
+                                    var_1 = Some(::std::sync::Arc::new(
                                         <TEST as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
@@ -1383,7 +1387,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServicetestResultRecv {
-            Ok(Test),
+            Ok(::std::sync::Arc<Test>),
 
             E(TestException),
         }
@@ -1429,7 +1433,9 @@ pub mod auto_name {
                     match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
-                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                let field_ident = ::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                );
                                 __protocol.struct_len(&field_ident);
                                 ret = Some(ServicetestResultRecv::Ok(field_ident));
                             } else {
@@ -1494,11 +1500,12 @@ pub mod auto_name {
                         match field_ident.id {
                             Some(0) => {
                                 if ret.is_none() {
-                                    let field_ident =
+                                    let field_ident = ::std::sync::Arc::new(
                                         <Test as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
-                                        .await?;
+                                        .await?,
+                                    );
 
                                     ret = Some(ServicetestResultRecv::Ok(field_ident));
                                 } else {
@@ -2021,7 +2028,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct ServiceTest2ArgsRecv {
-            pub r#type: TEST,
+            pub r#type: ::std::sync::Arc<TEST>,
         }
         impl ::pilota::thrift::Message for ServiceTest2ArgsRecv {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -2066,7 +2073,9 @@ pub mod auto_name {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_1 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
@@ -2128,12 +2137,12 @@ pub mod auto_name {
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_1 = Some(
+                                    var_1 = Some(::std::sync::Arc::new(
                                         <TEST as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
@@ -2179,7 +2188,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct ServiceTestArgsRecv {
-            pub req: TEST,
+            pub req: ::std::sync::Arc<TEST>,
         }
         impl ::pilota::thrift::Message for ServiceTestArgsRecv {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -2224,7 +2233,9 @@ pub mod auto_name {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_1 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
@@ -2286,12 +2297,12 @@ pub mod auto_name {
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_1 = Some(
+                                    var_1 = Some(::std::sync::Arc::new(
                                         <TEST as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
@@ -2342,7 +2353,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTestResultSend {
-            Ok(Test),
+            Ok(::std::sync::Arc<Test>),
 
             E(TestException),
         }
@@ -2388,7 +2399,9 @@ pub mod auto_name {
                     match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
-                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                let field_ident = ::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                );
                                 __protocol.struct_len(&field_ident);
                                 ret = Some(ServiceTestResultSend::Ok(field_ident));
                             } else {
@@ -2453,11 +2466,12 @@ pub mod auto_name {
                         match field_ident.id {
                             Some(0) => {
                                 if ret.is_none() {
-                                    let field_ident =
+                                    let field_ident = ::std::sync::Arc::new(
                                         <Test as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
-                                        .await?;
+                                        .await?,
+                                    );
 
                                     ret = Some(ServiceTestResultSend::Ok(field_ident));
                                 } else {
@@ -2712,7 +2726,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTest2ResultRecv {
-            Ok(Test),
+            Ok(::std::sync::Arc<Test>),
         }
 
         impl ::pilota::thrift::Message for ServiceTest2ResultRecv {
@@ -2753,7 +2767,9 @@ pub mod auto_name {
                     match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
-                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                let field_ident = ::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                );
                                 __protocol.struct_len(&field_ident);
                                 ret = Some(ServiceTest2ResultRecv::Ok(field_ident));
                             } else {
@@ -2804,11 +2820,12 @@ pub mod auto_name {
                         match field_ident.id {
                             Some(0) => {
                                 if ret.is_none() {
-                                    let field_ident =
+                                    let field_ident = ::std::sync::Arc::new(
                                         <Test as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
-                                        .await?;
+                                        .await?,
+                                    );
 
                                     ret = Some(ServiceTest2ResultRecv::Ok(field_ident));
                                 } else {
@@ -2851,9 +2868,9 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct ServicetestArgsSend {
-            pub req: TEST,
+            pub req: ::std::sync::Arc<TEST>,
 
-            pub Req: TEST,
+            pub Req: ::std::sync::Arc<TEST>,
         }
         impl ::pilota::thrift::Message for ServicetestArgsSend {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -2900,12 +2917,16 @@ pub mod auto_name {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_1 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_2 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_2 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
@@ -2977,23 +2998,23 @@ pub mod auto_name {
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_1 = Some(
+                                    var_1 = Some(::std::sync::Arc::new(
                                         <TEST as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 Some(2)
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_2 = Some(
+                                    var_2 = Some(::std::sync::Arc::new(
                                         <TEST as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
@@ -3776,9 +3797,9 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct ServicetestArgsRecv {
-            pub req: TEST,
+            pub req: ::std::sync::Arc<TEST>,
 
-            pub Req: TEST,
+            pub Req: ::std::sync::Arc<TEST>,
         }
         impl ::pilota::thrift::Message for ServicetestArgsRecv {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -3825,12 +3846,16 @@ pub mod auto_name {
                             Some(1)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_1 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             Some(2)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
                             {
-                                var_2 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                var_2 = Some(::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                ));
                             }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
@@ -3902,23 +3927,23 @@ pub mod auto_name {
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_1 = Some(
+                                    var_1 = Some(::std::sync::Arc::new(
                                         <TEST as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 Some(2)
                                     if field_ident.field_type
                                         == ::pilota::thrift::TType::Struct =>
                                 {
-                                    var_2 = Some(
+                                    var_2 = Some(::std::sync::Arc::new(
                                         <TEST as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
                                         .await?,
-                                    );
+                                    ));
                                 }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
@@ -3981,7 +4006,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServicetestResultSend {
-            Ok(Test),
+            Ok(::std::sync::Arc<Test>),
 
             E(TestException),
         }
@@ -4027,7 +4052,9 @@ pub mod auto_name {
                     match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
-                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                let field_ident = ::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                );
                                 __protocol.struct_len(&field_ident);
                                 ret = Some(ServicetestResultSend::Ok(field_ident));
                             } else {
@@ -4092,11 +4119,12 @@ pub mod auto_name {
                         match field_ident.id {
                             Some(0) => {
                                 if ret.is_none() {
-                                    let field_ident =
+                                    let field_ident = ::std::sync::Arc::new(
                                         <Test as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
-                                        .await?;
+                                        .await?,
+                                    );
 
                                     ret = Some(ServicetestResultSend::Ok(field_ident));
                                 } else {
@@ -4653,7 +4681,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTest2ResultSend {
-            Ok(Test),
+            Ok(::std::sync::Arc<Test>),
         }
 
         impl ::pilota::thrift::Message for ServiceTest2ResultSend {
@@ -4694,7 +4722,9 @@ pub mod auto_name {
                     match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
-                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                let field_ident = ::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                );
                                 __protocol.struct_len(&field_ident);
                                 ret = Some(ServiceTest2ResultSend::Ok(field_ident));
                             } else {
@@ -4745,11 +4775,12 @@ pub mod auto_name {
                         match field_ident.id {
                             Some(0) => {
                                 if ret.is_none() {
-                                    let field_ident =
+                                    let field_ident = ::std::sync::Arc::new(
                                         <Test as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
-                                        .await?;
+                                        .await?,
+                                    );
 
                                     ret = Some(ServiceTest2ResultSend::Ok(field_ident));
                                 } else {
@@ -4939,7 +4970,7 @@ pub mod auto_name {
         }
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
         pub enum ServiceTestResultRecv {
-            Ok(Test),
+            Ok(::std::sync::Arc<Test>),
 
             E(TestException),
         }
@@ -4985,7 +5016,9 @@ pub mod auto_name {
                     match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
-                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                let field_ident = ::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                );
                                 __protocol.struct_len(&field_ident);
                                 ret = Some(ServiceTestResultRecv::Ok(field_ident));
                             } else {
@@ -5050,11 +5083,12 @@ pub mod auto_name {
                         match field_ident.id {
                             Some(0) => {
                                 if ret.is_none() {
-                                    let field_ident =
+                                    let field_ident = ::std::sync::Arc::new(
                                         <Test as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
-                                        .await?;
+                                        .await?,
+                                    );
 
                                     ret = Some(ServiceTestResultRecv::Ok(field_ident));
                                 } else {

--- a/pilota-build/test_data/thrift/auto_name.thrift
+++ b/pilota-build/test_data/thrift/auto_name.thrift
@@ -21,10 +21,10 @@ struct TestException {
 }
 
 service Service {
-    Test test(1: TEST req, 2: TEST Req) throws (1: TestException e);
+    Test(pilota.rust_wrapper_arc="true") test(1: TEST req(pilota.rust_wrapper_arc="true")  , 2: TEST Req) throws (1: TestException e);
     Test Test(1: TEST Req) throws (1: TestException e);
     Test Test2(1: TEST type);
-}
+} (pilota.rust_wrapper_arc="true")
 
 service service {
     Test test(1: TEST req) throws (1: TestException e);

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -130,7 +130,7 @@ pub mod wrapper_arc {
         }
         #[derive(Debug, Clone, PartialEq)]
         pub enum TestServiceTestResultRecv {
-            Ok(Test),
+            Ok(::std::sync::Arc<Test>),
         }
 
         impl ::pilota::thrift::Message for TestServiceTestResultRecv {
@@ -171,7 +171,9 @@ pub mod wrapper_arc {
                     match field_ident.id {
                         Some(0) => {
                             if ret.is_none() {
-                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                let field_ident = ::std::sync::Arc::new(
+                                    ::pilota::thrift::Message::decode(__protocol)?,
+                                );
                                 __protocol.struct_len(&field_ident);
                                 ret = Some(TestServiceTestResultRecv::Ok(field_ident));
                             } else {
@@ -222,11 +224,12 @@ pub mod wrapper_arc {
                         match field_ident.id {
                             Some(0) => {
                                 if ret.is_none() {
-                                    let field_ident =
+                                    let field_ident = ::std::sync::Arc::new(
                                         <Test as ::pilota::thrift::Message>::decode_async(
                                             __protocol,
                                         )
-                                        .await?;
+                                        .await?,
+                                    );
 
                                     ret = Some(TestServiceTestResultRecv::Ok(field_ident));
                                 } else {

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultRecv.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_TestServiceTestResultRecv.rs
@@ -6,7 +6,7 @@ impl ::std::default::Default for TestServiceTestResultRecv {
 }
 #[derive(Debug, Clone, PartialEq)]
 pub enum TestServiceTestResultRecv {
-    Ok(Test),
+    Ok(::std::sync::Arc<Test>),
 }
 
 impl ::pilota::thrift::Message for TestServiceTestResultRecv {
@@ -47,7 +47,8 @@ impl ::pilota::thrift::Message for TestServiceTestResultRecv {
             match field_ident.id {
                 Some(0) => {
                     if ret.is_none() {
-                        let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                        let field_ident =
+                            ::std::sync::Arc::new(::pilota::thrift::Message::decode(__protocol)?);
                         __protocol.struct_len(&field_ident);
                         ret = Some(TestServiceTestResultRecv::Ok(field_ident));
                     } else {
@@ -98,9 +99,10 @@ impl ::pilota::thrift::Message for TestServiceTestResultRecv {
                 match field_ident.id {
                     Some(0) => {
                         if ret.is_none() {
-                            let field_ident =
+                            let field_ident = ::std::sync::Arc::new(
                                 <Test as ::pilota::thrift::Message>::decode_async(__protocol)
-                                    .await?;
+                                    .await?,
+                            );
 
                             ret = Some(TestServiceTestResultRecv::Ok(field_ident));
                         } else {

--- a/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultRecv_2.rs
+++ b/pilota-build/test_data/thrift_with_split/wrapper_arc/enum_testServiceTestResultRecv_2.rs
@@ -6,7 +6,7 @@ impl ::std::default::Default for testServiceTestResultRecv {
 }
 #[derive(Debug, Clone, PartialEq)]
 pub enum testServiceTestResultRecv {
-    Ok(Test),
+    Ok(::std::sync::Arc<Test>),
 }
 
 impl ::pilota::thrift::Message for testServiceTestResultRecv {
@@ -47,7 +47,8 @@ impl ::pilota::thrift::Message for testServiceTestResultRecv {
             match field_ident.id {
                 Some(0) => {
                     if ret.is_none() {
-                        let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                        let field_ident =
+                            ::std::sync::Arc::new(::pilota::thrift::Message::decode(__protocol)?);
                         __protocol.struct_len(&field_ident);
                         ret = Some(testServiceTestResultRecv::Ok(field_ident));
                     } else {
@@ -98,9 +99,10 @@ impl ::pilota::thrift::Message for testServiceTestResultRecv {
                 match field_ident.id {
                     Some(0) => {
                         if ret.is_none() {
-                            let field_ident =
+                            let field_ident = ::std::sync::Arc::new(
                                 <Test as ::pilota::thrift::Message>::decode_async(__protocol)
-                                    .await?;
+                                    .await?,
+                            );
 
                             ret = Some(testServiceTestResultRecv::Ok(field_ident));
                         } else {


### PR DESCRIPTION
Change-Id: I46ef067abd6afbb88f38e4be14dca8107e1edc70

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
The arc wrapper is used to modify the rust type `T` to `Arc<T>`. For fields that are known not to change, the copy cost can be optimized, while reducing the memmove overhead caused by excessive data on the stack.

For ease of use, support service-level annotation to set the arc wrapper of request and response for all methods.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

When processing the service ir, we will enable the rust_arc_wrapper for each arg and result of each method if this annotation is detected.
