### PR TITLE
fix(pilota-build): use root crate Option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.12.9"
+version = "0.12.10"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.12.9"
+version = "0.12.10"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -279,7 +279,7 @@ where
                     }}
                 }}
 
-                pub fn try_from_{repr}(value: {repr}) -> Option<Self> {{
+                pub fn try_from_{repr}(value: {repr}) -> ::std::option::Option<Self> {{
                     match value {{
                         {try_from_arms}
                         _ => None,

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -228,7 +228,7 @@ pub mod serde {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     0 => Some(Self::D),
                     1 => Some(Self::E),

--- a/pilota-build/test_data/protobuf/nested_message.new_pb.rs
+++ b/pilota-build/test_data/protobuf/nested_message.new_pb.rs
@@ -88,7 +88,7 @@ pub mod nested_message {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     1 => Some(Self::LABEL_OPTIONAL),
                     2 => Some(Self::LABEL_REQUIRED),

--- a/pilota-build/test_data/protobuf/nested_message.rs
+++ b/pilota-build/test_data/protobuf/nested_message.rs
@@ -108,7 +108,7 @@ pub mod nested_message {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     1 => Some(Self::LABEL_OPTIONAL),
                     2 => Some(Self::LABEL_REQUIRED),

--- a/pilota-build/test_data/thrift/apache.rs
+++ b/pilota-build/test_data/thrift/apache.rs
@@ -35,7 +35,7 @@ pub mod apache {
                         }
                     }
 
-                    pub fn try_from_i32(value: i32) -> Option<Self> {
+                    pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                         match value {
                             1 => Some(Self::ONE),
                             2 => Some(Self::TWO),

--- a/pilota-build/test_data/thrift/auto_name.rs
+++ b/pilota-build/test_data/thrift/auto_name.rs
@@ -3117,7 +3117,7 @@ pub mod auto_name {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     0 => Some(Self::A),
                     1 => Some(Self::a),

--- a/pilota-build/test_data/thrift/btree.rs
+++ b/pilota-build/test_data/thrift/btree.rs
@@ -892,7 +892,7 @@ pub mod btree {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     0 => Some(Self::A),
                     1 => Some(Self::B),

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -23,7 +23,7 @@ pub mod const_val {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     0 => Some(Self::A),
                     1 => Some(Self::B),

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -23,7 +23,7 @@ pub mod default_value {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     1 => Some(Self::READ),
                     2 => Some(Self::WRITE),

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -23,7 +23,7 @@ pub mod enum_test {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     1 => Some(Self::A),
                     16 => Some(Self::B),
@@ -423,7 +423,7 @@ pub mod enum_test {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     _ => None,
                 }
@@ -1332,7 +1332,7 @@ pub mod enum_test {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     1 => Some(Self::_1),
                     2 => Some(Self::_2),
@@ -1722,7 +1722,7 @@ pub mod enum_test {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     _ => None,
                 }

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -199,7 +199,7 @@ pub mod multi {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     1 => Some(Self::READ),
                     2 => Some(Self::WRITE),

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -971,7 +971,7 @@ pub mod pilota_name {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     0 => Some(Self::AA),
                     1 => Some(Self::B),

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -23,7 +23,7 @@ pub mod self_kw {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     0 => Some(Self::A),
                     1 => Some(Self::SELF),

--- a/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
@@ -23,7 +23,7 @@ pub mod r#gen {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     0 => Some(Self::NORMAL),
                     1 => Some(Self::DELETED),

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/enum_Status.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/enum_Status.rs
@@ -18,7 +18,7 @@ impl Status {
         }
     }
 
-    pub fn try_from_i32(value: i32) -> Option<Self> {
+    pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
         match value {
             0 => Some(Self::NORMAL),
             1 => Some(Self::DELETED),

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -2700,7 +2700,7 @@ pub mod unknown_fields {
                 }
             }
 
-            pub fn try_from_i32(value: i32) -> Option<Self> {
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
                 match value {
                     0 => Some(Self::A),
                     1 => Some(Self::B),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
Currently, the Option type used for the return value of the enum try_from method does not use the root crate syntax, resulting in ambiguity with user-defined types of the same name
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Used the full path of ::std::option::Option
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
