### PR TITLE
fix(pb): remove short_circuit when repeated field detected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,7 @@ dependencies = [
 name = "examples"
 version = "0.1.0"
 dependencies = [
+ "linkedbytes",
  "pilota",
  "pilota-build",
  "pilota-thrift-fieldmask",
@@ -554,9 +555,8 @@ checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "linkedbytes"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c663657632044d71a150755f0527ec22d7eb21b67e173bfce20597387284260a"
+version = "0.1.14"
+source = "git+https://github.com/volo-rs/linkedbytes.git?branch=feat%2Fconcat#220c83e90a1b16e4320d8ec629f616d6affc05af"
 dependencies = [
  "bytes",
  "faststr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "async-recursion"
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -104,7 +104,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -124,15 +124,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "boxcar"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c4925bc979b677330a8c7fe7a8c94af2dbb4a2d37b4a20a80d884400f46baa"
+checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bumpalo"
@@ -157,9 +157,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "ciborium"
@@ -190,18 +190,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -306,7 +306,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
 dependencies = [
- "nu-ansi-term 0.50.1",
+ "nu-ansi-term",
 ]
 
 [[package]]
@@ -323,12 +323,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -350,9 +350,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "faststr"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6503af7917fea18ffef8f7e8553fb8dff89e2e6837e94e09dd7fb069c82d62c"
+checksum = "baec6a0289d7f1fe5665586ef7340af82e3037207bef60f5785e57569776f0c8"
 dependencies = [
  "bytes",
  "rkyv",
@@ -387,7 +387,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -420,9 +420,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -435,7 +435,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -471,12 +471,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -496,6 +496,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
 dependencies = [
  "memoffset",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -533,9 +544,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -549,14 +560,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "linkedbytes"
-version = "0.1.14"
-source = "git+https://github.com/volo-rs/linkedbytes.git?branch=feat%2Fconcat#220c83e90a1b16e4320d8ec629f616d6affc05af"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80dd357febf29a3b1e37d0ff3509b035077769e5f4af161ff32edc3e97a78548"
 dependencies = [
  "bytes",
  "faststr",
@@ -571,9 +583,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -587,17 +599,17 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -631,19 +643,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "munge"
-version = "0.4.5"
+name = "mio"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cce144fab80fbb74ec5b89d1ca9d41ddf6b644ab7e986f7d3ed0aab31625cb1"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7feb0b48aa0a25f9fe0899482c6e1379ee7a11b24a53073eacdecb9adb6dc60"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574af9cd5b9971cbfdf535d6a8d533778481b241c447826d976101e0149392a1"
+checksum = "f2e3795a5d2da581a8b252fec6022eee01aea10161a4d1bf237d4cbe47f7e988"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -662,21 +685,11 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
+checksum = "c178369371fd7db523726931e50d430b560e3059665abc537ba3277e9274c9c4"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -730,12 +743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "papaya"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,7 +772,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -781,8 +788,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset",
- "hashbrown 0.15.4",
- "indexmap 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.3",
  "serde",
 ]
 
@@ -845,10 +852,10 @@ dependencies = [
  "ordered-float",
  "paste",
  "proptest",
- "rand 0.9.1",
+ "rand 0.9.2",
  "serde",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
 ]
 
@@ -878,7 +885,7 @@ dependencies = [
  "protobuf-parse2",
  "protobuf2",
  "quote",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rayon",
  "rustc-hash 1.1.0",
  "salsa",
@@ -903,7 +910,7 @@ dependencies = [
  "pilota",
  "pilota-thrift-parser",
  "pilota-thrift-reflect",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -925,7 +932,7 @@ dependencies = [
  "faststr",
  "pilota",
  "pilota-thrift-parser",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -979,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -997,10 +1004,10 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1104,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
@@ -1151,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -1161,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1171,56 +1178,41 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rend"
@@ -1230,13 +1222,13 @@ checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 
 [[package]]
 name = "rkyv"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
+checksum = "19f5c3e5da784cd8c69d32cdc84673f3204536ca56e1fa01be31a74b92c932ac"
 dependencies = [
  "bytes",
- "hashbrown 0.15.4",
- "indexmap 2.10.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.3",
  "munge",
  "ptr_meta",
  "rancor",
@@ -1248,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
+checksum = "4270433626cffc9c4c1d3707dd681f2a2718d3d7b09ad754bec137acecda8d22"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1259,9 +1251,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1290,22 +1282,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -1334,9 +1326,9 @@ dependencies = [
  "boxcar",
  "crossbeam-queue",
  "crossbeam-utils",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.10.0",
+ "indexmap 2.11.3",
  "intrusive-collections",
  "papaya",
  "parking_lot",
@@ -1391,28 +1383,38 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seize"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b8d813387d566f627f3ea1b914c068aac94c40ae27ec43f5f33bde65abefe7"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1421,14 +1423,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1446,7 +1449,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.3",
  "itoa",
  "ryu",
  "serde",
@@ -1475,6 +1478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,9 +1491,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1504,15 +1513,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1532,11 +1541,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -1552,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1582,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1597,13 +1606,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -1633,7 +1646,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.3",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1692,14 +1705,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
- "nu-ansi-term 0.46.0",
+ "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1716,9 +1729,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1728,9 +1741,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1769,30 +1782,46 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -1804,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1814,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1827,18 +1856,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1857,35 +1886,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-link"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -1893,7 +1906,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1902,16 +1915,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-link",
 ]
 
 [[package]]
@@ -1920,30 +1933,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1953,22 +1950,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1977,22 +1962,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2001,22 +1974,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2025,55 +1986,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ hex = "0.4"
 integer-encoding = { version = "4", features = ["tokio", "tokio_async"] }
 itertools = "0.14"
 lazy_static = "1"
-linkedbytes = "0.1"
+# linkedbytes = "0.1"
+linkedbytes = {git = "https://github.com/volo-rs/linkedbytes.git", branch = "feat/concat"}
 nom = "7"
 normpath = "1"
 ordered-float = { version = "5", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,7 @@ hex = "0.4"
 integer-encoding = { version = "4", features = ["tokio", "tokio_async"] }
 itertools = "0.14"
 lazy_static = "1"
-# linkedbytes = "0.1"
-linkedbytes = {git = "https://github.com/volo-rs/linkedbytes.git", branch = "feat/concat"}
+linkedbytes = "0.1"
 nom = "7"
 normpath = "1"
 ordered-float = { version = "5", features = ["serde"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,7 @@ maintenance = { status = "actively-developed" }
 pilota = { path = "../pilota", features = ["pb-encode-default-value"] }
 pilota-thrift-fieldmask = { path = "../pilota-thrift-fieldmask" }
 pilota-thrift-reflect = { path = "../pilota-thrift-reflect" }
+linkedbytes.workspace = true
 
 [build-dependencies]
 pilota-build = { path = "../pilota-build" }

--- a/examples/idl/zero_value.proto
+++ b/examples/idl/zero_value.proto
@@ -10,10 +10,10 @@ message C {
 }
 
 message A {
-    required C c = 4;
-    required B b = 3;
-    map<string, string> str_map = 1;
-    required string s1 = 2;
+    required B b = 1;
+    required C c = 2;
+    map<string, string> str_map = 3;
+    required string s1 = 4;
     optional string s2 = 2047;
 }
 
@@ -24,6 +24,10 @@ message CC {
 }
 
 message UnknownA {
-    required BB b = 3;
-    required CC c = 4;
+    required BB b = 1;
+    required CC c = 2;
+}
+
+service TestService {
+   rpc Test(A) returns (UnknownA);
 }

--- a/examples/idl/zero_value.proto
+++ b/examples/idl/zero_value.proto
@@ -15,6 +15,10 @@ message A {
     map<string, string> str_map = 3;
     required string s1 = 4;
     optional string s2 = 2047;
+    oneof test {
+        string x = 6;
+        int32 y = 8;
+    }
 }
 
 message BB {}

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -42,29 +42,66 @@ fn test_pb_encode_zero_value() {
 
     // decode a
     let decode_a = encoded_a.clone();
-    let decode_unknown_a = encoded_a.clone();
+    let decode_a_to_unknown_a = encoded_a.clone();
     let decoded_a = zero_value::zero_value::A::decode(decode_a).unwrap();
     println!("decode a: {:?}", decoded_a);
+    assert_eq!(decoded_a, a);
 
-    // decode unknown_a
-    let decoded_unknown_a = zero_value::zero_value::UnknownA::decode(decode_unknown_a).unwrap();
-    println!("decode a to unknown_a: {:?}", decoded_unknown_a);
+    // decode a to unknown_a
+    let decoded_a_to_unknown_a =
+        zero_value::zero_value::UnknownA::decode(decode_a_to_unknown_a).unwrap();
+    println!("decode a to unknown_a: {:?}", decoded_a_to_unknown_a);
 
     // encode unknown_a
     let mut encode_unknown_a = pilota::pb::LinkedBytes::new();
-    decoded_unknown_a.encode(&mut encode_unknown_a).unwrap();
+    decoded_a_to_unknown_a
+        .encode(&mut encode_unknown_a)
+        .unwrap();
     let encoded_unknown_a = encode_unknown_a.bytes().clone().freeze();
+    println!("encode unknown_a: {:?}", encoded_unknown_a);
+    assert_eq!(encoded_unknown_a.as_ref(), encoded_a.as_ref());
 
     // decode unknown_a
     let decode_unknown_a = encoded_unknown_a.clone();
-    let decode_a = encoded_unknown_a.clone();
-    println!("encode unknown_a: {:?}", encoded_unknown_a);
+    let decode_unknown_a_to_a = encoded_unknown_a.clone();
     let decoded_unknown_a = zero_value::zero_value::UnknownA::decode(decode_unknown_a).unwrap();
     println!("decode unknown_a: {:?}", decoded_unknown_a);
+    assert_eq!(decoded_unknown_a, decoded_a_to_unknown_a);
 
-    // decode a
-    let decoded_a = zero_value::zero_value::A::decode(decode_a).unwrap();
-    println!("decode unknown_a to a: {:?}", decoded_a);
+    // decode unknown_a to a
+    let decoded_unknown_a_to_a = zero_value::zero_value::A::decode(decode_unknown_a_to_a).unwrap();
+    println!("decode unknown_a to a: {:?}", decoded_unknown_a_to_a);
+    assert_eq!(decoded_unknown_a_to_a, a);
+
+    // encode c
+    let mut encode_c = pilota::pb::LinkedBytes::new();
+    decoded_a.c.encode(&mut encode_c).unwrap();
+    let encoded_c = encode_c.bytes().clone().freeze();
+    println!("encode c: {:?}", encoded_c);
+
+    // decode c to unknown_c
+    let decode_c_to_unknown_c = encoded_c.clone();
+    let decoded_c_to_unknown_c = zero_value::zero_value::Cc::decode(decode_c_to_unknown_c).unwrap();
+    println!("decode c to unknown_c: {:?}", decoded_c_to_unknown_c);
+
+    // encode unknown_c
+    let mut encode_unknown_c = pilota::pb::LinkedBytes::new();
+    decoded_c_to_unknown_c
+        .encode(&mut encode_unknown_c)
+        .unwrap();
+    let encoded_unknown_c = encode_unknown_c.bytes().clone().freeze();
+    println!("encode unknown_c: {:?}", encoded_unknown_c);
+    assert_eq!(encoded_unknown_c.as_ref(), encoded_c.as_ref());
+
+    // decode unknown_c
+    let decoded_unknown_c = zero_value::zero_value::Cc::decode(encoded_unknown_c.clone()).unwrap();
+    println!("decode unknown_c: {:?}", decoded_unknown_c);
+    assert_eq!(decoded_unknown_c, decoded_c_to_unknown_c);
+
+    // decode unknown_c to c
+    let decoded_c = zero_value::zero_value::C::decode(encoded_unknown_c).unwrap();
+    println!("decode unknown_c to c: {:?}", decoded_c);
+    assert_eq!(decoded_c, a.c);
 }
 
 #[test]

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,4 +1,3 @@
-// mod fieldmask;
 pub mod zero_value {
     include!(concat!(env!("OUT_DIR"), "/zero_value.rs"));
 }
@@ -35,9 +34,9 @@ fn test_pb_encode_zero_value() {
     println!("a: {:?}", a);
 
     // encode a
-    let mut encode_a = pilota::pb::LinkedBytes::new();
+    let mut encode_a = pilota::LinkedBytes::new();
     a.encode(&mut encode_a).unwrap();
-    let encoded_a = encode_a.bytes().clone().freeze();
+    let encoded_a = encode_a.concat();
     println!("encode a: {:?}", encoded_a);
 
     // decode a
@@ -57,7 +56,7 @@ fn test_pb_encode_zero_value() {
     decoded_a_to_unknown_a
         .encode(&mut encode_unknown_a)
         .unwrap();
-    let encoded_unknown_a = encode_unknown_a.bytes().clone().freeze();
+    let encoded_unknown_a = encode_unknown_a.concat();
     println!("encode unknown_a: {:?}", encoded_unknown_a);
     assert_eq!(encoded_unknown_a.as_ref(), encoded_a.as_ref());
 
@@ -76,7 +75,7 @@ fn test_pb_encode_zero_value() {
     // encode c
     let mut encode_c = pilota::pb::LinkedBytes::new();
     decoded_a.c.encode(&mut encode_c).unwrap();
-    let encoded_c = encode_c.bytes().clone().freeze();
+    let encoded_c = encode_c.concat();
     println!("encode c: {:?}", encoded_c);
 
     // decode c to unknown_c
@@ -89,7 +88,7 @@ fn test_pb_encode_zero_value() {
     decoded_c_to_unknown_c
         .encode(&mut encode_unknown_c)
         .unwrap();
-    let encoded_unknown_c = encode_unknown_c.bytes().clone().freeze();
+    let encoded_unknown_c = encode_unknown_c.concat();
     println!("encode unknown_c: {:?}", encoded_unknown_c);
     assert_eq!(encoded_unknown_c.as_ref(), encoded_c.as_ref());
 

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -31,6 +31,7 @@ fn test_pb_encode_zero_value() {
         s3: "s6".into(),
         ..Default::default()
     });
+    a.test = Some(zero_value::zero_value::a::Test::X("test".into()));
     println!("a: {:?}", a);
 
     // encode a
@@ -71,6 +72,8 @@ fn test_pb_encode_zero_value() {
     let decoded_unknown_a_to_a = zero_value::zero_value::A::decode(decode_unknown_a_to_a).unwrap();
     println!("decode unknown_a to a: {:?}", decoded_unknown_a_to_a);
     assert_eq!(decoded_unknown_a_to_a, a);
+
+    println!("--------------------------------");
 
     // encode c
     let mut encode_c = pilota::pb::LinkedBytes::new();

--- a/pilota-build/benches/unknown_pb_new.rs
+++ b/pilota-build/benches/unknown_pb_new.rs
@@ -1,6 +1,9 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use faststr::FastStr;
-use pilota::{Bytes, LinkedBytes, pb::EncodeLengthContext, pb::Message};
+use pilota::{
+    Bytes, LinkedBytes,
+    pb::{EncodeLengthContext, Message},
+};
 use rand::{Rng, distr::Alphanumeric};
 
 include!("../test_data/protobuf/normal.new_pb.rs");

--- a/pilota-build/benches/unknown_pb_new.rs
+++ b/pilota-build/benches/unknown_pb_new.rs
@@ -1,6 +1,6 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use faststr::FastStr;
-use pilota::{Bytes, LinkedBytes, pb::Message};
+use pilota::{Bytes, LinkedBytes, pb::EncodeLengthContext, pb::Message};
 use rand::{Rng, distr::Alphanumeric};
 
 include!("../test_data/protobuf/normal.new_pb.rs");
@@ -9,14 +9,23 @@ include!("../test_data/unknown_fields_pb_new.rs");
 fn decode_encode_known_fields_pb(bytes: Bytes) {
     let req = normal::ObjReq::decode(bytes).unwrap();
 
-    let mut out_buf = LinkedBytes::with_capacity(req.encoded_len());
+    let mut ctx = EncodeLengthContext::default();
+    let real_size = req.encoded_len(&mut ctx);
+    let zero_copy_size = ctx.zero_copy_len;
+    let malloc_size = real_size - zero_copy_size;
+    let mut out_buf = LinkedBytes::with_capacity(malloc_size);
     req.encode(&mut out_buf).unwrap();
 }
 
 fn decode_encode_unknown_fields_pb(bytes: Bytes) {
     let req = unknown_fields_pb_new::ObjReq::decode(bytes).unwrap();
 
-    let mut out_buf = LinkedBytes::with_capacity(req.encoded_len());
+    let mut ctx = EncodeLengthContext::default();
+    let real_size = req.encoded_len(&mut ctx);
+    let zero_copy_size = ctx.zero_copy_len;
+    let malloc_size = real_size - zero_copy_size;
+    // println!("real_size: {}, malloc_size: {}", real_size, malloc_size);
+    let mut out_buf = LinkedBytes::with_capacity(malloc_size);
     req.encode(&mut out_buf).unwrap();
 }
 
@@ -46,7 +55,7 @@ fn prepare_obj_req_pb(size: usize) -> normal::ObjReq {
     // size
     let msg_key = normal::Message {
         uid: "".into(),
-        value: None,
+        value: Some(generate_random_string_pb(size / 2)),
         sub_messages: vec![sub_msg_1.clone()],
     };
 
@@ -87,9 +96,13 @@ fn pb_codegen(c: &mut Criterion) {
     let lens = [16, 64, 128, 512, 2 * 1024, 128 * 1024, 10 * 128 * 1024];
     for len_param in lens {
         let req_instance = prepare_obj_req_pb(len_param);
-        let mut encoded_known_bytes_lb = LinkedBytes::with_capacity(req_instance.encoded_len());
+        let mut ctx = EncodeLengthContext::default();
+        let real_size = req_instance.encoded_len(&mut ctx);
+        let zero_copy_size = ctx.zero_copy_len;
+        let malloc_size = real_size - zero_copy_size;
+        let mut encoded_known_bytes_lb = LinkedBytes::with_capacity(malloc_size);
         req_instance.encode(&mut encoded_known_bytes_lb).unwrap();
-        let encoded_known_bytes = encoded_known_bytes_lb.bytes().clone().freeze();
+        let encoded_known_bytes = encoded_known_bytes_lb.concat();
 
         group.bench_function(
             format!("PB KnownFields DecodeEncode {} bytes", len_param * 8),

--- a/pilota-build/src/codegen/pb/mod.rs
+++ b/pilota-build/src/codegen/pb/mod.rs
@@ -395,8 +395,7 @@ impl CodegenBackend for ProtobufBackend {
                 let field_ident = self.cx.rust_name(field.did);
                 let merge =
                     self.codegen_merge_field("_inner_pilota_value".into(), &field.ty, field.kind);
-                let mut tags = self.field_tags(field).map(|tag| tag.to_string());
-                let tags = tags.join("|");
+                let tags = self.field_tags(field).join("|");
 
                 format! {
                     r#"{tags} => {{
@@ -432,7 +431,7 @@ impl CodegenBackend for ProtobufBackend {
                 }"#,
             );
 
-            let tags_repr = s.fields.iter().map(|f| f.id).join("|");
+            let tags_repr = s.fields.iter().flat_map(|f| self.field_tags(f)).join("|");
             let tags_dismatch = if tags_repr.is_empty() {
                 "".into()
             } else {
@@ -576,7 +575,7 @@ impl CodegenBackend for ProtobufBackend {
                 }}
 
                 #[inline]
-                pub fn encoded_len(&self) -> usize {{
+                pub fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {{
                     match self {{
                         {encoded_len}
                     }}

--- a/pilota-build/src/codegen/pb/mod.rs
+++ b/pilota-build/src/codegen/pb/mod.rs
@@ -380,6 +380,14 @@ impl CodegenBackend for ProtobufBackend {
             })
             .join("");
 
+        // add unknown fields
+        let keep = self.keep_unknown_fields.contains(&def_id);
+
+        let mut inc_decoded_fields_num = String::new();
+        if keep {
+            inc_decoded_fields_num = "if is_root { ctx.inc_root_decoded_fields_num(tag); }".into();
+        }
+
         let merge = s
             .fields
             .iter()
@@ -392,6 +400,7 @@ impl CodegenBackend for ProtobufBackend {
 
                 format! {
                     r#"{tags} => {{
+                    {inc_decoded_fields_num}
                     let mut _inner_pilota_value = &mut self.{field_ident};
                     {merge}.map_err(|mut error| {{
                         error.push(STRUCT_NAME, stringify!({field_ident}));
@@ -408,15 +417,14 @@ impl CodegenBackend for ProtobufBackend {
             format!("const STRUCT_NAME: &'static str = stringify!({name});")
         };
 
-        // add unknown fields
-        let keep = self.keep_unknown_fields.contains(&def_id);
-
         let mut unknown_fields = "";
-        let mut skip_field = "::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)";
+        let mut short_circuit = "".into();
+        let mut skip_field =
+            String::from("::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)");
 
         if keep {
-            unknown_fields = r#"
-            let mut _unknown_fields = &mut self._unknown_fields;"#;
+            let fields_num = s.fields.len() as u32;
+            unknown_fields = r#"let mut _unknown_fields = &mut self._unknown_fields;"#;
             encoded_len.push_str(" + self._unknown_fields.size()");
             encode.push_str(
                 r#"for bytes in self._unknown_fields.list.iter() {
@@ -424,14 +432,38 @@ impl CodegenBackend for ProtobufBackend {
                 }"#,
             );
 
-            skip_field = r#"{
+            let tags_repr = s.fields.iter().map(|f| f.id).join("|");
+            let tags_dismatch = if tags_repr.is_empty() {
+                "".into()
+            } else {
+                format!("&& !matches!(tag, {tags_repr})")
+            };
+
+            short_circuit = format!(
+                r#"// short circuit
+                if is_root {tags_dismatch} && ctx.root_decoded_fields_num() == {fields_num} {{
+                    // advance buf
+                    let cur = buf.chunk().as_ptr();
+                    let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
+                    buf.advance(len);
+
+                    // read rest bytes
+                    let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
+                    _unknown_fields.push_back(val);
+                    return Ok(());
+                }}"#
+            );
+
+            skip_field = format!(
+                r#"{{
                 ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
                 let end = buf.chunk().as_ptr();
                 let len = end as usize - ctx.raw_bytes_cursor();
                 let val = ctx.raw_bytes_split_to(len);
                 _unknown_fields.push_back(val);
                 Ok(())
-            }"#;
+            }}"#
+            );
         }
 
         stream.push_str(&format!(
@@ -454,9 +486,11 @@ impl CodegenBackend for ProtobufBackend {
                     wire_type: ::pilota::pb::encoding::WireType,
                     buf: &mut ::pilota::Bytes,
                     ctx: &mut ::pilota::pb::encoding::DecodeContext,
+                    is_root: bool,
                 ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {{
                     {struct_name}
                     {unknown_fields}
+                    {short_circuit}
                     match tag {{
                         {merge}
                         _ => {skip_field}

--- a/pilota-build/test_data/protobuf/bytes.new_pb.rs
+++ b/pilota-build/test_data/protobuf/bytes.new_pb.rs
@@ -7,9 +7,9 @@ pub mod bytes {
     }
     impl ::pilota::pb::Message for A {
         #[inline]
-        fn encoded_len(&self) -> usize {
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
             0 + self.a.as_ref().map_or(0, |value| {
-                ::pilota::pb::encoding::bytes::encoded_len(1, value)
+                ::pilota::pb::encoding::bytes::encoded_len(ctx, 1, value)
             })
         }
 

--- a/pilota-build/test_data/protobuf/bytes.new_pb.rs
+++ b/pilota-build/test_data/protobuf/bytes.new_pb.rs
@@ -27,6 +27,7 @@ pub mod bytes {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(A);
 

--- a/pilota-build/test_data/protobuf/nested_message.new_pb.rs
+++ b/pilota-build/test_data/protobuf/nested_message.new_pb.rs
@@ -31,6 +31,7 @@ pub mod nested_message {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(Tt1);
 
@@ -123,6 +124,7 @@ pub mod nested_message {
                 wire_type: ::pilota::pb::encoding::WireType,
                 buf: &mut ::pilota::Bytes,
                 ctx: &mut ::pilota::pb::encoding::DecodeContext,
+                is_root: bool,
             ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
                 const STRUCT_NAME: &'static str = stringify!(T2);
 
@@ -189,6 +191,7 @@ pub mod nested_message {
                     wire_type: ::pilota::pb::encoding::WireType,
                     buf: &mut ::pilota::Bytes,
                     ctx: &mut ::pilota::pb::encoding::DecodeContext,
+                    is_root: bool,
                 ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
                     const STRUCT_NAME: &'static str = stringify!(Tt3);
 

--- a/pilota-build/test_data/protobuf/nested_message.new_pb.rs
+++ b/pilota-build/test_data/protobuf/nested_message.new_pb.rs
@@ -11,10 +11,10 @@ pub mod nested_message {
     }
     impl ::pilota::pb::Message for Tt1 {
         #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + ::pilota::pb::encoding::message::encoded_len(1, &self.t2)
-                + ::pilota::pb::encoding::int32::encoded_len(2, &self.t3)
-                + ::pilota::pb::encoding::message::encoded_len(4, &self.t4)
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::message::encoded_len(ctx, 1, &self.t2)
+                + ::pilota::pb::encoding::int32::encoded_len(ctx, 2, &self.t3)
+                + ::pilota::pb::encoding::message::encoded_len(ctx, 4, &self.t4)
         }
 
         #[allow(unused_variables)]
@@ -108,8 +108,8 @@ pub mod nested_message {
         }
         impl ::pilota::pb::Message for T2 {
             #[inline]
-            fn encoded_len(&self) -> usize {
-                0 + ::pilota::pb::encoding::message::encoded_len(1, &self.t3)
+            fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+                0 + ::pilota::pb::encoding::message::encoded_len(ctx, 1, &self.t3)
             }
 
             #[allow(unused_variables)]
@@ -157,10 +157,11 @@ pub mod nested_message {
             }
             impl ::pilota::pb::Message for Tt3 {
                 #[inline]
-                fn encoded_len(&self) -> usize {
+                fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
                     0 + self.a.as_ref().map_or(0, |value| {
-                        ::pilota::pb::encoding::int32::encoded_len(1, value)
+                        ::pilota::pb::encoding::int32::encoded_len(ctx, 1, value)
                     }) + ::pilota::pb::encoding::hash_map::encoded_len(
+                        ctx,
                         ::pilota::pb::encoding::int32::encoded_len,
                         ::pilota::pb::encoding::message::encoded_len,
                         2,

--- a/pilota-build/test_data/protobuf/normal.new_pb.rs
+++ b/pilota-build/test_data/protobuf/normal.new_pb.rs
@@ -23,6 +23,7 @@ pub mod normal {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(A);
 
@@ -65,6 +66,7 @@ pub mod normal {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(SubMessage);
 
@@ -143,6 +145,7 @@ pub mod normal {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(ObjReq);
 
@@ -250,6 +253,7 @@ pub mod normal {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(B);
 
@@ -307,6 +311,7 @@ pub mod normal {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(Message);
 
@@ -385,6 +390,7 @@ pub mod normal {
                 wire_type: ::pilota::pb::encoding::WireType,
                 buf: &mut ::pilota::Bytes,
                 ctx: &mut ::pilota::pb::encoding::DecodeContext,
+                is_root: bool,
             ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
                 const STRUCT_NAME: &'static str = stringify!(MsgMapEntry);
 

--- a/pilota-build/test_data/protobuf/normal.new_pb.rs
+++ b/pilota-build/test_data/protobuf/normal.new_pb.rs
@@ -7,8 +7,8 @@ pub mod normal {
     }
     impl ::pilota::pb::Message for A {
         #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + ::pilota::pb::encoding::int32::encoded_len(1, &self.a)
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::int32::encoded_len(ctx, 1, &self.a)
         }
 
         #[allow(unused_variables)]
@@ -46,9 +46,9 @@ pub mod normal {
     }
     impl ::pilota::pb::Message for SubMessage {
         #[inline]
-        fn encoded_len(&self) -> usize {
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
             0 + self.value.as_ref().map_or(0, |value| {
-                ::pilota::pb::encoding::faststr::encoded_len(2, value)
+                ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, value)
             })
         }
 
@@ -106,15 +106,15 @@ pub mod normal {
     }
     impl ::pilota::pb::Message for ObjReq {
         #[inline]
-        fn encoded_len(&self) -> usize {
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
             0 + self.msg.as_ref().map_or(0, |msg| {
-                ::pilota::pb::encoding::message::encoded_len(1, msg)
-            }) + ::pilota::pb::encoding::message::encoded_len_repeated(2, &self.msg_map)
-                + ::pilota::pb::encoding::message::encoded_len_repeated(3, &self.sub_msgs)
-                + ::pilota::pb::encoding::message::encoded_len_repeated(4, &self.msg_set)
-                + ::pilota::pb::encoding::faststr::encoded_len(5, &self.flag_msg)
+                ::pilota::pb::encoding::message::encoded_len(ctx, 1, msg)
+            }) + ::pilota::pb::encoding::message::encoded_len_repeated(ctx, 2, &self.msg_map)
+                + ::pilota::pb::encoding::message::encoded_len_repeated(ctx, 3, &self.sub_msgs)
+                + ::pilota::pb::encoding::message::encoded_len_repeated(ctx, 4, &self.msg_set)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 5, &self.flag_msg)
                 + self.mock_cost.as_ref().map_or(0, |value| {
-                    ::pilota::pb::encoding::faststr::encoded_len(6, value)
+                    ::pilota::pb::encoding::faststr::encoded_len(ctx, 6, value)
                 })
         }
 
@@ -233,9 +233,9 @@ pub mod normal {
     }
     impl ::pilota::pb::Message for B {
         #[inline]
-        fn encoded_len(&self) -> usize {
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
             0 + self.a.as_ref().map_or(0, |msg| {
-                ::pilota::pb::encoding::message::encoded_len(2, msg)
+                ::pilota::pb::encoding::message::encoded_len(ctx, 2, msg)
             })
         }
 
@@ -285,12 +285,12 @@ pub mod normal {
     }
     impl ::pilota::pb::Message for Message {
         #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + ::pilota::pb::encoding::faststr::encoded_len(1, &self.uid)
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.uid)
                 + self.value.as_ref().map_or(0, |value| {
-                    ::pilota::pb::encoding::faststr::encoded_len(2, value)
+                    ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, value)
                 })
-                + ::pilota::pb::encoding::message::encoded_len_repeated(3, &self.sub_messages)
+                + ::pilota::pb::encoding::message::encoded_len_repeated(ctx, 3, &self.sub_messages)
         }
 
         #[allow(unused_variables)]
@@ -365,11 +365,11 @@ pub mod normal {
         }
         impl ::pilota::pb::Message for MsgMapEntry {
             #[inline]
-            fn encoded_len(&self) -> usize {
+            fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
                 0 + self.key.as_ref().map_or(0, |msg| {
-                    ::pilota::pb::encoding::message::encoded_len(1, msg)
+                    ::pilota::pb::encoding::message::encoded_len(ctx, 1, msg)
                 }) + self.value.as_ref().map_or(0, |msg| {
-                    ::pilota::pb::encoding::message::encoded_len(2, msg)
+                    ::pilota::pb::encoding::message::encoded_len(ctx, 2, msg)
                 })
             }
 

--- a/pilota-build/test_data/protobuf/oneof.new_pb.rs
+++ b/pilota-build/test_data/protobuf/oneof.new_pb.rs
@@ -163,7 +163,7 @@ pub mod oneof {
             }
 
             #[inline]
-            pub fn encoded_len(&self) -> usize {
+            pub fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
                 match self {
                     Test::A(value) => ::pilota::pb::encoding::faststr::encoded_len(ctx, 6, &*value),
                     Test::B(value) => ::pilota::pb::encoding::int32::encoded_len(ctx, 8, &*value),
@@ -230,7 +230,7 @@ pub mod oneof {
             }
 
             #[inline]
-            pub fn encoded_len(&self) -> usize {
+            pub fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
                 match self {
                     Type::S(value) => ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, &*value),
                     Type::I(value) => ::pilota::pb::encoding::int32::encoded_len(ctx, 4, &*value),

--- a/pilota-build/test_data/protobuf/oneof.new_pb.rs
+++ b/pilota-build/test_data/protobuf/oneof.new_pb.rs
@@ -15,13 +15,13 @@ pub mod oneof {
     }
     impl ::pilota::pb::Message for Test {
         #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + ::pilota::pb::encoding::int32::encoded_len(1, &self.c)
-                + self.r#type.as_ref().map_or(0, |msg| msg.encoded_len())
-                + ::pilota::pb::encoding::int64::encoded_len(5, &self.j)
-                + self.test.as_ref().map_or(0, |msg| msg.encoded_len())
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::int32::encoded_len(ctx, 1, &self.c)
+                + self.r#type.as_ref().map_or(0, |msg| msg.encoded_len(ctx))
+                + ::pilota::pb::encoding::int64::encoded_len(ctx, 5, &self.j)
+                + self.test.as_ref().map_or(0, |msg| msg.encoded_len(ctx))
                 + self.e.as_ref().map_or(0, |value| {
-                    ::pilota::pb::encoding::int32::encoded_len(10, value)
+                    ::pilota::pb::encoding::int32::encoded_len(ctx, 10, value)
                 })
         }
 
@@ -165,8 +165,8 @@ pub mod oneof {
             #[inline]
             pub fn encoded_len(&self) -> usize {
                 match self {
-                    Test::A(value) => ::pilota::pb::encoding::faststr::encoded_len(6, &*value),
-                    Test::B(value) => ::pilota::pb::encoding::int32::encoded_len(8, &*value),
+                    Test::A(value) => ::pilota::pb::encoding::faststr::encoded_len(ctx, 6, &*value),
+                    Test::B(value) => ::pilota::pb::encoding::int32::encoded_len(ctx, 8, &*value),
                 }
             }
 
@@ -232,8 +232,8 @@ pub mod oneof {
             #[inline]
             pub fn encoded_len(&self) -> usize {
                 match self {
-                    Type::S(value) => ::pilota::pb::encoding::faststr::encoded_len(2, &*value),
-                    Type::I(value) => ::pilota::pb::encoding::int32::encoded_len(4, &*value),
+                    Type::S(value) => ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, &*value),
+                    Type::I(value) => ::pilota::pb::encoding::int32::encoded_len(ctx, 4, &*value),
                 }
             }
 

--- a/pilota-build/test_data/protobuf/oneof.new_pb.rs
+++ b/pilota-build/test_data/protobuf/oneof.new_pb.rs
@@ -10,6 +10,8 @@ pub mod oneof {
         pub j: i64,
 
         pub test: ::std::option::Option<test::Test>,
+
+        pub e: ::std::option::Option<Enum>,
     }
     impl ::pilota::pb::Message for Test {
         #[inline]
@@ -18,6 +20,9 @@ pub mod oneof {
                 + self.r#type.as_ref().map_or(0, |msg| msg.encoded_len())
                 + ::pilota::pb::encoding::int64::encoded_len(5, &self.j)
                 + self.test.as_ref().map_or(0, |msg| msg.encoded_len())
+                + self.e.as_ref().map_or(0, |value| {
+                    ::pilota::pb::encoding::int32::encoded_len(10, value)
+                })
         }
 
         #[allow(unused_variables)]
@@ -30,6 +35,9 @@ pub mod oneof {
             if let Some(_pilota_inner_value) = self.test.as_ref() {
                 _pilota_inner_value.encode(buf);
             }
+            if let Some(_pilota_inner_value) = self.e.as_ref() {
+                ::pilota::pb::encoding::int32::encode(10, _pilota_inner_value, buf);
+            };
         }
 
         #[allow(unused_variables)]
@@ -39,6 +47,7 @@ pub mod oneof {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(Test);
 
@@ -77,8 +86,53 @@ pub mod oneof {
                         },
                     )
                 }
+                10 => {
+                    let mut _inner_pilota_value = &mut self.e;
+                    ::pilota::pb::encoding::int32::merge(
+                        wire_type,
+                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(e));
+                        error
+                    })
+                }
                 _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
             }
+        }
+    }
+    #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
+    #[repr(transparent)]
+    pub struct Enum(i32);
+
+    impl Enum {
+        pub const A: Self = Self(0);
+        pub const B: Self = Self(1);
+
+        pub fn inner(&self) -> i32 {
+            self.0
+        }
+
+        pub fn to_string(&self) -> ::std::string::String {
+            match self {
+                Self(0) => ::std::string::String::from("A"),
+                Self(1) => ::std::string::String::from("B"),
+                Self(val) => val.to_string(),
+            }
+        }
+    }
+
+    impl ::std::convert::From<i32> for Enum {
+        fn from(value: i32) -> Self {
+            Self(value)
+        }
+    }
+
+    impl ::std::convert::From<Enum> for i32 {
+        fn from(value: Enum) -> i32 {
+            value.0
         }
     }
 

--- a/pilota-build/test_data/protobuf/oneof.proto
+++ b/pilota-build/test_data/protobuf/oneof.proto
@@ -1,5 +1,11 @@
 syntax = "proto3";
 
+enum Enum {
+  A = 0;
+  B = 1;
+}
+
+
 message Test {
     int32 c = 1;
     oneof type {
@@ -11,4 +17,5 @@ message Test {
         string a = 6;
         int32 b = 8;
     }
+    optional Enum e = 10;
 }

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -9,6 +9,8 @@ pub mod oneof {
         pub j: i64,
 
         pub test: ::std::option::Option<test::Test>,
+
+        pub e: ::std::option::Option<Enum>,
     }
     impl ::pilota::prost::Message for Test {
         #[inline]
@@ -17,6 +19,9 @@ pub mod oneof {
                 + self.r#type.as_ref().map_or(0, |msg| msg.encoded_len())
                 + ::pilota::prost::encoding::int64::encoded_len(5, &self.j)
                 + self.test.as_ref().map_or(0, |msg| msg.encoded_len())
+                + self.e.as_ref().map_or(0, |value| {
+                    ::pilota::prost::encoding::int32::encoded_len(10, value)
+                })
         }
 
         #[allow(unused_variables)]
@@ -32,6 +37,9 @@ pub mod oneof {
             if let Some(_pilota_inner_value) = self.test.as_ref() {
                 _pilota_inner_value.encode(buf);
             }
+            if let Some(_pilota_inner_value) = self.e.as_ref() {
+                ::pilota::prost::encoding::int32::encode(10, _pilota_inner_value, buf);
+            };
         }
 
         #[allow(unused_variables)]
@@ -92,8 +100,53 @@ pub mod oneof {
                         },
                     )
                 }
+                10 => {
+                    let mut _inner_pilota_value = &mut self.e;
+                    ::pilota::prost::encoding::int32::merge(
+                        wire_type,
+                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(e));
+                        error
+                    })
+                }
                 _ => ::pilota::prost::encoding::skip_field(wire_type, tag, buf, ctx),
             }
+        }
+    }
+    #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
+    #[repr(transparent)]
+    pub struct Enum(i32);
+
+    impl Enum {
+        pub const A: Self = Self(0);
+        pub const B: Self = Self(1);
+
+        pub fn inner(&self) -> i32 {
+            self.0
+        }
+
+        pub fn to_string(&self) -> ::std::string::String {
+            match self {
+                Self(0) => ::std::string::String::from("A"),
+                Self(1) => ::std::string::String::from("B"),
+                Self(val) => val.to_string(),
+            }
+        }
+    }
+
+    impl ::std::convert::From<i32> for Enum {
+        fn from(value: i32) -> Self {
+            Self(value)
+        }
+    }
+
+    impl ::std::convert::From<Enum> for i32 {
+        fn from(value: Enum) -> i32 {
+            value.0
         }
     }
 

--- a/pilota-build/test_data/protobuf/optional.new_pb.rs
+++ b/pilota-build/test_data/protobuf/optional.new_pb.rs
@@ -7,9 +7,9 @@ pub mod optional {
     }
     impl ::pilota::pb::Message for SearchRequest {
         #[inline]
-        fn encoded_len(&self) -> usize {
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
             0 + self.page_number.as_ref().map_or(0, |value| {
-                ::pilota::pb::encoding::int32::encoded_len(2, value)
+                ::pilota::pb::encoding::int32::encoded_len(ctx, 2, value)
             })
         }
 

--- a/pilota-build/test_data/protobuf/optional.new_pb.rs
+++ b/pilota-build/test_data/protobuf/optional.new_pb.rs
@@ -27,6 +27,7 @@ pub mod optional {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(SearchRequest);
 

--- a/pilota-build/test_data/protobuf/service.new_pb.rs
+++ b/pilota-build/test_data/protobuf/service.new_pb.rs
@@ -25,6 +25,7 @@ pub mod service {
                 wire_type: ::pilota::pb::encoding::WireType,
                 buf: &mut ::pilota::Bytes,
                 ctx: &mut ::pilota::pb::encoding::DecodeContext,
+                is_root: bool,
             ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
                 const STRUCT_NAME: &'static str = stringify!(EchoRequest);
 
@@ -70,6 +71,7 @@ pub mod service {
                 wire_type: ::pilota::pb::encoding::WireType,
                 buf: &mut ::pilota::Bytes,
                 ctx: &mut ::pilota::pb::encoding::DecodeContext,
+                is_root: bool,
             ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
                 const STRUCT_NAME: &'static str = stringify!(EchoResponse);
 

--- a/pilota-build/test_data/protobuf/service.new_pb.rs
+++ b/pilota-build/test_data/protobuf/service.new_pb.rs
@@ -9,8 +9,8 @@ pub mod service {
         }
         impl ::pilota::pb::Message for EchoRequest {
             #[inline]
-            fn encoded_len(&self) -> usize {
-                0 + ::pilota::pb::encoding::faststr::encoded_len(1, &self.message)
+            fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+                0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.message)
             }
 
             #[allow(unused_variables)]
@@ -55,8 +55,8 @@ pub mod service {
         }
         impl ::pilota::pb::Message for EchoResponse {
             #[inline]
-            fn encoded_len(&self) -> usize {
-                0 + ::pilota::pb::encoding::faststr::encoded_len(1, &self.message)
+            fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+                0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.message)
             }
 
             #[allow(unused_variables)]

--- a/pilota-build/test_data/protobuf/string.new_pb.rs
+++ b/pilota-build/test_data/protobuf/string.new_pb.rs
@@ -9,10 +9,10 @@ pub mod string {
     }
     impl ::pilota::pb::Message for A {
         #[inline]
-        fn encoded_len(&self) -> usize {
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
             0 + self.a.as_ref().map_or(0, |value| {
-                ::pilota::pb::encoding::faststr::encoded_len(1, value)
-            }) + ::pilota::pb::encoding::faststr::encoded_len(2, &self.b)
+                ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, value)
+            }) + ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, &self.b)
         }
 
         #[allow(unused_variables)]

--- a/pilota-build/test_data/protobuf/string.new_pb.rs
+++ b/pilota-build/test_data/protobuf/string.new_pb.rs
@@ -30,6 +30,7 @@ pub mod string {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(A);
 

--- a/pilota-build/test_data/protobuf_with_split/new_pb/service/message_EchoRequest.rs
+++ b/pilota-build/test_data/protobuf_with_split/new_pb/service/message_EchoRequest.rs
@@ -4,8 +4,8 @@ pub struct EchoRequest {
 }
 impl ::pilota::pb::Message for EchoRequest {
     #[inline]
-    fn encoded_len(&self) -> usize {
-        0 + ::pilota::pb::encoding::faststr::encoded_len(1, &self.message)
+    fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+        0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.message)
     }
 
     #[allow(unused_variables)]

--- a/pilota-build/test_data/protobuf_with_split/new_pb/service/message_EchoRequest.rs
+++ b/pilota-build/test_data/protobuf_with_split/new_pb/service/message_EchoRequest.rs
@@ -20,6 +20,7 @@ impl ::pilota::pb::Message for EchoRequest {
         wire_type: ::pilota::pb::encoding::WireType,
         buf: &mut ::pilota::Bytes,
         ctx: &mut ::pilota::pb::encoding::DecodeContext,
+        is_root: bool,
     ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
         const STRUCT_NAME: &'static str = stringify!(EchoRequest);
 

--- a/pilota-build/test_data/protobuf_with_split/new_pb/service/message_EchoResponse.rs
+++ b/pilota-build/test_data/protobuf_with_split/new_pb/service/message_EchoResponse.rs
@@ -20,6 +20,7 @@ impl ::pilota::pb::Message for EchoResponse {
         wire_type: ::pilota::pb::encoding::WireType,
         buf: &mut ::pilota::Bytes,
         ctx: &mut ::pilota::pb::encoding::DecodeContext,
+        is_root: bool,
     ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
         const STRUCT_NAME: &'static str = stringify!(EchoResponse);
 

--- a/pilota-build/test_data/protobuf_with_split/new_pb/service/message_EchoResponse.rs
+++ b/pilota-build/test_data/protobuf_with_split/new_pb/service/message_EchoResponse.rs
@@ -4,8 +4,8 @@ pub struct EchoResponse {
 }
 impl ::pilota::pb::Message for EchoResponse {
     #[inline]
-    fn encoded_len(&self) -> usize {
-        0 + ::pilota::pb::encoding::faststr::encoded_len(1, &self.message)
+    fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+        0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.message)
     }
 
     #[allow(unused_variables)]

--- a/pilota-build/test_data/unknown_fields_pb.proto
+++ b/pilota-build/test_data/unknown_fields_pb.proto
@@ -14,11 +14,13 @@ message SubMessage {
 
 message Message {
   string uid = 1;
-  optional string value = 2;
-  repeated SubMessage sub_messages = 3;
+  string value = 2;
 }
 
-message ObjReq {}
+message ObjReq {
+  Message msg = 1;
+  string flag_msg = 5;
+}
 
 service TestService {
    rpc TestException(ObjReq) returns (ObjReq);

--- a/pilota-build/test_data/unknown_fields_pb.proto
+++ b/pilota-build/test_data/unknown_fields_pb.proto
@@ -9,17 +9,12 @@ message B {
 }
 
 message SubMessage {
-  optional string value = 2;
 }
 
 message Message {
-  string uid = 1;
-  string value = 2;
 }
 
 message ObjReq {
-  Message msg = 1;
-  string flag_msg = 5;
 }
 
 service TestService {

--- a/pilota-build/test_data/unknown_fields_pb.rs
+++ b/pilota-build/test_data/unknown_fields_pb.rs
@@ -76,87 +76,6 @@ pub mod unknown_fields_pb {
             }
         }
     }
-
-    pub trait TestService {}
-    #[derive(
-        PartialOrd,
-        Hash,
-        Eq,
-        Ord,
-        Debug,
-        Default,
-        ::pilota::serde::Serialize,
-        ::pilota::serde::Deserialize,
-        Clone,
-        PartialEq,
-    )]
-    pub struct SubMessage {
-        pub value: ::std::option::Option<::pilota::FastStr>,
-        pub _unknown_fields: ::pilota::BytesVec,
-    }
-    impl ::pilota::prost::Message for SubMessage {
-        #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + self.value.as_ref().map_or(0, |value| {
-                ::pilota::prost::encoding::faststr::encoded_len(2, value)
-            }) + self._unknown_fields.size()
-        }
-
-        #[allow(unused_variables)]
-        fn encode_raw<B>(&self, buf: &mut B)
-        where
-            B: ::pilota::prost::bytes::BufMut,
-        {
-            if let Some(_pilota_inner_value) = self.value.as_ref() {
-                ::pilota::prost::encoding::faststr::encode(2, _pilota_inner_value, buf);
-            };
-            for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
-            }
-        }
-
-        #[allow(unused_variables)]
-        fn merge_field<B>(
-            &mut self,
-            tag: u32,
-            wire_type: ::pilota::prost::encoding::WireType,
-            buf: &mut B,
-            ctx: ::pilota::prost::encoding::DecodeContext,
-        ) -> ::core::result::Result<(), ::pilota::prost::DecodeError>
-        where
-            B: ::pilota::prost::bytes::Buf,
-        {
-            const STRUCT_NAME: &'static str = stringify!(SubMessage);
-
-            let mut _unknown_fields = &mut self._unknown_fields;
-            match tag {
-                2 => {
-                    let mut _inner_pilota_value = &mut self.value;
-                    ::pilota::prost::encoding::faststr::merge(
-                        wire_type,
-                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(value));
-                        error
-                    })
-                }
-                _ => {
-                    let tag_value = (tag << 3) | wire_type as u32;
-                    let tag_len = ::pilota::prost::encoding::encoded_len_varint(tag_value as u64);
-                    let begin = unsafe { buf.chunk().as_ptr().sub(tag_len) };
-                    ::pilota::prost::encoding::skip_field(wire_type, tag, buf, ctx)?;
-                    let end = buf.chunk().as_ptr();
-                    _unknown_fields.push_back(::pilota::Bytes::copy_from_slice(unsafe {
-                        std::slice::from_raw_parts(begin, end as usize - begin as usize)
-                    }));
-                    Ok(())
-                }
-            }
-        }
-    }
     #[derive(
         PartialOrd,
         Hash,
@@ -170,18 +89,12 @@ pub mod unknown_fields_pb {
         PartialEq,
     )]
     pub struct ObjReq {
-        pub msg: ::std::option::Option<Message>,
-
-        pub flag_msg: ::pilota::FastStr,
         pub _unknown_fields: ::pilota::BytesVec,
     }
     impl ::pilota::prost::Message for ObjReq {
         #[inline]
         fn encoded_len(&self) -> usize {
-            0 + self.msg.as_ref().map_or(0, |msg| {
-                ::pilota::prost::encoding::message::encoded_len(1, msg)
-            }) + ::pilota::prost::encoding::faststr::encoded_len(5, &self.flag_msg)
-                + self._unknown_fields.size()
+            0 + self._unknown_fields.size()
         }
 
         #[allow(unused_variables)]
@@ -189,10 +102,6 @@ pub mod unknown_fields_pb {
         where
             B: ::pilota::prost::bytes::BufMut,
         {
-            if let Some(_pilota_inner_value) = self.msg.as_ref() {
-                ::pilota::prost::encoding::message::encode(1, _pilota_inner_value, buf);
-            }
-            ::pilota::prost::encoding::faststr::encode(5, &self.flag_msg, buf);
             for bytes in self._unknown_fields.list.iter() {
                 buf.put_slice(bytes.as_ref());
             }
@@ -209,36 +118,8 @@ pub mod unknown_fields_pb {
         where
             B: ::pilota::prost::bytes::Buf,
         {
-            const STRUCT_NAME: &'static str = stringify!(ObjReq);
-
             let mut _unknown_fields = &mut self._unknown_fields;
             match tag {
-                1 => {
-                    let mut _inner_pilota_value = &mut self.msg;
-                    ::pilota::prost::encoding::message::merge(
-                        wire_type,
-                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(msg));
-                        error
-                    })
-                }
-                5 => {
-                    let mut _inner_pilota_value = &mut self.flag_msg;
-                    ::pilota::prost::encoding::faststr::merge(
-                        wire_type,
-                        _inner_pilota_value,
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(flag_msg));
-                        error
-                    })
-                }
                 _ => {
                     let tag_value = (tag << 3) | wire_type as u32;
                     let tag_len = ::pilota::prost::encoding::encoded_len_varint(tag_value as u64);
@@ -332,6 +213,8 @@ pub mod unknown_fields_pb {
             }
         }
     }
+
+    pub trait TestService {}
     #[derive(
         PartialOrd,
         Hash,
@@ -344,18 +227,13 @@ pub mod unknown_fields_pb {
         Clone,
         PartialEq,
     )]
-    pub struct Message {
-        pub uid: ::pilota::FastStr,
-
-        pub value: ::pilota::FastStr,
+    pub struct SubMessage {
         pub _unknown_fields: ::pilota::BytesVec,
     }
-    impl ::pilota::prost::Message for Message {
+    impl ::pilota::prost::Message for SubMessage {
         #[inline]
         fn encoded_len(&self) -> usize {
-            0 + ::pilota::prost::encoding::faststr::encoded_len(1, &self.uid)
-                + ::pilota::prost::encoding::faststr::encoded_len(2, &self.value)
-                + self._unknown_fields.size()
+            0 + self._unknown_fields.size()
         }
 
         #[allow(unused_variables)]
@@ -363,8 +241,6 @@ pub mod unknown_fields_pb {
         where
             B: ::pilota::prost::bytes::BufMut,
         {
-            ::pilota::prost::encoding::faststr::encode(1, &self.uid, buf);
-            ::pilota::prost::encoding::faststr::encode(2, &self.value, buf);
             for bytes in self._unknown_fields.list.iter() {
                 buf.put_slice(bytes.as_ref());
             }
@@ -381,36 +257,66 @@ pub mod unknown_fields_pb {
         where
             B: ::pilota::prost::bytes::Buf,
         {
-            const STRUCT_NAME: &'static str = stringify!(Message);
-
             let mut _unknown_fields = &mut self._unknown_fields;
             match tag {
-                1 => {
-                    let mut _inner_pilota_value = &mut self.uid;
-                    ::pilota::prost::encoding::faststr::merge(
-                        wire_type,
-                        _inner_pilota_value,
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(uid));
-                        error
-                    })
+                _ => {
+                    let tag_value = (tag << 3) | wire_type as u32;
+                    let tag_len = ::pilota::prost::encoding::encoded_len_varint(tag_value as u64);
+                    let begin = unsafe { buf.chunk().as_ptr().sub(tag_len) };
+                    ::pilota::prost::encoding::skip_field(wire_type, tag, buf, ctx)?;
+                    let end = buf.chunk().as_ptr();
+                    _unknown_fields.push_back(::pilota::Bytes::copy_from_slice(unsafe {
+                        std::slice::from_raw_parts(begin, end as usize - begin as usize)
+                    }));
+                    Ok(())
                 }
-                2 => {
-                    let mut _inner_pilota_value = &mut self.value;
-                    ::pilota::prost::encoding::faststr::merge(
-                        wire_type,
-                        _inner_pilota_value,
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(value));
-                        error
-                    })
-                }
+            }
+        }
+    }
+    #[derive(
+        PartialOrd,
+        Hash,
+        Eq,
+        Ord,
+        Debug,
+        Default,
+        ::pilota::serde::Serialize,
+        ::pilota::serde::Deserialize,
+        Clone,
+        PartialEq,
+    )]
+    pub struct Message {
+        pub _unknown_fields: ::pilota::BytesVec,
+    }
+    impl ::pilota::prost::Message for Message {
+        #[inline]
+        fn encoded_len(&self) -> usize {
+            0 + self._unknown_fields.size()
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw<B>(&self, buf: &mut B)
+        where
+            B: ::pilota::prost::bytes::BufMut,
+        {
+            for bytes in self._unknown_fields.list.iter() {
+                buf.put_slice(bytes.as_ref());
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field<B>(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::prost::encoding::WireType,
+            buf: &mut B,
+            ctx: ::pilota::prost::encoding::DecodeContext,
+        ) -> ::core::result::Result<(), ::pilota::prost::DecodeError>
+        where
+            B: ::pilota::prost::bytes::Buf,
+        {
+            let mut _unknown_fields = &mut self._unknown_fields;
+            match tag {
                 _ => {
                     let tag_value = (tag << 3) | wire_type as u32;
                     let tag_len = ::pilota::prost::encoding::encoded_len_varint(tag_value as u64);

--- a/pilota-build/test_data/unknown_fields_pb.rs
+++ b/pilota-build/test_data/unknown_fields_pb.rs
@@ -76,143 +76,6 @@ pub mod unknown_fields_pb {
             }
         }
     }
-    #[derive(
-        PartialOrd,
-        Hash,
-        Eq,
-        Ord,
-        Debug,
-        Default,
-        ::pilota::serde::Serialize,
-        ::pilota::serde::Deserialize,
-        Clone,
-        PartialEq,
-    )]
-    pub struct ObjReq {
-        pub _unknown_fields: ::pilota::BytesVec,
-    }
-    impl ::pilota::prost::Message for ObjReq {
-        #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + self._unknown_fields.size()
-        }
-
-        #[allow(unused_variables)]
-        fn encode_raw<B>(&self, buf: &mut B)
-        where
-            B: ::pilota::prost::bytes::BufMut,
-        {
-            for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
-            }
-        }
-
-        #[allow(unused_variables)]
-        fn merge_field<B>(
-            &mut self,
-            tag: u32,
-            wire_type: ::pilota::prost::encoding::WireType,
-            buf: &mut B,
-            ctx: ::pilota::prost::encoding::DecodeContext,
-        ) -> ::core::result::Result<(), ::pilota::prost::DecodeError>
-        where
-            B: ::pilota::prost::bytes::Buf,
-        {
-            let mut _unknown_fields = &mut self._unknown_fields;
-            match tag {
-                _ => {
-                    let tag_value = (tag << 3) | wire_type as u32;
-                    let tag_len = ::pilota::prost::encoding::encoded_len_varint(tag_value as u64);
-                    let begin = unsafe { buf.chunk().as_ptr().sub(tag_len) };
-                    ::pilota::prost::encoding::skip_field(wire_type, tag, buf, ctx)?;
-                    let end = buf.chunk().as_ptr();
-                    _unknown_fields.push_back(::pilota::Bytes::copy_from_slice(unsafe {
-                        std::slice::from_raw_parts(begin, end as usize - begin as usize)
-                    }));
-                    Ok(())
-                }
-            }
-        }
-    }
-    #[derive(
-        PartialOrd,
-        Hash,
-        Eq,
-        Ord,
-        Debug,
-        Default,
-        ::pilota::serde::Serialize,
-        ::pilota::serde::Deserialize,
-        Clone,
-        PartialEq,
-    )]
-    pub struct B {
-        pub a: ::std::option::Option<A>,
-        pub _unknown_fields: ::pilota::BytesVec,
-    }
-    impl ::pilota::prost::Message for B {
-        #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + self.a.as_ref().map_or(0, |msg| {
-                ::pilota::prost::encoding::message::encoded_len(2, msg)
-            }) + self._unknown_fields.size()
-        }
-
-        #[allow(unused_variables)]
-        fn encode_raw<B>(&self, buf: &mut B)
-        where
-            B: ::pilota::prost::bytes::BufMut,
-        {
-            if let Some(_pilota_inner_value) = self.a.as_ref() {
-                ::pilota::prost::encoding::message::encode(2, _pilota_inner_value, buf);
-            }
-            for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
-            }
-        }
-
-        #[allow(unused_variables)]
-        fn merge_field<B>(
-            &mut self,
-            tag: u32,
-            wire_type: ::pilota::prost::encoding::WireType,
-            buf: &mut B,
-            ctx: ::pilota::prost::encoding::DecodeContext,
-        ) -> ::core::result::Result<(), ::pilota::prost::DecodeError>
-        where
-            B: ::pilota::prost::bytes::Buf,
-        {
-            const STRUCT_NAME: &'static str = stringify!(B);
-
-            let mut _unknown_fields = &mut self._unknown_fields;
-            match tag {
-                2 => {
-                    let mut _inner_pilota_value = &mut self.a;
-                    ::pilota::prost::encoding::message::merge(
-                        wire_type,
-                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(a));
-                        error
-                    })
-                }
-                _ => {
-                    let tag_value = (tag << 3) | wire_type as u32;
-                    let tag_len = ::pilota::prost::encoding::encoded_len_varint(tag_value as u64);
-                    let begin = unsafe { buf.chunk().as_ptr().sub(tag_len) };
-                    ::pilota::prost::encoding::skip_field(wire_type, tag, buf, ctx)?;
-                    let end = buf.chunk().as_ptr();
-                    _unknown_fields.push_back(::pilota::Bytes::copy_from_slice(unsafe {
-                        std::slice::from_raw_parts(begin, end as usize - begin as usize)
-                    }));
-                    Ok(())
-                }
-            }
-        }
-    }
 
     pub trait TestService {}
     #[derive(
@@ -306,22 +169,192 @@ pub mod unknown_fields_pb {
         Clone,
         PartialEq,
     )]
+    pub struct ObjReq {
+        pub msg: ::std::option::Option<Message>,
+
+        pub flag_msg: ::pilota::FastStr,
+        pub _unknown_fields: ::pilota::BytesVec,
+    }
+    impl ::pilota::prost::Message for ObjReq {
+        #[inline]
+        fn encoded_len(&self) -> usize {
+            0 + self.msg.as_ref().map_or(0, |msg| {
+                ::pilota::prost::encoding::message::encoded_len(1, msg)
+            }) + ::pilota::prost::encoding::faststr::encoded_len(5, &self.flag_msg)
+                + self._unknown_fields.size()
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw<B>(&self, buf: &mut B)
+        where
+            B: ::pilota::prost::bytes::BufMut,
+        {
+            if let Some(_pilota_inner_value) = self.msg.as_ref() {
+                ::pilota::prost::encoding::message::encode(1, _pilota_inner_value, buf);
+            }
+            ::pilota::prost::encoding::faststr::encode(5, &self.flag_msg, buf);
+            for bytes in self._unknown_fields.list.iter() {
+                buf.put_slice(bytes.as_ref());
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field<B>(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::prost::encoding::WireType,
+            buf: &mut B,
+            ctx: ::pilota::prost::encoding::DecodeContext,
+        ) -> ::core::result::Result<(), ::pilota::prost::DecodeError>
+        where
+            B: ::pilota::prost::bytes::Buf,
+        {
+            const STRUCT_NAME: &'static str = stringify!(ObjReq);
+
+            let mut _unknown_fields = &mut self._unknown_fields;
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.msg;
+                    ::pilota::prost::encoding::message::merge(
+                        wire_type,
+                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(msg));
+                        error
+                    })
+                }
+                5 => {
+                    let mut _inner_pilota_value = &mut self.flag_msg;
+                    ::pilota::prost::encoding::faststr::merge(
+                        wire_type,
+                        _inner_pilota_value,
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(flag_msg));
+                        error
+                    })
+                }
+                _ => {
+                    let tag_value = (tag << 3) | wire_type as u32;
+                    let tag_len = ::pilota::prost::encoding::encoded_len_varint(tag_value as u64);
+                    let begin = unsafe { buf.chunk().as_ptr().sub(tag_len) };
+                    ::pilota::prost::encoding::skip_field(wire_type, tag, buf, ctx)?;
+                    let end = buf.chunk().as_ptr();
+                    _unknown_fields.push_back(::pilota::Bytes::copy_from_slice(unsafe {
+                        std::slice::from_raw_parts(begin, end as usize - begin as usize)
+                    }));
+                    Ok(())
+                }
+            }
+        }
+    }
+    #[derive(
+        PartialOrd,
+        Hash,
+        Eq,
+        Ord,
+        Debug,
+        Default,
+        ::pilota::serde::Serialize,
+        ::pilota::serde::Deserialize,
+        Clone,
+        PartialEq,
+    )]
+    pub struct B {
+        pub a: ::std::option::Option<A>,
+        pub _unknown_fields: ::pilota::BytesVec,
+    }
+    impl ::pilota::prost::Message for B {
+        #[inline]
+        fn encoded_len(&self) -> usize {
+            0 + self.a.as_ref().map_or(0, |msg| {
+                ::pilota::prost::encoding::message::encoded_len(2, msg)
+            }) + self._unknown_fields.size()
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw<B>(&self, buf: &mut B)
+        where
+            B: ::pilota::prost::bytes::BufMut,
+        {
+            if let Some(_pilota_inner_value) = self.a.as_ref() {
+                ::pilota::prost::encoding::message::encode(2, _pilota_inner_value, buf);
+            }
+            for bytes in self._unknown_fields.list.iter() {
+                buf.put_slice(bytes.as_ref());
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field<B>(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::prost::encoding::WireType,
+            buf: &mut B,
+            ctx: ::pilota::prost::encoding::DecodeContext,
+        ) -> ::core::result::Result<(), ::pilota::prost::DecodeError>
+        where
+            B: ::pilota::prost::bytes::Buf,
+        {
+            const STRUCT_NAME: &'static str = stringify!(B);
+
+            let mut _unknown_fields = &mut self._unknown_fields;
+            match tag {
+                2 => {
+                    let mut _inner_pilota_value = &mut self.a;
+                    ::pilota::prost::encoding::message::merge(
+                        wire_type,
+                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(a));
+                        error
+                    })
+                }
+                _ => {
+                    let tag_value = (tag << 3) | wire_type as u32;
+                    let tag_len = ::pilota::prost::encoding::encoded_len_varint(tag_value as u64);
+                    let begin = unsafe { buf.chunk().as_ptr().sub(tag_len) };
+                    ::pilota::prost::encoding::skip_field(wire_type, tag, buf, ctx)?;
+                    let end = buf.chunk().as_ptr();
+                    _unknown_fields.push_back(::pilota::Bytes::copy_from_slice(unsafe {
+                        std::slice::from_raw_parts(begin, end as usize - begin as usize)
+                    }));
+                    Ok(())
+                }
+            }
+        }
+    }
+    #[derive(
+        PartialOrd,
+        Hash,
+        Eq,
+        Ord,
+        Debug,
+        Default,
+        ::pilota::serde::Serialize,
+        ::pilota::serde::Deserialize,
+        Clone,
+        PartialEq,
+    )]
     pub struct Message {
         pub uid: ::pilota::FastStr,
 
-        pub value: ::std::option::Option<::pilota::FastStr>,
-
-        pub sub_messages: ::std::vec::Vec<SubMessage>,
+        pub value: ::pilota::FastStr,
         pub _unknown_fields: ::pilota::BytesVec,
     }
     impl ::pilota::prost::Message for Message {
         #[inline]
         fn encoded_len(&self) -> usize {
             0 + ::pilota::prost::encoding::faststr::encoded_len(1, &self.uid)
-                + self.value.as_ref().map_or(0, |value| {
-                    ::pilota::prost::encoding::faststr::encoded_len(2, value)
-                })
-                + ::pilota::prost::encoding::message::encoded_len_repeated(3, &self.sub_messages)
+                + ::pilota::prost::encoding::faststr::encoded_len(2, &self.value)
                 + self._unknown_fields.size()
         }
 
@@ -331,12 +364,7 @@ pub mod unknown_fields_pb {
             B: ::pilota::prost::bytes::BufMut,
         {
             ::pilota::prost::encoding::faststr::encode(1, &self.uid, buf);
-            if let Some(_pilota_inner_value) = self.value.as_ref() {
-                ::pilota::prost::encoding::faststr::encode(2, _pilota_inner_value, buf);
-            };
-            for msg in &self.sub_messages {
-                ::pilota::prost::encoding::message::encode(3, msg, buf);
-            }
+            ::pilota::prost::encoding::faststr::encode(2, &self.value, buf);
             for bytes in self._unknown_fields.list.iter() {
                 buf.put_slice(bytes.as_ref());
             }
@@ -374,25 +402,12 @@ pub mod unknown_fields_pb {
                     let mut _inner_pilota_value = &mut self.value;
                     ::pilota::prost::encoding::faststr::merge(
                         wire_type,
-                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(value));
-                        error
-                    })
-                }
-                3 => {
-                    let mut _inner_pilota_value = &mut self.sub_messages;
-                    ::pilota::prost::encoding::message::merge_repeated(
-                        wire_type,
                         _inner_pilota_value,
                         buf,
                         ctx,
                     )
                     .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(sub_messages));
+                        error.push(STRUCT_NAME, stringify!(value));
                         error
                     })
                 }

--- a/pilota-build/test_data/unknown_fields_pb_new.rs
+++ b/pilota-build/test_data/unknown_fields_pb_new.rs
@@ -19,15 +19,16 @@ pub mod unknown_fields_pb_new {
     }
     impl ::pilota::pb::Message for A {
         #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + ::pilota::pb::encoding::int32::encoded_len(1, &self.a) + self._unknown_fields.size()
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::int32::encoded_len(ctx, 1, &self.a)
+                + self._unknown_fields.size()
         }
 
         #[allow(unused_variables)]
         fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
             ::pilota::pb::encoding::int32::encode(1, &self.a, buf);
             for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
+                buf.insert(bytes.clone());
             }
         }
 
@@ -77,93 +78,6 @@ pub mod unknown_fields_pb_new {
             }
         }
     }
-
-    pub trait TestService {}
-    #[derive(
-        PartialOrd,
-        Hash,
-        Eq,
-        Ord,
-        Debug,
-        Default,
-        ::pilota::serde::Serialize,
-        ::pilota::serde::Deserialize,
-        Clone,
-        PartialEq,
-    )]
-    pub struct SubMessage {
-        pub value: ::std::option::Option<::pilota::FastStr>,
-        pub _unknown_fields: ::pilota::BytesVec,
-    }
-    impl ::pilota::pb::Message for SubMessage {
-        #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + self.value.as_ref().map_or(0, |value| {
-                ::pilota::pb::encoding::faststr::encoded_len(2, value)
-            }) + self._unknown_fields.size()
-        }
-
-        #[allow(unused_variables)]
-        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
-            if let Some(_pilota_inner_value) = self.value.as_ref() {
-                ::pilota::pb::encoding::faststr::encode(2, _pilota_inner_value, buf);
-            };
-            for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
-            }
-        }
-
-        #[allow(unused_variables)]
-        fn merge_field(
-            &mut self,
-            tag: u32,
-            wire_type: ::pilota::pb::encoding::WireType,
-            buf: &mut ::pilota::Bytes,
-            ctx: &mut ::pilota::pb::encoding::DecodeContext,
-            is_root: bool,
-        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
-            const STRUCT_NAME: &'static str = stringify!(SubMessage);
-            let mut _unknown_fields = &mut self._unknown_fields;
-            // short circuit
-            if is_root && !matches!(tag, 2) && ctx.root_decoded_fields_num() == 1 {
-                // advance buf
-                let cur = buf.chunk().as_ptr();
-                let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
-                buf.advance(len);
-
-                // read rest bytes
-                let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
-                _unknown_fields.push_back(val);
-                return Ok(());
-            }
-            match tag {
-                2 => {
-                    if is_root {
-                        ctx.inc_root_decoded_fields_num(tag);
-                    }
-                    let mut _inner_pilota_value = &mut self.value;
-                    ::pilota::pb::encoding::faststr::merge(
-                        wire_type,
-                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(value));
-                        error
-                    })
-                }
-                _ => {
-                    ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
-                    let end = buf.chunk().as_ptr();
-                    let len = end as usize - ctx.raw_bytes_cursor();
-                    let val = ctx.raw_bytes_split_to(len);
-                    _unknown_fields.push_back(val);
-                    Ok(())
-                }
-            }
-        }
-    }
     #[derive(
         PartialOrd,
         Hash,
@@ -177,28 +91,18 @@ pub mod unknown_fields_pb_new {
         PartialEq,
     )]
     pub struct ObjReq {
-        pub msg: ::std::option::Option<Message>,
-
-        pub flag_msg: ::pilota::FastStr,
         pub _unknown_fields: ::pilota::BytesVec,
     }
     impl ::pilota::pb::Message for ObjReq {
         #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + self.msg.as_ref().map_or(0, |msg| {
-                ::pilota::pb::encoding::message::encoded_len(1, msg)
-            }) + ::pilota::pb::encoding::faststr::encoded_len(5, &self.flag_msg)
-                + self._unknown_fields.size()
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + self._unknown_fields.size()
         }
 
         #[allow(unused_variables)]
         fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
-            if let Some(_pilota_inner_value) = self.msg.as_ref() {
-                ::pilota::pb::encoding::message::encode(1, _pilota_inner_value, buf);
-            }
-            ::pilota::pb::encoding::faststr::encode(5, &self.flag_msg, buf);
             for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
+                buf.insert(bytes.clone());
             }
         }
 
@@ -211,10 +115,9 @@ pub mod unknown_fields_pb_new {
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
             is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
-            const STRUCT_NAME: &'static str = stringify!(ObjReq);
             let mut _unknown_fields = &mut self._unknown_fields;
             // short circuit
-            if is_root && !matches!(tag, 1 | 5) && ctx.root_decoded_fields_num() == 2 {
+            if is_root && ctx.root_decoded_fields_num() == 0 {
                 // advance buf
                 let cur = buf.chunk().as_ptr();
                 let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
@@ -226,33 +129,6 @@ pub mod unknown_fields_pb_new {
                 return Ok(());
             }
             match tag {
-                1 => {
-                    if is_root {
-                        ctx.inc_root_decoded_fields_num(tag);
-                    }
-                    let mut _inner_pilota_value = &mut self.msg;
-                    ::pilota::pb::encoding::message::merge(
-                        wire_type,
-                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(msg));
-                        error
-                    })
-                }
-                5 => {
-                    if is_root {
-                        ctx.inc_root_decoded_fields_num(tag);
-                    }
-                    let mut _inner_pilota_value = &mut self.flag_msg;
-                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
-                        .map_err(|mut error| {
-                            error.push(STRUCT_NAME, stringify!(flag_msg));
-                            error
-                        })
-                }
                 _ => {
                     ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
                     let end = buf.chunk().as_ptr();
@@ -282,9 +158,9 @@ pub mod unknown_fields_pb_new {
     }
     impl ::pilota::pb::Message for B {
         #[inline]
-        fn encoded_len(&self) -> usize {
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
             0 + self.a.as_ref().map_or(0, |msg| {
-                ::pilota::pb::encoding::message::encoded_len(2, msg)
+                ::pilota::pb::encoding::message::encoded_len(ctx, 2, msg)
             }) + self._unknown_fields.size()
         }
 
@@ -294,7 +170,7 @@ pub mod unknown_fields_pb_new {
                 ::pilota::pb::encoding::message::encode(2, _pilota_inner_value, buf);
             }
             for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
+                buf.insert(bytes.clone());
             }
         }
 
@@ -349,6 +225,70 @@ pub mod unknown_fields_pb_new {
             }
         }
     }
+
+    pub trait TestService {}
+    #[derive(
+        PartialOrd,
+        Hash,
+        Eq,
+        Ord,
+        Debug,
+        Default,
+        ::pilota::serde::Serialize,
+        ::pilota::serde::Deserialize,
+        Clone,
+        PartialEq,
+    )]
+    pub struct SubMessage {
+        pub _unknown_fields: ::pilota::BytesVec,
+    }
+    impl ::pilota::pb::Message for SubMessage {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + self._unknown_fields.size()
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            for bytes in self._unknown_fields.list.iter() {
+                buf.insert(bytes.clone());
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            let mut _unknown_fields = &mut self._unknown_fields;
+            // short circuit
+            if is_root && ctx.root_decoded_fields_num() == 0 {
+                // advance buf
+                let cur = buf.chunk().as_ptr();
+                let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
+                buf.advance(len);
+
+                // read rest bytes
+                let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
+                _unknown_fields.push_back(val);
+                return Ok(());
+            }
+            match tag {
+                _ => {
+                    ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
+                    let end = buf.chunk().as_ptr();
+                    let len = end as usize - ctx.raw_bytes_cursor();
+                    let val = ctx.raw_bytes_split_to(len);
+                    _unknown_fields.push_back(val);
+                    Ok(())
+                }
+            }
+        }
+    }
     #[derive(
         PartialOrd,
         Hash,
@@ -362,25 +302,18 @@ pub mod unknown_fields_pb_new {
         PartialEq,
     )]
     pub struct Message {
-        pub uid: ::pilota::FastStr,
-
-        pub value: ::pilota::FastStr,
         pub _unknown_fields: ::pilota::BytesVec,
     }
     impl ::pilota::pb::Message for Message {
         #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + ::pilota::pb::encoding::faststr::encoded_len(1, &self.uid)
-                + ::pilota::pb::encoding::faststr::encoded_len(2, &self.value)
-                + self._unknown_fields.size()
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + self._unknown_fields.size()
         }
 
         #[allow(unused_variables)]
         fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
-            ::pilota::pb::encoding::faststr::encode(1, &self.uid, buf);
-            ::pilota::pb::encoding::faststr::encode(2, &self.value, buf);
             for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
+                buf.insert(bytes.clone());
             }
         }
 
@@ -393,10 +326,9 @@ pub mod unknown_fields_pb_new {
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
             is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
-            const STRUCT_NAME: &'static str = stringify!(Message);
             let mut _unknown_fields = &mut self._unknown_fields;
             // short circuit
-            if is_root && !matches!(tag, 1 | 2) && ctx.root_decoded_fields_num() == 2 {
+            if is_root && ctx.root_decoded_fields_num() == 0 {
                 // advance buf
                 let cur = buf.chunk().as_ptr();
                 let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
@@ -408,28 +340,6 @@ pub mod unknown_fields_pb_new {
                 return Ok(());
             }
             match tag {
-                1 => {
-                    if is_root {
-                        ctx.inc_root_decoded_fields_num(tag);
-                    }
-                    let mut _inner_pilota_value = &mut self.uid;
-                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
-                        .map_err(|mut error| {
-                            error.push(STRUCT_NAME, stringify!(uid));
-                            error
-                        })
-                }
-                2 => {
-                    if is_root {
-                        ctx.inc_root_decoded_fields_num(tag);
-                    }
-                    let mut _inner_pilota_value = &mut self.value;
-                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
-                        .map_err(|mut error| {
-                            error.push(STRUCT_NAME, stringify!(value));
-                            error
-                        })
-                }
                 _ => {
                     ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
                     let end = buf.chunk().as_ptr();

--- a/pilota-build/test_data/unknown_fields_pb_new.rs
+++ b/pilota-build/test_data/unknown_fields_pb_new.rs
@@ -38,137 +38,33 @@ pub mod unknown_fields_pb_new {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(A);
-
             let mut _unknown_fields = &mut self._unknown_fields;
+            // short circuit
+            if is_root && !matches!(tag, 1) && ctx.root_decoded_fields_num() == 1 {
+                // advance buf
+                let cur = buf.chunk().as_ptr();
+                let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
+                buf.advance(len);
+
+                // read rest bytes
+                let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
+                _unknown_fields.push_back(val);
+                return Ok(());
+            }
             match tag {
                 1 => {
+                    if is_root {
+                        ctx.inc_root_decoded_fields_num(tag);
+                    }
                     let mut _inner_pilota_value = &mut self.a;
                     ::pilota::pb::encoding::int32::merge(wire_type, _inner_pilota_value, buf, ctx)
                         .map_err(|mut error| {
                             error.push(STRUCT_NAME, stringify!(a));
                             error
                         })
-                }
-                _ => {
-                    ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
-                    let end = buf.chunk().as_ptr();
-                    let len = end as usize - ctx.raw_bytes_cursor();
-                    let val = ctx.raw_bytes_split_to(len);
-                    _unknown_fields.push_back(val);
-                    Ok(())
-                }
-            }
-        }
-    }
-    #[derive(
-        PartialOrd,
-        Hash,
-        Eq,
-        Ord,
-        Debug,
-        Default,
-        ::pilota::serde::Serialize,
-        ::pilota::serde::Deserialize,
-        Clone,
-        PartialEq,
-    )]
-    pub struct ObjReq {
-        pub _unknown_fields: ::pilota::BytesVec,
-    }
-    impl ::pilota::pb::Message for ObjReq {
-        #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + self._unknown_fields.size()
-        }
-
-        #[allow(unused_variables)]
-        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
-            for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
-            }
-        }
-
-        #[allow(unused_variables)]
-        fn merge_field(
-            &mut self,
-            tag: u32,
-            wire_type: ::pilota::pb::encoding::WireType,
-            buf: &mut ::pilota::Bytes,
-            ctx: &mut ::pilota::pb::encoding::DecodeContext,
-        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
-            let mut _unknown_fields = &mut self._unknown_fields;
-            match tag {
-                _ => {
-                    ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
-                    let end = buf.chunk().as_ptr();
-                    let len = end as usize - ctx.raw_bytes_cursor();
-                    let val = ctx.raw_bytes_split_to(len);
-                    _unknown_fields.push_back(val);
-                    Ok(())
-                }
-            }
-        }
-    }
-    #[derive(
-        PartialOrd,
-        Hash,
-        Eq,
-        Ord,
-        Debug,
-        Default,
-        ::pilota::serde::Serialize,
-        ::pilota::serde::Deserialize,
-        Clone,
-        PartialEq,
-    )]
-    pub struct B {
-        pub a: ::std::option::Option<A>,
-        pub _unknown_fields: ::pilota::BytesVec,
-    }
-    impl ::pilota::pb::Message for B {
-        #[inline]
-        fn encoded_len(&self) -> usize {
-            0 + self.a.as_ref().map_or(0, |msg| {
-                ::pilota::pb::encoding::message::encoded_len(2, msg)
-            }) + self._unknown_fields.size()
-        }
-
-        #[allow(unused_variables)]
-        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
-            if let Some(_pilota_inner_value) = self.a.as_ref() {
-                ::pilota::pb::encoding::message::encode(2, _pilota_inner_value, buf);
-            }
-            for bytes in self._unknown_fields.list.iter() {
-                buf.put_slice(bytes.as_ref());
-            }
-        }
-
-        #[allow(unused_variables)]
-        fn merge_field(
-            &mut self,
-            tag: u32,
-            wire_type: ::pilota::pb::encoding::WireType,
-            buf: &mut ::pilota::Bytes,
-            ctx: &mut ::pilota::pb::encoding::DecodeContext,
-        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
-            const STRUCT_NAME: &'static str = stringify!(B);
-
-            let mut _unknown_fields = &mut self._unknown_fields;
-            match tag {
-                2 => {
-                    let mut _inner_pilota_value = &mut self.a;
-                    ::pilota::pb::encoding::message::merge(
-                        wire_type,
-                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(a));
-                        error
-                    })
                 }
                 _ => {
                     ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
@@ -224,12 +120,27 @@ pub mod unknown_fields_pb_new {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(SubMessage);
-
             let mut _unknown_fields = &mut self._unknown_fields;
+            // short circuit
+            if is_root && !matches!(tag, 2) && ctx.root_decoded_fields_num() == 1 {
+                // advance buf
+                let cur = buf.chunk().as_ptr();
+                let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
+                buf.advance(len);
+
+                // read rest bytes
+                let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
+                _unknown_fields.push_back(val);
+                return Ok(());
+            }
             match tag {
                 2 => {
+                    if is_root {
+                        ctx.inc_root_decoded_fields_num(tag);
+                    }
                     let mut _inner_pilota_value = &mut self.value;
                     ::pilota::pb::encoding::faststr::merge(
                         wire_type,
@@ -265,33 +176,122 @@ pub mod unknown_fields_pb_new {
         Clone,
         PartialEq,
     )]
-    pub struct Message {
-        pub uid: ::pilota::FastStr,
+    pub struct ObjReq {
+        pub msg: ::std::option::Option<Message>,
 
-        pub value: ::std::option::Option<::pilota::FastStr>,
-
-        pub sub_messages: ::std::vec::Vec<SubMessage>,
+        pub flag_msg: ::pilota::FastStr,
         pub _unknown_fields: ::pilota::BytesVec,
     }
-    impl ::pilota::pb::Message for Message {
+    impl ::pilota::pb::Message for ObjReq {
         #[inline]
         fn encoded_len(&self) -> usize {
-            0 + ::pilota::pb::encoding::faststr::encoded_len(1, &self.uid)
-                + self.value.as_ref().map_or(0, |value| {
-                    ::pilota::pb::encoding::faststr::encoded_len(2, value)
-                })
-                + ::pilota::pb::encoding::message::encoded_len_repeated(3, &self.sub_messages)
+            0 + self.msg.as_ref().map_or(0, |msg| {
+                ::pilota::pb::encoding::message::encoded_len(1, msg)
+            }) + ::pilota::pb::encoding::faststr::encoded_len(5, &self.flag_msg)
                 + self._unknown_fields.size()
         }
 
         #[allow(unused_variables)]
         fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
-            ::pilota::pb::encoding::faststr::encode(1, &self.uid, buf);
-            if let Some(_pilota_inner_value) = self.value.as_ref() {
-                ::pilota::pb::encoding::faststr::encode(2, _pilota_inner_value, buf);
-            };
-            for msg in &self.sub_messages {
-                ::pilota::pb::encoding::message::encode(3, msg, buf);
+            if let Some(_pilota_inner_value) = self.msg.as_ref() {
+                ::pilota::pb::encoding::message::encode(1, _pilota_inner_value, buf);
+            }
+            ::pilota::pb::encoding::faststr::encode(5, &self.flag_msg, buf);
+            for bytes in self._unknown_fields.list.iter() {
+                buf.put_slice(bytes.as_ref());
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(ObjReq);
+            let mut _unknown_fields = &mut self._unknown_fields;
+            // short circuit
+            if is_root && !matches!(tag, 1 | 5) && ctx.root_decoded_fields_num() == 2 {
+                // advance buf
+                let cur = buf.chunk().as_ptr();
+                let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
+                buf.advance(len);
+
+                // read rest bytes
+                let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
+                _unknown_fields.push_back(val);
+                return Ok(());
+            }
+            match tag {
+                1 => {
+                    if is_root {
+                        ctx.inc_root_decoded_fields_num(tag);
+                    }
+                    let mut _inner_pilota_value = &mut self.msg;
+                    ::pilota::pb::encoding::message::merge(
+                        wire_type,
+                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(msg));
+                        error
+                    })
+                }
+                5 => {
+                    if is_root {
+                        ctx.inc_root_decoded_fields_num(tag);
+                    }
+                    let mut _inner_pilota_value = &mut self.flag_msg;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(flag_msg));
+                            error
+                        })
+                }
+                _ => {
+                    ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
+                    let end = buf.chunk().as_ptr();
+                    let len = end as usize - ctx.raw_bytes_cursor();
+                    let val = ctx.raw_bytes_split_to(len);
+                    _unknown_fields.push_back(val);
+                    Ok(())
+                }
+            }
+        }
+    }
+    #[derive(
+        PartialOrd,
+        Hash,
+        Eq,
+        Ord,
+        Debug,
+        Default,
+        ::pilota::serde::Serialize,
+        ::pilota::serde::Deserialize,
+        Clone,
+        PartialEq,
+    )]
+    pub struct B {
+        pub a: ::std::option::Option<A>,
+        pub _unknown_fields: ::pilota::BytesVec,
+    }
+    impl ::pilota::pb::Message for B {
+        #[inline]
+        fn encoded_len(&self) -> usize {
+            0 + self.a.as_ref().map_or(0, |msg| {
+                ::pilota::pb::encoding::message::encoded_len(2, msg)
+            }) + self._unknown_fields.size()
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            if let Some(_pilota_inner_value) = self.a.as_ref() {
+                ::pilota::pb::encoding::message::encode(2, _pilota_inner_value, buf);
             }
             for bytes in self._unknown_fields.list.iter() {
                 buf.put_slice(bytes.as_ref());
@@ -305,12 +305,113 @@ pub mod unknown_fields_pb_new {
             wire_type: ::pilota::pb::encoding::WireType,
             buf: &mut ::pilota::Bytes,
             ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(B);
+            let mut _unknown_fields = &mut self._unknown_fields;
+            // short circuit
+            if is_root && !matches!(tag, 2) && ctx.root_decoded_fields_num() == 1 {
+                // advance buf
+                let cur = buf.chunk().as_ptr();
+                let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
+                buf.advance(len);
+
+                // read rest bytes
+                let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
+                _unknown_fields.push_back(val);
+                return Ok(());
+            }
+            match tag {
+                2 => {
+                    if is_root {
+                        ctx.inc_root_decoded_fields_num(tag);
+                    }
+                    let mut _inner_pilota_value = &mut self.a;
+                    ::pilota::pb::encoding::message::merge(
+                        wire_type,
+                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(a));
+                        error
+                    })
+                }
+                _ => {
+                    ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;
+                    let end = buf.chunk().as_ptr();
+                    let len = end as usize - ctx.raw_bytes_cursor();
+                    let val = ctx.raw_bytes_split_to(len);
+                    _unknown_fields.push_back(val);
+                    Ok(())
+                }
+            }
+        }
+    }
+    #[derive(
+        PartialOrd,
+        Hash,
+        Eq,
+        Ord,
+        Debug,
+        Default,
+        ::pilota::serde::Serialize,
+        ::pilota::serde::Deserialize,
+        Clone,
+        PartialEq,
+    )]
+    pub struct Message {
+        pub uid: ::pilota::FastStr,
+
+        pub value: ::pilota::FastStr,
+        pub _unknown_fields: ::pilota::BytesVec,
+    }
+    impl ::pilota::pb::Message for Message {
+        #[inline]
+        fn encoded_len(&self) -> usize {
+            0 + ::pilota::pb::encoding::faststr::encoded_len(1, &self.uid)
+                + ::pilota::pb::encoding::faststr::encoded_len(2, &self.value)
+                + self._unknown_fields.size()
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::faststr::encode(1, &self.uid, buf);
+            ::pilota::pb::encoding::faststr::encode(2, &self.value, buf);
+            for bytes in self._unknown_fields.list.iter() {
+                buf.put_slice(bytes.as_ref());
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(Message);
-
             let mut _unknown_fields = &mut self._unknown_fields;
+            // short circuit
+            if is_root && !matches!(tag, 1 | 2) && ctx.root_decoded_fields_num() == 2 {
+                // advance buf
+                let cur = buf.chunk().as_ptr();
+                let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
+                buf.advance(len);
+
+                // read rest bytes
+                let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
+                _unknown_fields.push_back(val);
+                return Ok(());
+            }
             match tag {
                 1 => {
+                    if is_root {
+                        ctx.inc_root_decoded_fields_num(tag);
+                    }
                     let mut _inner_pilota_value = &mut self.uid;
                     ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
                         .map_err(|mut error| {
@@ -319,30 +420,15 @@ pub mod unknown_fields_pb_new {
                         })
                 }
                 2 => {
+                    if is_root {
+                        ctx.inc_root_decoded_fields_num(tag);
+                    }
                     let mut _inner_pilota_value = &mut self.value;
-                    ::pilota::pb::encoding::faststr::merge(
-                        wire_type,
-                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(value));
-                        error
-                    })
-                }
-                3 => {
-                    let mut _inner_pilota_value = &mut self.sub_messages;
-                    ::pilota::pb::encoding::message::merge_repeated(
-                        wire_type,
-                        _inner_pilota_value,
-                        buf,
-                        ctx,
-                    )
-                    .map_err(|mut error| {
-                        error.push(STRUCT_NAME, stringify!(sub_messages));
-                        error
-                    })
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(value));
+                            error
+                        })
                 }
                 _ => {
                     ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;

--- a/pilota/src/pb/encoding.rs
+++ b/pilota/src/pb/encoding.rs
@@ -9,6 +9,7 @@ use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
 use core::{cmp::min, convert::TryFrom, mem, str};
 
 use ::bytes::{Buf, BufMut, Bytes};
+use ahash::AHashSet;
 use linkedbytes::LinkedBytes;
 
 use super::{DecodeError, Message};
@@ -190,6 +191,9 @@ pub struct DecodeContext {
 
     raw_bytes: Bytes,
     raw_bytes_cursor: usize,
+
+    root_decoded_fields_num: u32,
+    decoded_fields_tag: AHashSet<u32>,
 }
 
 impl DecodeContext {
@@ -199,6 +203,8 @@ impl DecodeContext {
             recurse_count: super::RECURSION_LIMIT,
             raw_bytes,
             raw_bytes_cursor,
+            root_decoded_fields_num: 0,
+            decoded_fields_tag: AHashSet::new(),
         }
     }
     /// Call this function before recursively decoding.
@@ -255,6 +261,10 @@ impl DecodeContext {
         Ok(())
     }
 
+    pub fn raw_bytes_len(&self) -> usize {
+        self.raw_bytes.len()
+    }
+
     pub fn raw_bytes_split_to(&mut self, len: usize) -> Bytes {
         let split = self.raw_bytes.split_to(len);
         self.raw_bytes_cursor += len;
@@ -265,9 +275,26 @@ impl DecodeContext {
         self.raw_bytes_cursor
     }
 
+    pub fn align_with_buf(&mut self, buf: &Bytes) {
+        let cur = buf.chunk().as_ptr();
+        let last = self.raw_bytes_cursor();
+        self.advance_raw_bytes(cur as usize - last);
+    }
+
     pub fn advance_raw_bytes(&mut self, n: usize) {
         self.raw_bytes.advance(n);
         self.raw_bytes_cursor += n;
+    }
+
+    pub fn root_decoded_fields_num(&self) -> u32 {
+        self.root_decoded_fields_num
+    }
+
+    pub fn inc_root_decoded_fields_num(&mut self, tag: u32) {
+        if !self.decoded_fields_tag.contains(&tag) {
+            self.decoded_fields_tag.insert(tag);
+            self.root_decoded_fields_num += 1;
+        }
     }
 }
 
@@ -376,12 +403,9 @@ where
         return Err(DecodeError::new("buffer underflow"));
     }
 
-    let cur = buf.chunk().as_ptr();
-    let last = ctx.raw_bytes_cursor();
-    ctx.advance_raw_bytes(cur as usize - last);
-
     let limit = remaining - len as usize;
     while buf.remaining() > limit {
+        ctx.align_with_buf(buf);
         merge(value, buf, ctx)?;
     }
 
@@ -1264,7 +1288,7 @@ pub mod message {
             ctx,
             |msg: &mut M, buf: &mut Bytes, ctx: &mut DecodeContext| {
                 let (tag, wire_type) = decode_key(buf)?;
-                msg.merge_field(tag, wire_type, buf, ctx)
+                msg.merge_field(tag, wire_type, buf, ctx, false)
             },
         )?;
         ctx.exit_recursion();
@@ -1354,7 +1378,7 @@ pub mod group {
             }
 
             ctx.enter_recursion();
-            M::merge_field(msg, field_tag, field_wire_type, buf, ctx)?;
+            M::merge_field(msg, field_tag, field_wire_type, buf, ctx, false)?;
             ctx.exit_recursion();
         }
     }

--- a/pilota/src/pb/encoding.rs
+++ b/pilota/src/pb/encoding.rs
@@ -12,9 +12,8 @@ use ::bytes::{Buf, BufMut, Bytes};
 use ahash::AHashSet;
 use linkedbytes::LinkedBytes;
 
-use crate::pb::ZERO_COPY_THRESHOLD;
-
 use super::{DecodeError, Message};
+use crate::pb::ZERO_COPY_THRESHOLD;
 
 /// Encodes an integer value into LEB128 variable length format, and writes it
 /// to the buffer. The buffer must have enough remaining space (maximum 10

--- a/pilota/src/pb/encoding.rs
+++ b/pilota/src/pb/encoding.rs
@@ -12,6 +12,8 @@ use ::bytes::{Buf, BufMut, Bytes};
 use ahash::AHashSet;
 use linkedbytes::LinkedBytes;
 
+use crate::pb::ZERO_COPY_THRESHOLD;
+
 use super::{DecodeError, Message};
 
 /// Encodes an integer value into LEB128 variable length format, and writes it
@@ -547,19 +549,19 @@ macro_rules! varint {
             merge_repeated_numeric!($ty, WireType::Varint, merge, merge_repeated);
 
             #[inline]
-            pub fn encoded_len(tag: u32, $to_uint64_value: &$ty) -> usize {
+            pub fn encoded_len(_ctx: &mut EncodeLengthContext, tag: u32, $to_uint64_value: &$ty) -> usize {
                 key_len(tag) + encoded_len_varint($to_uint64)
             }
 
             #[inline]
-            pub fn encoded_len_repeated(tag: u32, values: &[$ty]) -> usize {
+            pub fn encoded_len_repeated(_ctx: &mut EncodeLengthContext, tag: u32, values: &[$ty]) -> usize {
                 key_len(tag) * values.len() + values.iter().map(|$to_uint64_value| {
                     encoded_len_varint($to_uint64)
                 }).sum::<usize>()
             }
 
             #[inline]
-            pub fn encoded_len_packed(tag: u32, values: &[$ty]) -> usize {
+            pub fn encoded_len_packed(_ctx: &mut EncodeLengthContext, tag: u32, values: &[$ty]) -> usize {
                 if values.is_empty() {
                     0
                 } else {
@@ -692,12 +694,20 @@ pub mod int32 {
     }
 
     #[inline]
-    pub fn encoded_len<T: Into<i32> + Copy>(tag: u32, value: &T) -> usize {
+    pub fn encoded_len<T: Into<i32> + Copy>(
+        _ctx: &mut EncodeLengthContext,
+        tag: u32,
+        value: &T,
+    ) -> usize {
         key_len(tag) + encoded_len_varint((*value).into() as u64)
     }
 
     #[inline]
-    pub fn encoded_len_repeated<V: Into<i32> + Copy>(tag: u32, values: &[V]) -> usize {
+    pub fn encoded_len_repeated<V: Into<i32> + Copy>(
+        _ctx: &mut EncodeLengthContext,
+        tag: u32,
+        values: &[V],
+    ) -> usize {
         key_len(tag) * values.len()
             + values
                 .iter()
@@ -787,17 +797,25 @@ macro_rules! fixed_width {
             merge_repeated_numeric!($ty, $wire_type, merge, merge_repeated);
 
             #[inline]
-            pub fn encoded_len(tag: u32, _: &$ty) -> usize {
+            pub fn encoded_len(_ctx: &mut EncodeLengthContext, tag: u32, _: &$ty) -> usize {
                 key_len(tag) + $width
             }
 
             #[inline]
-            pub fn encoded_len_repeated(tag: u32, values: &[$ty]) -> usize {
+            pub fn encoded_len_repeated(
+                _ctx: &mut EncodeLengthContext,
+                tag: u32,
+                values: &[$ty],
+            ) -> usize {
                 (key_len(tag) + $width) * values.len()
             }
 
             #[inline]
-            pub fn encoded_len_packed(tag: u32, values: &[$ty]) -> usize {
+            pub fn encoded_len_packed(
+                _ctx: &mut EncodeLengthContext,
+                tag: u32,
+                values: &[$ty],
+            ) -> usize {
                 if values.is_empty() {
                     0
                 } else {
@@ -906,16 +924,28 @@ macro_rules! length_delimited {
         }
 
         #[inline]
-        pub fn encoded_len(tag: u32, value: &$ty) -> usize {
+        pub fn encoded_len(ctx: &mut EncodeLengthContext, tag: u32, value: &$ty) -> usize {
+            if value.zero_copy_len() > ZERO_COPY_THRESHOLD {
+                ctx.zero_copy_len += value.zero_copy_len();
+            }
             key_len(tag) + encoded_len_varint(value.len() as u64) + value.len()
         }
 
         #[inline]
-        pub fn encoded_len_repeated(tag: u32, values: &[$ty]) -> usize {
+        pub fn encoded_len_repeated(
+            ctx: &mut EncodeLengthContext,
+            tag: u32,
+            values: &[$ty],
+        ) -> usize {
             key_len(tag) * values.len()
                 + values
                     .iter()
-                    .map(|value| encoded_len_varint(value.len() as u64) + value.len())
+                    .map(|value| {
+                        if value.zero_copy_len() > ZERO_COPY_THRESHOLD {
+                            ctx.zero_copy_len += value.zero_copy_len();
+                        }
+                        encoded_len_varint(value.len() as u64) + value.len()
+                    })
                     .sum::<usize>()
         }
     };
@@ -1001,13 +1031,21 @@ pub mod string {
     }
 
     #[inline]
-    pub fn encoded_len<T: Borrow<str>>(tag: u32, value: &T) -> usize {
+    pub fn encoded_len<T: Borrow<str>>(
+        _ctx: &mut EncodeLengthContext,
+        tag: u32,
+        value: &T,
+    ) -> usize {
         let value = value.borrow();
         key_len(tag) + encoded_len_varint(value.len() as u64) + value.len()
     }
 
     #[inline]
-    pub fn encoded_len_repeated<T: Borrow<str>>(tag: u32, values: &[T]) -> usize {
+    pub fn encoded_len_repeated<T: Borrow<str>>(
+        _ctx: &mut EncodeLengthContext,
+        tag: u32,
+        values: &[T],
+    ) -> usize {
         key_len(tag) * values.len()
             + values
                 .iter()
@@ -1050,11 +1088,14 @@ pub mod faststr {
 
     use super::*;
 
-    pub fn encode<T: Borrow<str>>(tag: u32, value: &T, buf: &mut LinkedBytes) {
-        let value = value.borrow();
+    pub fn encode(tag: u32, value: &FastStr, buf: &mut LinkedBytes) {
         encode_key(tag, WireType::LengthDelimited, buf);
         encode_varint(value.len() as u64, buf);
-        buf.put_slice(value.as_bytes());
+        if value.len() >= ZERO_COPY_THRESHOLD {
+            buf.insert_faststr(value.clone());
+        } else {
+            buf.put_slice(value.as_bytes());
+        }
     }
     pub fn merge(
         wire_type: WireType,
@@ -1069,7 +1110,7 @@ pub mod faststr {
         Ok(())
     }
 
-    pub fn encode_repeated<T: Borrow<str>>(tag: u32, values: &[T], buf: &mut LinkedBytes) {
+    pub fn encode_repeated(tag: u32, values: &[FastStr], buf: &mut LinkedBytes) {
         for value in values {
             encode(tag, value, buf);
         }
@@ -1089,18 +1130,32 @@ pub mod faststr {
     }
 
     #[inline]
-    pub fn encoded_len<T: Borrow<str>>(tag: u32, value: &T) -> usize {
+    pub fn encoded_len<T: Borrow<str>>(
+        ctx: &mut EncodeLengthContext,
+        tag: u32,
+        value: &T,
+    ) -> usize {
         let value = value.borrow();
+        if value.len() >= ZERO_COPY_THRESHOLD {
+            ctx.zero_copy_len += value.len();
+        }
         key_len(tag) + encoded_len_varint(value.len() as u64) + value.len()
     }
 
     #[inline]
-    pub fn encoded_len_repeated<T: Borrow<str>>(tag: u32, values: &[T]) -> usize {
+    pub fn encoded_len_repeated<T: Borrow<str>>(
+        ctx: &mut EncodeLengthContext,
+        tag: u32,
+        values: &[T],
+    ) -> usize {
         key_len(tag) * values.len()
             + values
                 .iter()
                 .map(|value| {
                     let value = value.borrow();
+                    if value.len() >= ZERO_COPY_THRESHOLD {
+                        ctx.zero_copy_len += value.len();
+                    }
                     encoded_len_varint(value.len() as u64) + value.len()
                 })
                 .sum::<usize>()
@@ -1125,6 +1180,10 @@ mod sealed {
         fn is_empty(&self) -> bool {
             self.len() == 0
         }
+
+        fn zero_copy_len(&self) -> usize {
+            0
+        }
     }
 }
 
@@ -1143,7 +1202,20 @@ impl sealed::BytesAdapter for Bytes {
 
     #[inline]
     fn append_to(&self, buf: &mut LinkedBytes) {
-        buf.put(self.clone())
+        if self.len() >= ZERO_COPY_THRESHOLD {
+            buf.insert(self.clone());
+        } else {
+            buf.put_slice(self);
+        }
+    }
+
+    #[inline]
+    fn zero_copy_len(&self) -> usize {
+        if self.len() >= ZERO_COPY_THRESHOLD {
+            self.len()
+        } else {
+            0
+        }
     }
 }
 
@@ -1266,7 +1338,10 @@ pub mod message {
         M: Message,
     {
         encode_key(tag, WireType::LengthDelimited, buf);
-        encode_varint(msg.encoded_len() as u64, buf);
+        encode_varint(
+            msg.encoded_len(&mut EncodeLengthContext::default()) as u64,
+            buf,
+        );
         msg.encode_raw(buf);
     }
 
@@ -1321,23 +1396,23 @@ pub mod message {
     }
 
     #[inline]
-    pub fn encoded_len<M>(tag: u32, msg: &M) -> usize
+    pub fn encoded_len<M>(ctx: &mut EncodeLengthContext, tag: u32, msg: &M) -> usize
     where
         M: Message,
     {
-        let len = msg.encoded_len();
+        let len = msg.encoded_len(ctx);
         key_len(tag) + encoded_len_varint(len as u64) + len
     }
 
     #[inline]
-    pub fn encoded_len_repeated<M>(tag: u32, messages: &[M]) -> usize
+    pub fn encoded_len_repeated<M>(ctx: &mut EncodeLengthContext, tag: u32, messages: &[M]) -> usize
     where
         M: Message,
     {
         key_len(tag) * messages.len()
             + messages
                 .iter()
-                .map(Message::encoded_len)
+                .map(|msg| msg.encoded_len(ctx))
                 .map(|len| len + encoded_len_varint(len as u64))
                 .sum::<usize>()
     }
@@ -1410,19 +1485,23 @@ pub mod group {
     }
 
     #[inline]
-    pub fn encoded_len<M>(tag: u32, msg: &M) -> usize
+    pub fn encoded_len<M>(ctx: &mut EncodeLengthContext, tag: u32, msg: &M) -> usize
     where
         M: Message,
     {
-        2 * key_len(tag) + msg.encoded_len()
+        2 * key_len(tag) + msg.encoded_len(ctx)
     }
 
     #[inline]
-    pub fn encoded_len_repeated<M>(tag: u32, messages: &[M]) -> usize
+    pub fn encoded_len_repeated<M>(ctx: &mut EncodeLengthContext, tag: u32, messages: &[M]) -> usize
     where
         M: Message,
     {
-        2 * key_len(tag) * messages.len() + messages.iter().map(Message::encoded_len).sum::<usize>()
+        2 * key_len(tag) * messages.len()
+            + messages
+                .iter()
+                .map(|msg| msg.encoded_len(ctx))
+                .sum::<usize>()
     }
 }
 
@@ -1447,9 +1526,9 @@ macro_rules! map {
             K: Default + Eq + Hash + Ord,
             V: Default + PartialEq,
             KE: Fn(u32, &K, &mut LinkedBytes),
-            KL: Fn(u32, &K) -> usize,
+            KL: Fn(&mut EncodeLengthContext, u32, &K) -> usize,
             VE: Fn(u32, &V, &mut LinkedBytes),
-            VL: Fn(u32, &V) -> usize,
+            VL: Fn(&mut EncodeLengthContext, u32, &V) -> usize,
         {
             encode_with_default(
                 key_encode,
@@ -1482,6 +1561,7 @@ macro_rules! map {
 
         /// Generic protobuf map encode function.
         pub fn encoded_len<K, V, KL, VL>(
+            ctx: &mut EncodeLengthContext,
             key_encoded_len: KL,
             val_encoded_len: VL,
             tag: u32,
@@ -1490,10 +1570,17 @@ macro_rules! map {
         where
             K: Default + Eq + Hash + Ord,
             V: Default + PartialEq,
-            KL: Fn(u32, &K) -> usize,
-            VL: Fn(u32, &V) -> usize,
+            KL: Fn(&mut EncodeLengthContext, u32, &K) -> usize,
+            VL: Fn(&mut EncodeLengthContext, u32, &V) -> usize,
         {
-            encoded_len_with_default(key_encoded_len, val_encoded_len, &V::default(), tag, values)
+            encoded_len_with_default(
+                ctx,
+                key_encoded_len,
+                val_encoded_len,
+                &V::default(),
+                tag,
+                values,
+            )
         }
 
         /// Generic protobuf map encode function with an overridden value default.
@@ -1514,16 +1601,23 @@ macro_rules! map {
             K: Default + Eq + Hash + Ord,
             V: PartialEq,
             KE: Fn(u32, &K, &mut LinkedBytes),
-            KL: Fn(u32, &K) -> usize,
+            KL: Fn(&mut EncodeLengthContext, u32, &K) -> usize,
             VE: Fn(u32, &V, &mut LinkedBytes),
-            VL: Fn(u32, &V) -> usize,
+            VL: Fn(&mut EncodeLengthContext, u32, &V) -> usize,
         {
             for (key, val) in values.iter() {
                 let skip_key = !cfg!(feature = "pb-encode-default-value") && key == &K::default();
                 let skip_val = !cfg!(feature = "pb-encode-default-value") && val == val_default;
 
-                let len = (if skip_key { 0 } else { key_encoded_len(1, key) })
-                    + (if skip_val { 0 } else { val_encoded_len(2, val) });
+                let len = (if skip_key {
+                    0
+                } else {
+                    key_encoded_len(&mut EncodeLengthContext::default(), 1, key)
+                }) + (if skip_val {
+                    0
+                } else {
+                    val_encoded_len(&mut EncodeLengthContext::default(), 2, val)
+                });
 
                 encode_key(tag, WireType::LengthDelimited, buf);
                 encode_varint(len as u64, buf);
@@ -1581,6 +1675,7 @@ macro_rules! map {
         /// This is necessary because enumeration values can have a default value other
         /// than 0 in proto2.
         pub fn encoded_len_with_default<K, V, KL, VL>(
+            ctx: &mut EncodeLengthContext,
             key_encoded_len: KL,
             val_encoded_len: VL,
             val_default: &V,
@@ -1590,8 +1685,8 @@ macro_rules! map {
         where
             K: Default + Eq + Hash + Ord,
             V: PartialEq,
-            KL: Fn(u32, &K) -> usize,
-            VL: Fn(u32, &V) -> usize,
+            KL: Fn(&mut EncodeLengthContext, u32, &K) -> usize,
+            VL: Fn(&mut EncodeLengthContext, u32, &V) -> usize,
         {
             let skip_default_value = !cfg!(feature = "pb-encode-default-value");
 
@@ -1602,11 +1697,11 @@ macro_rules! map {
                         let len = (if key == &K::default() && skip_default_value {
                             0
                         } else {
-                            key_encoded_len(1, key)
+                            key_encoded_len(ctx, 1, key)
                         }) + (if val == val_default && skip_default_value {
                             0
                         } else {
-                            val_encoded_len(2, val)
+                            val_encoded_len(ctx, 2, val)
                         });
                         encoded_len_varint(len as u64) + len
                     })
@@ -1622,6 +1717,11 @@ pub mod hash_map {
 
 pub mod btree_map {
     map!(BTreeMap);
+}
+
+#[derive(Default)]
+pub struct EncodeLengthContext {
+    pub zero_copy_len: usize,
 }
 
 #[cfg(test)]
@@ -1640,19 +1740,19 @@ mod test {
         wire_type: WireType,
         encode: fn(u32, &T, &mut LinkedBytes),
         merge: fn(WireType, &mut T, &mut Bytes, &mut DecodeContext) -> Result<(), DecodeError>,
-        encoded_len: fn(u32, &T) -> usize,
+        encoded_len: fn(&mut EncodeLengthContext, u32, &T) -> usize,
     ) -> TestCaseResult
     where
         T: Debug + Default + PartialEq,
     {
         prop_assume!((MIN_TAG..=MAX_TAG).contains(&tag));
 
-        let expected_len = encoded_len(tag, &value);
+        let expected_len = encoded_len(&mut EncodeLengthContext::default(), tag, &value);
 
         let mut buf = LinkedBytes::with_capacity(expected_len);
         encode(tag, &value, &mut buf);
 
-        let mut buf = buf.bytes().clone().freeze();
+        let mut buf = buf.concat();
 
         prop_assert_eq!(
             buf.remaining(),
@@ -1727,16 +1827,17 @@ mod test {
         T: Debug + Default + PartialEq + AsRef<[Item]>,
         E: FnOnce(u32, &[Item], &mut LinkedBytes),
         M: FnMut(WireType, &mut T, &mut Bytes, &mut DecodeContext) -> Result<(), DecodeError>,
-        L: FnOnce(u32, &[Item]) -> usize,
+        L: FnOnce(&mut EncodeLengthContext, u32, &[Item]) -> usize,
     {
         prop_assume!((MIN_TAG..=MAX_TAG).contains(&tag));
 
-        let expected_len = encoded_len(tag, value.as_ref());
+        let mut ctx = EncodeLengthContext::default();
+        let expected_len = encoded_len(&mut ctx, tag, value.as_ref());
 
         let mut buf = LinkedBytes::with_capacity(expected_len);
         encode(tag, value.as_ref(), &mut buf);
 
-        let mut buf = buf.bytes().clone().freeze();
+        let mut buf = buf.concat();
 
         prop_assert_eq!(
             buf.remaining(),

--- a/pilota/src/pb/message.rs
+++ b/pilota/src/pb/message.rs
@@ -33,6 +33,7 @@ pub trait Message: Debug + Send + Sync {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        is_root: bool,
     ) -> Result<(), DecodeError>
     where
         Self: Sized;
@@ -108,11 +109,9 @@ pub trait Message: Debug + Send + Sync {
     {
         let mut ctx = DecodeContext::new(buf.clone());
         while buf.has_remaining() {
+            ctx.align_with_buf(&buf);
             let (tag, wire_type) = decode_key(&mut buf)?;
-            self.merge_field(tag, wire_type, &mut buf, &mut ctx)?;
-            let align_ptr = buf.chunk().as_ptr();
-            let last_ptr = ctx.raw_bytes_cursor();
-            ctx.advance_raw_bytes(align_ptr as usize - last_ptr);
+            self.merge_field(tag, wire_type, &mut buf, &mut ctx, true)?;
         }
         Ok(())
     }
@@ -141,8 +140,9 @@ where
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        is_root: bool,
     ) -> Result<(), DecodeError> {
-        (**self).merge_field(tag, wire_type, buf, ctx)
+        (**self).merge_field(tag, wire_type, buf, ctx, is_root)
     }
     fn encoded_len(&self) -> usize {
         (**self).encoded_len()

--- a/pilota/src/pb/message.rs
+++ b/pilota/src/pb/message.rs
@@ -6,12 +6,11 @@ use core::fmt::Debug;
 use bytes::{Buf, BufMut, Bytes};
 use linkedbytes::LinkedBytes;
 
-use crate::pb::encoding::EncodeLengthContext;
-
 use super::{
     DecodeError, EncodeError,
     encoding::{DecodeContext, WireType, decode_key, encode_varint, encoded_len_varint, message},
 };
+use crate::pb::encoding::EncodeLengthContext;
 
 /// A Protocol Buffers message.
 pub trait Message: Debug + Send + Sync {

--- a/pilota/src/pb/mod.rs
+++ b/pilota/src/pb/mod.rs
@@ -9,6 +9,7 @@ mod types;
 pub mod encoding;
 
 use bytes::{BufMut, Bytes};
+pub use encoding::EncodeLengthContext;
 use encoding::{decode_varint, encode_varint, encoded_len_varint};
 pub use error::{DecodeError, EncodeError};
 pub use linkedbytes::LinkedBytes;
@@ -78,3 +79,12 @@ extern crate prost_derive;
 #[cfg(feature = "prost-derive")]
 #[doc(hidden)]
 pub use prost_derive::*;
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+// According to the benchmark, 1KB is the suitable threshold for zero-copy on
+// Apple Silicon.
+const ZERO_COPY_THRESHOLD: usize = 1024;
+
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+// While 4KB is better for other platforms (mainly amd64 linux).
+const ZERO_COPY_THRESHOLD: usize = 4 * 1024;

--- a/pilota/src/pb/types.rs
+++ b/pilota/src/pb/types.rs
@@ -11,8 +11,6 @@ use alloc::{string::String, vec::Vec};
 use ::bytes::Bytes;
 use linkedbytes::LinkedBytes;
 
-use crate::pb::ZERO_COPY_THRESHOLD;
-
 use super::{
     DecodeError, Message,
     encoding::{
@@ -20,6 +18,7 @@ use super::{
         skip_field, string, uint32, uint64,
     },
 };
+use crate::pb::ZERO_COPY_THRESHOLD;
 
 /// `google.protobuf.BoolValue`
 impl Message for bool {

--- a/pilota/src/pb/types.rs
+++ b/pilota/src/pb/types.rs
@@ -32,6 +32,7 @@ impl Message for bool {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             bool::merge(wire_type, self, buf, ctx)
@@ -57,6 +58,7 @@ impl Message for u32 {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             uint32::merge(wire_type, self, buf, ctx)
@@ -86,6 +88,7 @@ impl Message for u64 {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             uint64::merge(wire_type, self, buf, ctx)
@@ -115,6 +118,7 @@ impl Message for i32 {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             int32::merge(wire_type, self, buf, ctx)
@@ -144,6 +148,7 @@ impl Message for i64 {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             int64::merge(wire_type, self, buf, ctx)
@@ -173,6 +178,7 @@ impl Message for f32 {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             float::merge(wire_type, self, buf, ctx)
@@ -202,6 +208,7 @@ impl Message for f64 {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             double::merge(wire_type, self, buf, ctx)
@@ -231,6 +238,7 @@ impl Message for String {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             string::merge(wire_type, self, buf, ctx)
@@ -260,6 +268,7 @@ impl Message for Vec<u8> {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             bytes::merge(wire_type, self, buf, ctx)
@@ -289,6 +298,7 @@ impl Message for Bytes {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         if tag == 1 {
             bytes::merge(wire_type, self, buf, ctx)
@@ -314,6 +324,7 @@ impl Message for () {
         wire_type: WireType,
         buf: &mut Bytes,
         ctx: &mut DecodeContext,
+        _is_root: bool,
     ) -> Result<(), DecodeError> {
         skip_field(wire_type, tag, buf, ctx)
     }


### PR DESCRIPTION
## Motivation

The original short_circuit optimization mechanism cannot accurately determine whether reading is complete when reading non-consecutive unpacked encoded pb repeated fields.

## Solution

If a repeated field is read in the struct of the AST, this optimization mechanism should be removed.
