### PR TITLE
fix(pilota): clean the recursion status for shared context when exit …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "pilota"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -10,7 +10,6 @@ pub mod fieldmask {
 #[test]
 fn test_pb_encode_zero_value() {
     use pilota::pb::Message as _;
-
     let mut a = zero_value::zero_value::A::default();
 
     a.str_map.insert("key1".into(), "value".into());

--- a/pilota/Cargo.toml
+++ b/pilota/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota/src/pb/encoding.rs
+++ b/pilota/src/pb/encoding.rs
@@ -218,9 +218,22 @@ impl DecodeContext {
         self
     }
 
+    #[cfg(not(feature = "no-recursion-limit"))]
+    #[inline]
+    pub(crate) fn exit_recursion(&mut self) -> &mut DecodeContext {
+        self.recurse_count += 1;
+        self
+    }
+
     #[cfg(feature = "no-recursion-limit")]
     #[inline]
     pub(crate) fn enter_recursion(&mut self) -> &mut DecodeContext {
+        self
+    }
+
+    #[cfg(feature = "no-recursion-limit")]
+    #[inline]
+    pub(crate) fn exit_recursion(&mut self) -> &mut DecodeContext {
         self
     }
 
@@ -404,7 +417,11 @@ pub fn skip_field(
                     }
                     break 0;
                 }
-                _ => skip_field(inner_wire_type, inner_tag, buf, ctx.enter_recursion())?,
+                _ => {
+                    ctx.enter_recursion();
+                    skip_field(inner_wire_type, inner_tag, buf, ctx)?;
+                    ctx.exit_recursion();
+                }
             }
         },
         WireType::EndGroup => return Err(DecodeError::new("unexpected end group tag")),
@@ -1245,15 +1262,18 @@ pub mod message {
     {
         check_wire_type(WireType::LengthDelimited, wire_type)?;
         ctx.limit_reached()?;
+        ctx.enter_recursion();
         merge_loop(
             msg,
             buf,
-            ctx.enter_recursion(),
+            ctx,
             |msg: &mut M, buf: &mut Bytes, ctx: &mut DecodeContext| {
                 let (tag, wire_type) = decode_key(buf)?;
                 msg.merge_field(tag, wire_type, buf, ctx)
             },
-        )
+        )?;
+        ctx.exit_recursion();
+        Ok(())
     }
 
     pub fn encode_repeated<M>(tag: u32, messages: &[M], buf: &mut LinkedBytes)
@@ -1340,6 +1360,7 @@ pub mod group {
 
             ctx.enter_recursion();
             M::merge_field(msg, field_tag, field_wire_type, buf, ctx)?;
+            ctx.exit_recursion();
         }
     }
 
@@ -1516,10 +1537,11 @@ macro_rules! map {
             let mut key = Default::default();
             let mut val = val_default;
             ctx.limit_reached()?;
+            ctx.enter_recursion();
             merge_loop(
                 &mut (&mut key, &mut val),
                 buf,
-                ctx.enter_recursion(),
+                ctx,
                 |&mut (ref mut key, ref mut val), buf, ctx| {
                     let (tag, wire_type) = decode_key(buf)?;
                     match tag {
@@ -1529,6 +1551,7 @@ macro_rules! map {
                     }
                 },
             )?;
+            ctx.exit_recursion();
             values.insert(key, val);
 
             Ok(())


### PR DESCRIPTION
…the current level

Change-Id: I7d54e99b83bc90cd0c4ed164bc0145a9c48711bb

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
For better performance, we use the mut reference for a shared decode context in protobuf decoding.
However, this change will cause the wrong computation of recursion limit.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Add a symmetry exit function for recursion limit, and use it everywhere the enter is called.
