### PR TITLE
fix(pilota-build): add thrift duplicate id check

### DIFF
--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -545,6 +545,16 @@ impl ThriftLower {
     }
 
     fn lower_struct(&self, s: &thrift_parser::StructLike) -> ir::Message {
+        let mut seen_ids = FxHashSet::default();
+        for field in &s.fields {
+            if !seen_ids.insert(field.id) {
+                error_abort(format!(
+                    "Errors: duplicate ID `{}` in struct `{}`",
+                    field.id,
+                    self.lower_ident(&s.name),
+                ));
+            }
+        }
         ir::Message {
             name: self.lower_ident(&s.name),
             fields: s.fields.iter().map(|f| self.lower_field(f)).collect(),

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -548,11 +548,11 @@ impl ThriftLower {
         let mut seen_ids = FxHashSet::default();
         for field in &s.fields {
             if !seen_ids.insert(field.id) {
-                error_abort(format!(
-                    "Errors: duplicate ID `{}` in struct `{}`",
+                panic!(
+                    "duplicate ID `{}` in struct `{}`",
                     field.id,
                     self.lower_ident(&s.name),
-                ));
+                );
             }
         }
         ir::Message {

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -599,6 +599,24 @@ fn test_unknown_fields() {
     });
 }
 
+#[test]
+#[should_panic(expected = "duplicate ID `1` in struct `User`")]
+fn test_duplicate_field_id() {
+    let file_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test_data")
+        .join("duplicate_field_id.thrift");
+
+    let mut out_path = file_path.clone();
+    out_path.set_extension("rs");
+
+    crate::Builder::thrift()
+        .touch([(file_path.clone().into(), vec!["User"])])
+        .compile_with_config(
+            vec![IdlService::from_path(file_path)],
+            crate::Output::File(out_path),
+        );
+}
+
 mod tests {
 
     // use self::decode_error::decode_error::A;

--- a/pilota-build/test_data/duplicate_field_id.thrift
+++ b/pilota-build/test_data/duplicate_field_id.thrift
@@ -1,0 +1,4 @@
+struct User {
+    1: string name
+    1: i32 id
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
Currently, if there are duplicate ids in the user-defined idl, no error will be reported during the generation phase, but duplicate match statements will be generated in the generated code
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Added a check for duplicate id when trying to initialize the thrift file which panics
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
