### PR TITLE
fix(thrift): caculate zero copy size before encode to reduce the unnecessary malloc of linkedbytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.12.5"
+version = "0.12.6"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
When doing benchmark for unknown fields feature, we found the cost of zero-copy encoding of all fields is strange. And we found that the cost is the malloc of linkedbytes with large capacity. The reason is the zero-copy len is not be calculated before encode. The PR that accidentally deleted this logic is https://github.com/cloudwego/pilota/pull/181/files#diff-62578292749cb3d43d37b178fa70f413305265125d06a2203e2fd4f461cbffc4L108
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
We add it back for thrift binary protocol implement and use the unknown fields benchmark to check if it works.
