### PR TITLE
fix(pilota-build): add the arc type in the reference graph for workspace codegen mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.12.10"
+version = "0.12.11"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/middle/workspace_graph.rs
+++ b/pilota-build/src/middle/workspace_graph.rs
@@ -37,12 +37,15 @@ impl WorkspaceGraph {
                 ty::Path(p) => {
                     graph.add_edge(idx, node_map[&p.did], ());
                 }
-                ty::Vec(ty) | ty::Set(ty) => {
+                ty::Vec(ty) | ty::Set(ty) | ty::BTreeSet(ty) => {
                     visit(graph, idx, node_map, ty);
                 }
-                ty::Map(ty1, ty2) => {
+                ty::Map(ty1, ty2) | ty::BTreeMap(ty1, ty2) => {
                     visit(graph, idx, node_map, ty1);
                     visit(graph, idx, node_map, ty2);
+                }
+                ty::Arc(ty) => {
+                    visit(graph, idx, node_map, ty);
                 }
                 _ => {}
             }

--- a/pilota-build/test_data/thrift_workspace/input/article.thrift
+++ b/pilota-build/test_data/thrift_workspace/input/article.thrift
@@ -15,7 +15,7 @@ struct Article {
     3: required string content,
     4: required author.Author author,
     5: required Status status,
-    6: required list<image.Image> images,
+    6: required list<image.Image> images(pilota.rust_wrapper_arc="true"),
     7: required common.CommonData common_data,
 }
 

--- a/pilota-build/test_data/thrift_workspace/input/author.thrift
+++ b/pilota-build/test_data/thrift_workspace/input/author.thrift
@@ -7,7 +7,7 @@ struct Author {
     1: required i64 id,
     2: required string username,
     3: required string email,
-    4: required image.Image avatar,
+    //4: required image.Image avatar,
     5: required common.CommonData common_data,
 }
 

--- a/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
@@ -1018,7 +1018,7 @@ pub mod r#gen {
 
             pub status: Status,
 
-            pub images: ::std::vec::Vec<::common::article::image::Image>,
+            pub images: ::std::vec::Vec<::std::sync::Arc<::common::article::image::Image>>,
 
             pub common_data: ::common::common::CommonData,
         }
@@ -1108,12 +1108,15 @@ pub mod r#gen {
                             Some(6) if field_ident.field_type == ::pilota::thrift::TType::List => {
                                 var_6 = Some(unsafe {
                                     let list_ident = __protocol.read_list_begin()?;
-                                    let mut val: ::std::vec::Vec<::common::article::image::Image> =
-                                        ::std::vec::Vec::with_capacity(list_ident.size);
+                                    let mut val: ::std::vec::Vec<
+                                        ::std::sync::Arc<::common::article::image::Image>,
+                                    > = ::std::vec::Vec::with_capacity(list_ident.size);
                                     for i in 0..list_ident.size {
-                                        val.as_mut_ptr()
-                                            .offset(i as isize)
-                                            .write(::pilota::thrift::Message::decode(__protocol)?);
+                                        val.as_mut_ptr().offset(i as isize).write(
+                                            ::std::sync::Arc::new(
+                                                ::pilota::thrift::Message::decode(__protocol)?,
+                                            ),
+                                        );
                                     }
                                     val.set_len(list_ident.size);
                                     __protocol.read_list_end()?;
@@ -1255,7 +1258,7 @@ pub mod r#gen {
                             let list_ident = __protocol.read_list_begin().await?;
                             let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
                             for _ in 0..list_ident.size {
-                                val.push(<::common::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+                                val.push(::std::sync::Arc::new(<::common::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?));
                             };
                             __protocol.read_list_end().await?;
                             val

--- a/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
@@ -1,18 +1,6 @@
 pub mod r#gen {
     #![allow(warnings, clippy::all)]
 
-    pub mod article {
-
-        pub mod image {
-
-            pub use ::common::article::image::Image;
-            pub mod cdn {
-
-                pub use ::common::article::image::cdn::Cdn;
-            }
-        }
-    }
-
     pub mod author {
 
         pub trait AuthorService {}

--- a/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
@@ -529,8 +529,6 @@ pub mod r#gen {
 
             pub email: ::pilota::FastStr,
 
-            pub avatar: super::article::image::Image,
-
             pub common_data: super::common::CommonData,
         }
         impl ::pilota::thrift::Message for Author {
@@ -546,7 +544,6 @@ pub mod r#gen {
                 __protocol.write_i64_field(1, *&self.id)?;
                 __protocol.write_faststr_field(2, (&self.username).clone())?;
                 __protocol.write_faststr_field(3, (&self.email).clone())?;
-                __protocol.write_struct_field(4, &self.avatar, ::pilota::thrift::TType::Struct)?;
                 __protocol.write_struct_field(
                     5,
                     &self.common_data,
@@ -566,7 +563,6 @@ pub mod r#gen {
                 let mut var_1 = None;
                 let mut var_2 = None;
                 let mut var_3 = None;
-                let mut var_4 = None;
                 let mut var_5 = None;
 
                 let mut __pilota_decoding_field_id = None;
@@ -595,11 +591,6 @@ pub mod r#gen {
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
                                 var_3 = Some(__protocol.read_faststr()?);
-                            }
-                            Some(4)
-                                if field_ident.field_type == ::pilota::thrift::TType::Struct =>
-                            {
-                                var_4 = Some(::pilota::thrift::Message::decode(__protocol)?);
                             }
                             Some(5)
                                 if field_ident.field_type == ::pilota::thrift::TType::Struct =>
@@ -644,12 +635,6 @@ pub mod r#gen {
                         "field email is required".to_string(),
                     ));
                 };
-                let Some(var_4) = var_4 else {
-                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
-                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                        "field avatar is required".to_string(),
-                    ));
-                };
                 let Some(var_5) = var_5 else {
                     return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                         ::pilota::thrift::ProtocolExceptionKind::InvalidData,
@@ -661,7 +646,6 @@ pub mod r#gen {
                     id: var_1,
                     username: var_2,
                     email: var_3,
-                    avatar: var_4,
                     common_data: var_5,
                 };
                 ::std::result::Result::Ok(data)
@@ -681,7 +665,6 @@ pub mod r#gen {
                     let mut var_1 = None;
                     let mut var_2 = None;
                     let mut var_3 = None;
-                    let mut var_4 = None;
                     let mut var_5 = None;
 
                     let mut __pilota_decoding_field_id = None;
@@ -708,9 +691,6 @@ pub mod r#gen {
 
                 },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Binary  => {
                     var_3 = Some(__protocol.read_faststr().await?);
-
-                },Some(4) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
-                    var_4 = Some(<super::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?);
 
                 },Some(5) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
                     var_5 = Some(<super::common::CommonData as ::pilota::thrift::Message>::decode_async(__protocol).await?);
@@ -759,14 +739,6 @@ pub mod r#gen {
                             ),
                         );
                     };
-                    let Some(var_4) = var_4 else {
-                        return ::std::result::Result::Err(
-                            ::pilota::thrift::new_protocol_exception(
-                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                                "field avatar is required".to_string(),
-                            ),
-                        );
-                    };
                     let Some(var_5) = var_5 else {
                         return ::std::result::Result::Err(
                             ::pilota::thrift::new_protocol_exception(
@@ -780,7 +752,6 @@ pub mod r#gen {
                         id: var_1,
                         username: var_2,
                         email: var_3,
-                        avatar: var_4,
                         common_data: var_5,
                     };
                     ::std::result::Result::Ok(data)
@@ -794,7 +765,6 @@ pub mod r#gen {
                     + __protocol.i64_field_len(Some(1), *&self.id)
                     + __protocol.faststr_field_len(Some(2), &self.username)
                     + __protocol.faststr_field_len(Some(3), &self.email)
-                    + __protocol.struct_field_len(Some(4), &self.avatar)
                     + __protocol.struct_field_len(Some(5), &self.common_data)
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()

--- a/pilota-build/test_data/thrift_workspace_with_split/input/article.thrift
+++ b/pilota-build/test_data/thrift_workspace_with_split/input/article.thrift
@@ -15,7 +15,7 @@ struct Article {
     3: required string content,
     4: required author.Author author,
     5: required Status status,
-    6: required list<image.Image> images,
+    //6: required list<image.Image> images,
     7: required common.CommonData common_data,
 }
 

--- a/pilota-build/test_data/thrift_workspace_with_split/input/author.thrift
+++ b/pilota-build/test_data/thrift_workspace_with_split/input/author.thrift
@@ -7,7 +7,7 @@ struct Author {
     1: required i64 id,
     2: required string username,
     3: required string email,
-    4: required image.Image avatar,
+    4: required image.Image avatar(pilota.rust_wrapper_arc="true"),
     5: required common.CommonData common_data,
 }
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/message_Article.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/message_Article.rs
@@ -10,8 +10,6 @@ pub struct Article {
 
     pub status: Status,
 
-    pub images: ::std::vec::Vec<::common::article::image::Image>,
-
     pub common_data: ::common::common::CommonData,
 }
 impl ::pilota::thrift::Message for Article {
@@ -29,15 +27,6 @@ impl ::pilota::thrift::Message for Article {
         __protocol.write_faststr_field(3, (&self.content).clone())?;
         __protocol.write_struct_field(4, &self.author, ::pilota::thrift::TType::Struct)?;
         __protocol.write_i32_field(5, (&self.status).inner())?;
-        __protocol.write_list_field(
-            6,
-            ::pilota::thrift::TType::Struct,
-            &&self.images,
-            |__protocol, val| {
-                __protocol.write_struct(val)?;
-                ::std::result::Result::Ok(())
-            },
-        )?;
         __protocol.write_struct_field(7, &self.common_data, ::pilota::thrift::TType::Struct)?;
         __protocol.write_field_stop()?;
         __protocol.write_struct_end()?;
@@ -55,7 +44,6 @@ impl ::pilota::thrift::Message for Article {
         let mut var_3 = None;
         let mut var_4 = None;
         let mut var_5 = None;
-        let mut var_6 = None;
         let mut var_7 = None;
 
         let mut __pilota_decoding_field_id = None;
@@ -86,21 +74,6 @@ impl ::pilota::thrift::Message for Article {
                     }
                     Some(5) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
                         var_5 = Some(::pilota::thrift::Message::decode(__protocol)?);
-                    }
-                    Some(6) if field_ident.field_type == ::pilota::thrift::TType::List => {
-                        var_6 = Some(unsafe {
-                            let list_ident = __protocol.read_list_begin()?;
-                            let mut val: ::std::vec::Vec<::common::article::image::Image> =
-                                ::std::vec::Vec::with_capacity(list_ident.size);
-                            for i in 0..list_ident.size {
-                                val.as_mut_ptr()
-                                    .offset(i as isize)
-                                    .write(::pilota::thrift::Message::decode(__protocol)?);
-                            }
-                            val.set_len(list_ident.size);
-                            __protocol.read_list_end()?;
-                            val
-                        });
                     }
                     Some(7) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
                         var_7 = Some(::pilota::thrift::Message::decode(__protocol)?);
@@ -155,12 +128,6 @@ impl ::pilota::thrift::Message for Article {
                 "field status is required".to_string(),
             ));
         };
-        let Some(var_6) = var_6 else {
-            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
-                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                "field images is required".to_string(),
-            ));
-        };
         let Some(var_7) = var_7 else {
             return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                 ::pilota::thrift::ProtocolExceptionKind::InvalidData,
@@ -174,7 +141,6 @@ impl ::pilota::thrift::Message for Article {
             content: var_3,
             author: var_4,
             status: var_5,
-            images: var_6,
             common_data: var_7,
         };
         ::std::result::Result::Ok(data)
@@ -196,7 +162,6 @@ impl ::pilota::thrift::Message for Article {
             let mut var_3 = None;
             let mut var_4 = None;
             let mut var_5 = None;
-            let mut var_6 = None;
             let mut var_7 = None;
 
             let mut __pilota_decoding_field_id = None;
@@ -229,17 +194,6 @@ impl ::pilota::thrift::Message for Article {
 
                 },Some(5) if field_ident.field_type == ::pilota::thrift::TType::I32  => {
                     var_5 = Some(<Status as ::pilota::thrift::Message>::decode_async(__protocol).await?);
-
-                },Some(6) if field_ident.field_type == ::pilota::thrift::TType::List  => {
-                    var_6 = Some({
-                            let list_ident = __protocol.read_list_begin().await?;
-                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
-                            for _ in 0..list_ident.size {
-                                val.push(<::common::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?);
-                            };
-                            __protocol.read_list_end().await?;
-                            val
-                        });
 
                 },Some(7) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
                     var_7 = Some(<::common::common::CommonData as ::pilota::thrift::Message>::decode_async(__protocol).await?);
@@ -294,12 +248,6 @@ impl ::pilota::thrift::Message for Article {
                     "field status is required".to_string(),
                 ));
             };
-            let Some(var_6) = var_6 else {
-                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
-                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
-                    "field images is required".to_string(),
-                ));
-            };
             let Some(var_7) = var_7 else {
                 return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
                     ::pilota::thrift::ProtocolExceptionKind::InvalidData,
@@ -313,7 +261,6 @@ impl ::pilota::thrift::Message for Article {
                 content: var_3,
                 author: var_4,
                 status: var_5,
-                images: var_6,
                 common_data: var_7,
             };
             ::std::result::Result::Ok(data)
@@ -329,12 +276,6 @@ impl ::pilota::thrift::Message for Article {
             + __protocol.faststr_field_len(Some(3), &self.content)
             + __protocol.struct_field_len(Some(4), &self.author)
             + __protocol.i32_field_len(Some(5), (&self.status).inner())
-            + __protocol.list_field_len(
-                Some(6),
-                ::pilota::thrift::TType::Struct,
-                &self.images,
-                |__protocol, el| __protocol.struct_len(el),
-            )
             + __protocol.struct_field_len(Some(7), &self.common_data)
             + __protocol.field_stop_len()
             + __protocol.struct_end_len()

--- a/pilota-build/test_data/thrift_workspace_with_split/output/common/src/author/message_Author.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/common/src/author/message_Author.rs
@@ -6,7 +6,7 @@ pub struct Author {
 
     pub email: ::pilota::FastStr,
 
-    pub avatar: super::article::image::Image,
+    pub avatar: ::std::sync::Arc<super::article::image::Image>,
 
     pub common_data: super::common::CommonData,
 }
@@ -66,7 +66,9 @@ impl ::pilota::thrift::Message for Author {
                         var_3 = Some(__protocol.read_faststr()?);
                     }
                     Some(4) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
-                        var_4 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                        var_4 = Some(::std::sync::Arc::new(::pilota::thrift::Message::decode(
+                            __protocol,
+                        )?));
                     }
                     Some(5) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
                         var_5 = Some(::pilota::thrift::Message::decode(__protocol)?);
@@ -175,7 +177,7 @@ impl ::pilota::thrift::Message for Author {
                     var_3 = Some(__protocol.read_faststr().await?);
 
                 },Some(4) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
-                    var_4 = Some(<super::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+                    var_4 = Some(::std::sync::Arc::new(<super::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?));
 
                 },Some(5) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
                     var_5 = Some(<super::common::CommonData as ::pilota::thrift::Message>::decode_async(__protocol).await?);


### PR DESCRIPTION
Change-Id: I8ff0270ff0a4da48a410757cd03a283aa8d8b66f

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The `pilota.rust_wrapper_arc` annotation will change the type for codegen item, but we found in workspace codegen modem it will lead to the inner type to be generated in the wrong location.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Compute the arc type into the reference graph in workspace codegen mode, which will decide its position and mod prefix.
