### PR TITLE
fix(pilota-build): use the '()' for priority of '&' compare to '.'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "ahash",
  "anyhow",

--- a/examples/idl/fieldmask.thrift
+++ b/examples/idl/fieldmask.thrift
@@ -16,7 +16,7 @@ struct Request {
     6: double f6,
     7: string f7,
     8: binary f8,
-    9: list<i32> f9,
+    9: required list<i32> f9,
     10: set<string> f10,
     11: A f11,
     12: list<list<i32>> f12,

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -10,22 +10,6 @@ pub mod fieldmask {
 #[test]
 fn test_pb_encode_zero_value() {
     use pilota::pb::Message as _;
-    // let test_data = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-    //     .join("idl")
-    //     .join("zero_value.proto");
-
-    // let out_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-    //     .join("src")
-    //     .join("zero_value.rs");
-
-    // pilota_build::Builder::pb()
-    //     .ignore_unused(false)
-    //     .include_dirs(vec![test_data.parent().unwrap().to_path_buf()])
-    //     .keep_unknown_fields([test_data.clone().into()])
-    //     .compile_with_config(
-    //         vec![pilota_build::IdlService::from_path(test_data.to_path_buf())],
-    //         pilota_build::Output::File(out_path.into()),
-    //     );
 
     let mut a = zero_value::zero_value::A::default();
 
@@ -101,7 +85,7 @@ fn test_thrift_fieldmask() {
         f6: Some(1.0),
         f7: Some("1".into()),
         f8: Some(pilota::Bytes::from_static(b"1")),
-        f9: Some(vec![1, 2, 3]),
+        f9: vec![1, 2, 3],
         f10: Some(pilota::AHashSet::from_iter(vec!["1".into(), "2".into()])),
         f11: Some(fieldmask::fieldmask::fieldmask::A {
             a: Some(1),

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.12.4"
+version = "0.12.5"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -115,7 +115,7 @@ impl ThriftBackend {
                     r#"if let Some(list_fm) = item_fm {{
                         __protocol.write_list_begin(::pilota::thrift::TListIdentifier {{
                             element_type: {el_ttype},
-                            size: (0..{ident}.len()).filter(|idx| list_fm.int(*idx as i32).1).count(),
+                            size: (0..({ident}).len()).filter(|idx| list_fm.int(*idx as i32).1).count(),
                         }})?;
                         let mut idx = 0;
                         for val in {ident} {{
@@ -403,7 +403,7 @@ impl ThriftBackend {
                         __protocol.write_field_begin(::pilota::thrift::TType::List, {id})?;
                         __protocol.write_list_begin(::pilota::thrift::TListIdentifier {{
                             element_type: {el_ttype},
-                            size: (0..{ident}.len()).filter(|idx| list_fm.int(*idx as i32).1).count(),
+                            size: (0..({ident}).len()).filter(|idx| list_fm.int(*idx as i32).1).count(),
                         }})?;
                         let mut idx = 0;
                         for val in {ident} {{

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -30,8 +30,6 @@ fn generate_short_uuid() -> FastStr {
 #[derive(Default, Clone)]
 struct ThriftSourceDatabase {
     storage: salsa::Storage<Self>,
-    file_cache: FxHashMap<PathBuf, Arc<str>>,
-    parse_cache: FxHashMap<PathBuf, Arc<thrift_parser::File>>,
 }
 
 #[salsa::db]


### PR DESCRIPTION
Change-Id: I5d2f5f4c577e0a7ae8a368b03880319608e96628

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The previous use of `{ident}.len()` is incompatible with the `&self.{fieldname}` ident, because the `.` is 
calculated before the `&`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
We use replace it with `({ident}).len()`.