### PR TITLE
fix(pilota-build): handle missing file paths for protobuf well-known types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -478,17 +478,19 @@ where
         });
 
         let mods_iter = mods.iter().map(|(p, def_ids)| {
-            let file_path = def_ids.first().map(|def_id| {
-                let node = self.node(def_id.def_id).unwrap();
-                let file_id = node.file_id;
+            let file_path = def_ids
+                .first()
+                .map(|def_id| {
+                    let node = self.node(def_id.def_id).unwrap();
+                    let file_id = node.file_id;
 
-                self.file_ids_map()
-                    .iter()
-                    .find(|(_, id)| **id == file_id)
-                    .map(|(path, _)| path)
-                    .cloned()
-                    .unwrap()
-            });
+                    self.file_ids_map()
+                        .iter()
+                        .find(|(_, id)| **id == file_id)
+                        .map(|(path, _)| path)
+                        .cloned()
+                })
+                .flatten();
 
             let has_direct = def_ids
                 .iter()


### PR DESCRIPTION
Previously, the code would panic when processing protobuf well-known types (e.g., google/protobuf/timestamp.proto) because these imports don't have corresponding file paths in the file_ids_map. This caused an unwrap() on a None value.

The fix removes the unwrap() and uses flatten() to safely handle the case where a file_id doesn't have a corresponding path, returning None instead of panicking.

Fixes panic: "called Option::unwrap() on a None value" at pilota-build/src/codegen/mod.rs:490:22