### PR TITLE
fix(pilota-build): process the field kind  for vec at pb backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "ahash",
  "anyhow",

--- a/examples/idl/zero_value.proto
+++ b/examples/idl/zero_value.proto
@@ -16,7 +16,7 @@ message B {
 
 message C {
     optional string s4 = 1;
-    repeated B bb = 2[(pilota.rust_wrapper_arc_field) = true];
+    repeated B bb = 2[(pilota.rust_wrapper_arc_field) = true,(pilota.optional_repeated) = true];
 }
 
 message A {

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -29,16 +29,19 @@ fn test_pb_encode_zero_value() {
         s4: Some("s4".into()),
         ..Default::default()
     });
-    a.c.as_mut()
+    let c = a.c.as_mut().unwrap();
+    if c.bb.is_none() {
+        c.bb = Some(Vec::new());
+    }
+    c.bb.as_mut()
         .unwrap()
-        .bb
         .push(Arc::new(zero_value::zero_value::B {
             s3: "s5".into(),
             ..Default::default()
         }));
-    a.c.as_mut()
+
+    c.bb.as_mut()
         .unwrap()
-        .bb
         .push(Arc::new(zero_value::zero_value::B {
             s3: "s6".into(),
             ..Default::default()

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.12.13"
+version = "0.12.14"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
When `pb options` previously supported the optional repeated annotation, only the scalar item type was verified. This handled the field kind at the `rir` layer. However, pb does not support the repeated semantics of optionals, so the previous implementation was dead code and did not handle non-scalar paths.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
When supporting optional repeated annotations, we will modify its field kind, so we need to add field kind processing of vec type to the pb backend
