### PR TITLE
fix(pilota-build): disable short circuit when repeated field detected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "async-recursion"
@@ -190,18 +190,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -424,6 +424,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,12 +461,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.3"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -519,9 +525,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -660,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c178369371fd7db523726931e50d430b560e3059665abc537ba3277e9274c9c4"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
 dependencies = [
  "windows-sys 0.61.0",
 ]
@@ -972,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -1370,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1380,18 +1386,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1413,9 +1419,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
  "serde_core",
 ]
@@ -1490,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -1598,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1613,27 +1619,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tracing"
@@ -1781,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1794,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -1808,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1818,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1831,18 +1837,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/pilota-build/src/codegen/pb/mod.rs
+++ b/pilota-build/src/codegen/pb/mod.rs
@@ -433,11 +433,16 @@ impl CodegenBackend for ProtobufBackend {
             })
             .join("");
 
+        let mut has_repeated = false;
+
         let mut encode = s
             .fields
             .iter()
             .map(|field| {
                 let field_name = self.cx.rust_name(field.did);
+                if matches!(field.ty.kind, ty::TyKind::Vec(_)) {
+                    has_repeated = true;
+                }
                 self.codegen_encode(
                     format!("self.{field_name}").into(),
                     &field.ty,
@@ -451,7 +456,7 @@ impl CodegenBackend for ProtobufBackend {
         let keep = self.keep_unknown_fields.contains(&def_id);
 
         let mut inc_decoded_fields_num = String::new();
-        if keep {
+        if keep && !has_repeated {
             inc_decoded_fields_num = "if is_root { ctx.inc_root_decoded_fields_num(tag); }".into();
         }
 
@@ -489,7 +494,6 @@ impl CodegenBackend for ProtobufBackend {
             String::from("::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)");
 
         if keep {
-            let fields_num = s.fields.len() as u32;
             unknown_fields = r#"let mut _unknown_fields = &mut self._unknown_fields;"#;
             encoded_len.push_str(" + self._unknown_fields.size()");
             encode.push_str(
@@ -498,27 +502,30 @@ impl CodegenBackend for ProtobufBackend {
                 }"#,
             );
 
-            let tags_repr = s.fields.iter().flat_map(|f| self.field_tags(f)).join("|");
-            let tags_dismatch = if tags_repr.is_empty() {
-                "".into()
-            } else {
-                format!("&& !matches!(tag, {tags_repr})")
-            };
+            if !has_repeated {
+                let fields_num = s.fields.len() as u32;
+                let tags_repr = s.fields.iter().flat_map(|f| self.field_tags(f)).join("|");
+                let tags_dismatch = if tags_repr.is_empty() {
+                    "".into()
+                } else {
+                    format!("&& !matches!(tag, {tags_repr})")
+                };
 
-            short_circuit = format!(
-                r#"// short circuit
-                if is_root {tags_dismatch} && ctx.root_decoded_fields_num() == {fields_num} {{
-                    // advance buf
-                    let cur = buf.chunk().as_ptr();
-                    let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
-                    buf.advance(len);
+                short_circuit = format!(
+                    r#"// short circuit
+                    if is_root {tags_dismatch} && ctx.root_decoded_fields_num() == {fields_num} {{
+                        // advance buf
+                        let cur = buf.chunk().as_ptr();
+                        let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
+                        buf.advance(len);
 
-                    // read rest bytes
-                    let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
-                    _unknown_fields.push_back(val);
-                    return Ok(());
-                }}"#
-            );
+                        // read rest bytes
+                        let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
+                        _unknown_fields.push_back(val);
+                        return Ok(());
+                    }}"#
+                )
+            }
 
             skip_field = format!(
                 r#"{{

--- a/pilota-build/test_data/unknown_fields_pb.proto
+++ b/pilota-build/test_data/unknown_fields_pb.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 message A {
-  int32 a = 1;
+  repeated int32 a = 1;
 }
 
 message B {

--- a/pilota-build/test_data/unknown_fields_pb.rs
+++ b/pilota-build/test_data/unknown_fields_pb.rs
@@ -13,13 +13,13 @@ pub mod unknown_fields_pb {
         PartialEq,
     )]
     pub struct A {
-        pub a: i32,
+        pub a: ::std::vec::Vec<i32>,
         pub _unknown_fields: ::pilota::BytesVec,
     }
     impl ::pilota::prost::Message for A {
         #[inline]
         fn encoded_len(&self) -> usize {
-            0 + ::pilota::prost::encoding::int32::encoded_len(1, &self.a)
+            0 + ::pilota::prost::encoding::int32::encoded_len_repeated(1, &self.a)
                 + self._unknown_fields.size()
         }
 
@@ -28,7 +28,7 @@ pub mod unknown_fields_pb {
         where
             B: ::pilota::prost::bytes::BufMut,
         {
-            ::pilota::prost::encoding::int32::encode(1, &self.a, buf);
+            ::pilota::prost::encoding::int32::encode_repeated(1, &self.a, buf);
             for bytes in self._unknown_fields.list.iter() {
                 buf.put_slice(bytes.as_ref());
             }
@@ -51,7 +51,7 @@ pub mod unknown_fields_pb {
             match tag {
                 1 => {
                     let mut _inner_pilota_value = &mut self.a;
-                    ::pilota::prost::encoding::int32::merge(
+                    ::pilota::prost::encoding::int32::merge_repeated(
                         wire_type,
                         _inner_pilota_value,
                         buf,

--- a/pilota-build/test_data/unknown_fields_pb_new.rs
+++ b/pilota-build/test_data/unknown_fields_pb_new.rs
@@ -14,19 +14,19 @@ pub mod unknown_fields_pb_new {
         PartialEq,
     )]
     pub struct A {
-        pub a: i32,
+        pub a: ::std::vec::Vec<i32>,
         pub _unknown_fields: ::pilota::BytesVec,
     }
     impl ::pilota::pb::Message for A {
         #[inline]
         fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
-            0 + ::pilota::pb::encoding::int32::encoded_len(ctx, 1, &self.a)
+            0 + ::pilota::pb::encoding::int32::encoded_len_repeated(ctx, 1, &self.a)
                 + self._unknown_fields.size()
         }
 
         #[allow(unused_variables)]
         fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
-            ::pilota::pb::encoding::int32::encode(1, &self.a, buf);
+            ::pilota::pb::encoding::int32::encode_repeated(1, &self.a, buf);
             for bytes in self._unknown_fields.list.iter() {
                 buf.insert(bytes.clone());
             }
@@ -43,29 +43,20 @@ pub mod unknown_fields_pb_new {
         ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
             const STRUCT_NAME: &'static str = stringify!(A);
             let mut _unknown_fields = &mut self._unknown_fields;
-            // short circuit
-            if is_root && !matches!(tag, 1) && ctx.root_decoded_fields_num() == 1 {
-                // advance buf
-                let cur = buf.chunk().as_ptr();
-                let len = ctx.raw_bytes_len() - (cur as usize - ctx.raw_bytes_cursor());
-                buf.advance(len);
 
-                // read rest bytes
-                let val = ctx.raw_bytes_split_to(ctx.raw_bytes_len());
-                _unknown_fields.push_back(val);
-                return Ok(());
-            }
             match tag {
                 1 => {
-                    if is_root {
-                        ctx.inc_root_decoded_fields_num(tag);
-                    }
                     let mut _inner_pilota_value = &mut self.a;
-                    ::pilota::pb::encoding::int32::merge(wire_type, _inner_pilota_value, buf, ctx)
-                        .map_err(|mut error| {
-                            error.push(STRUCT_NAME, stringify!(a));
-                            error
-                        })
+                    ::pilota::pb::encoding::int32::merge_repeated(
+                        wire_type,
+                        _inner_pilota_value,
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(a));
+                        error
+                    })
                 }
                 _ => {
                     ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx)?;


### PR DESCRIPTION
## Motivation

The original short_circuit optimization mechanism cannot accurately determine whether reading is complete when reading non-consecutive unpacked encoded pb repeated fields.

## Solution

If a repeated field is read in the struct of the AST, this optimization mechanism should be removed.