### PR TITLE
Feat/codegen with comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
 dependencies = [
+ "concolor",
  "unicode-width",
  "yansi",
 ]
@@ -114,7 +115,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -131,6 +132,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -246,6 +253,26 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "concolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
+dependencies = [
+ "bitflags 1.3.2",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "criterion"
@@ -478,6 +505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,9 +560,20 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -786,7 +830,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -919,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-fieldmask"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ahash",
  "chumsky",
@@ -936,11 +980,13 @@ dependencies = [
 name = "pilota-thrift-parser"
 version = "0.12.2"
 dependencies = [
+ "anyhow",
  "ariadne",
  "bytes",
  "chumsky",
  "faststr",
  "nom",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1023,7 +1069,7 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -1213,7 +1259,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1321,7 +1367,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1334,7 +1380,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -1968,11 +2014,20 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1981,7 +2036,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1995,19 +2050,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2017,9 +2093,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2035,9 +2123,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2047,9 +2147,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,7 +934,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "ariadne",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -453,7 +453,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -573,7 +573,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -602,9 +602,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "6247da8b8658ad4e73a186e747fcc5fc2a29f979d6fe6269127fdb5fd08298d0"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1477,28 +1477,38 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seize"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b8d813387d566f627f3ea1b914c068aac94c40ae27ec43f5f33bde65abefe7"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1507,23 +1517,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1723,12 +1734,12 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
@@ -1738,11 +1749,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1829,9 +1840,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1900,27 +1911,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "4ad224d2776649cfb4f4471124f8176e54c1cca67a88108e30a0cd98b90e7ad3"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1931,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "3a1364104bdcd3c03f22b16a3b1c9620891469f5e9f09bc38b2db121e593e732"
 dependencies = [
  "bumpalo",
  "log",
@@ -1945,9 +1956,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "0d7ab4ca3e367bb1ed84ddbd83cc6e41e115f8337ed047239578210214e36c76"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1955,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "4a518014843a19e2dbbd0ed5dfb6b99b23fb886b14e6192a00803a3e14c552b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1968,18 +1979,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "255eb0aa4cc2eea3662a00c2bbd66e93911b7361d5e0fcd62385acfd7e15dcee"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "50462a022f46851b81d5441d1a6f5bac0b21a1d72d64bd4906fbdd4bf7230ec7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2177,9 +2188,9 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "ariadne"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,7 +114,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -156,10 +166,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chumsky"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14377e276b2c8300513dff55ba4cc4142b44e5d6de6d00eb5b2307d650bb4ec1"
+dependencies = [
+ "hashbrown 0.15.5",
+ "regex-automata 0.3.9",
+ "serde",
+ "stacker",
+ "unicode-ident",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "ciborium"
@@ -190,18 +224,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -323,12 +357,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -360,6 +394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,7 +426,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -454,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -518,9 +558,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -557,9 +597,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -573,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "matchers"
@@ -583,7 +623,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.10",
 ]
 
 [[package]]
@@ -659,11 +699,11 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
+checksum = "c178369371fd7db523726931e50d430b560e3059665abc537ba3277e9274c9c4"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -746,7 +786,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -840,6 +880,8 @@ version = "0.12.15"
 dependencies = [
  "ahash",
  "anyhow",
+ "ariadne",
+ "chumsky",
  "criterion",
  "dashmap",
  "diffy",
@@ -880,6 +922,7 @@ name = "pilota-thrift-fieldmask"
 version = "0.1.2"
 dependencies = [
  "ahash",
+ "chumsky",
  "faststr",
  "nom",
  "pilota",
@@ -893,7 +936,9 @@ dependencies = [
 name = "pilota-thrift-parser"
 version = "0.12.1"
 dependencies = [
+ "ariadne",
  "bytes",
+ "chumsky",
  "faststr",
  "nom",
 ]
@@ -904,6 +949,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "bytes",
+ "chumsky",
  "dashmap",
  "faststr",
  "pilota",
@@ -983,7 +1029,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.6",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1023,6 +1069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1169,8 +1224,19 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1181,8 +1247,14 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.6",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -1258,15 +1330,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1431,6 +1503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1531,19 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "syn"
@@ -1478,15 +1569,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1675,7 +1766,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata",
+ "regex-automata 0.4.10",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1695,6 +1786,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1751,30 +1854,40 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -1786,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1796,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1809,18 +1922,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1840,18 +1953,18 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -1859,7 +1972,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1868,16 +1981,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1886,31 +1999,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1920,22 +2016,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1944,22 +2028,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1968,22 +2040,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1992,22 +2052,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -2017,24 +2065,30 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 ahash = "0.8"
 anyhow = "1"
+ariadne = "0.5"
 async-recursion = "1"
 bytes = { version = "1", features = ["serde"] }
+chumsky = "0.10"
 criterion = { version = "0.7", features = ["html_reports"] }
 dashmap = "6"
 diffy = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 ahash = "0.8"
 anyhow = "1"
-ariadne = "0.5"
+ariadne = { version = "0.5", features = ["auto-color"] }
 async-recursion = "1"
 bytes = { version = "1", features = ["serde"] }
 chumsky = "0.10"

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -50,6 +50,8 @@ tracing-subscriber.workspace = true
 
 protobuf-parse.workspace = true
 protobuf.workspace = true
+chumsky.workspace = true
+ariadne.workspace = true
 
 [dev-dependencies]
 pilota-thrift-fieldmask = { path = "../pilota-thrift-fieldmask" }

--- a/pilota-build/examples/salsa_cache_demo.rs
+++ b/pilota-build/examples/salsa_cache_demo.rs
@@ -30,8 +30,10 @@ fn main() {
 
     // Create a service item
     let service = rir::Item::Service(rir::Service {
+        comments: Arc::new(String::new()),
         name: "TestService".into(),
         methods: vec![Arc::new(Method {
+            comments: Arc::new(String::new()),
             def_id: DefId::from_u32(1),
             name: "method1".into(),
             args: vec![],

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -562,7 +562,7 @@ where
             mods.iter()
                 .map(|(mod_path, items)| {
                     let collect_has_direct = items
-                        .into_iter()
+                        .iter()
                         .into_group_map_by(|CodegenItem { def_id, .. }| {
                             self.node(*def_id).unwrap().file_id
                         })
@@ -651,7 +651,7 @@ where
             }
 
             if this.split {
-                Self::write_split_mod(this, base_dir, p, &def_ids, &mut stream, &mut dup);
+                Self::write_split_mod(this, base_dir, p, def_ids, &mut stream, &mut dup);
             } else {
                 for def_id in def_ids.iter() {
                     this.write_item(&mut stream, *def_id, &mut dup)

--- a/pilota-build/src/codegen/pb/mod.rs
+++ b/pilota-build/src/codegen/pb/mod.rs
@@ -81,9 +81,9 @@ impl ProtobufBackend {
 
                 if let ty::TyKind::Vec(_) = &ty.kind {
                     let encoded_len_fn = if is_arc {
-                        format!("::pilota::pb::encoding::arc_message::encoded_len_repeated")
+                        "::pilota::pb::encoding::arc_message::encoded_len_repeated"
                     } else {
-                        format!("::pilota::pb::encoding::message::encoded_len_repeated")
+                        "::pilota::pb::encoding::message::encoded_len_repeated"
                     };
 
                     match kind {
@@ -671,9 +671,9 @@ impl CodegenBackend for ProtobufBackend {
                         .collect::<Vec<_>>()
                         .join("::");
                     if pkg == "google::protobuf" {
-                        deps_builders.push_str(&format!(
-                            "deps.push(::pilota::pb::descriptor::file_descriptor().clone());\n"
-                        ));
+                        deps_builders.push_str(
+                            "deps.push(::pilota::pb::descriptor::file_descriptor().clone());\n",
+                        );
                     } else if has_include_path && !pkg.is_empty() {
                         let dep_filename = self
                             .file_paths()

--- a/pilota-build/src/ir/mod.rs
+++ b/pilota-build/src/ir/mod.rs
@@ -102,6 +102,7 @@ pub struct ExceptionVariant {
 
 #[derive(Clone, Debug)]
 pub struct Method {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub args: Vec<Arg>,
     pub ret: Ty,
@@ -112,6 +113,7 @@ pub struct Method {
 
 #[derive(Clone, Debug)]
 pub struct Service {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub methods: Vec<Method>,
     pub extend: Vec<Path>,
@@ -119,6 +121,7 @@ pub struct Service {
 
 #[derive(Clone, Debug)]
 pub struct Const {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub ty: Ty,
     pub lit: Literal,
@@ -132,6 +135,7 @@ pub enum FieldKind {
 
 #[derive(Clone, Debug)]
 pub struct Field {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub id: i32,
     pub ty: Ty,
@@ -142,6 +146,7 @@ pub struct Field {
 
 #[derive(Clone, Debug)]
 pub struct Message {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub fields: Vec<Field>,
     pub is_wrapper: bool,
@@ -150,6 +155,7 @@ pub struct Message {
 
 #[derive(Clone, Debug)]
 pub struct EnumVariant {
+    pub comments: Arc<String>,
     pub id: Option<i32>,
     pub name: Ident,
     pub discr: Option<i64>,
@@ -159,6 +165,7 @@ pub struct EnumVariant {
 
 #[derive(Clone, Debug)]
 pub struct Enum {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub variants: Vec<EnumVariant>,
     pub repr: Option<EnumRepr>,
@@ -166,6 +173,7 @@ pub struct Enum {
 
 #[derive(Clone, Debug)]
 pub struct NewType {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub ty: Ty,
 }

--- a/pilota-build/src/middle/rir.rs
+++ b/pilota-build/src/middle/rir.rs
@@ -78,6 +78,7 @@ pub enum MethodSource {
 }
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Method {
+    pub comments: Arc<String>,
     pub def_id: DefId,
     pub name: Ident,
     pub args: Vec<Arc<Arg>>,
@@ -89,6 +90,7 @@ pub struct Method {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Service {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub methods: Vec<Arc<Method>>,
     pub extend: Vec<Path>,
@@ -96,6 +98,7 @@ pub struct Service {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Const {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub ty: Ty,
     pub lit: Literal,
@@ -109,6 +112,7 @@ pub enum FieldKind {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Field {
+    pub comments: Arc<String>,
     pub did: DefId,
     pub name: Ident,
     pub id: i32,
@@ -130,6 +134,7 @@ impl Field {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Message {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub fields: Vec<Arc<Field>>,
     pub is_wrapper: bool,
@@ -138,6 +143,7 @@ pub struct Message {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EnumVariant {
+    pub comments: Arc<String>,
     pub id: Option<i32>,
     pub did: DefId,
     pub name: Ident,
@@ -147,6 +153,7 @@ pub struct EnumVariant {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Enum {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub variants: Vec<Arc<EnumVariant>>,
     pub repr: Option<EnumRepr>,
@@ -154,6 +161,7 @@ pub struct Enum {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NewType {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub ty: Ty,
 }

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -230,11 +230,13 @@ impl Lower {
             related_items: Default::default(),
             tags: Arc::new(self.extract_enum_tags(e)),
             kind: ir::ItemKind::Enum(ir::Enum {
+                comments: Arc::new(String::new()),
                 name: FastStr::new(e.name()).into(),
                 variants: e
                     .value
                     .iter()
                     .map(|v| ir::EnumVariant {
+                        comments: Arc::new(String::new()),
                         id: v.number,
                         name: FastStr::new(v.name()).into(),
                         discr: v.number.map(|v| v as i64),
@@ -299,11 +301,13 @@ impl Lower {
                     related_items: Default::default(),
                     tags: Arc::new(crate::tags!(OneOf)),
                     kind: ir::ItemKind::Enum(ir::Enum {
+                        comments: Arc::new(String::new()),
                         name: FastStr::new(d.name()).into(),
                         repr: None,
                         variants: fields
                             .iter()
                             .map(|(_, f)| ir::EnumVariant {
+                                comments: Arc::new(String::new()),
                                 discr: None,
                                 id: f.number,
                                 name: FastStr::new(f.name()).into(),
@@ -322,6 +326,7 @@ impl Lower {
                 extra_fields.push((
                     fields[0].0,
                     ir::Field {
+                        comments: Arc::new(String::new()),
                         name: FastStr::new(d.name()).into(),
                         id: -1,
                         ty: ir::Ty {
@@ -363,6 +368,7 @@ impl Lower {
             related_items: Default::default(),
             tags: Arc::new(self.extract_message_tags(message)),
             kind: ir::ItemKind::Message(ir::Message {
+                comments: Arc::new(String::new()),
                 fields: fields
                     .iter()
                     .map(|(idx, f)| {
@@ -401,6 +407,7 @@ impl Lower {
                         (
                             *idx,
                             ir::Field {
+                                comments: Arc::new(String::new()),
                                 default: None,
                                 id: f.number(),
                                 name: FastStr::new(f.name()).into(),
@@ -461,6 +468,7 @@ impl Lower {
             tags: Arc::new(service_tags),
             related_items: Default::default(),
             kind: ir::ItemKind::Service(ir::Service {
+                comments: Arc::new(String::new()),
                 name: FastStr::new(service.name()).into(),
                 methods: service
                     .method
@@ -480,6 +488,7 @@ impl Lower {
                         }
 
                         ir::Method {
+                            comments: Arc::new(String::new()),
                             name: FastStr::new(m.name()).into(),
                             tags: Arc::new(tags),
                             args: vec![ir::Arg {
@@ -580,6 +589,7 @@ impl Lower {
                         related_items: Default::default(),
                         tags: Arc::new(Tags::default()),
                         kind: ir::ItemKind::Const(ir::Const {
+                            comments: Arc::new(String::new()),
                             name: FastStr::new(format!("__PILOTA_PB_EXT_{}", file_id.as_u32()))
                                 .into(),
                             ty: ir::Ty {

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -773,7 +773,7 @@ impl Parser for ProtobufParser {
             files,
             input_files: input_file_ids,
             file_ids_map: file_ids,
-            file_paths: file_paths,
+            file_paths,
         }
     }
 }

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -1,13 +1,13 @@
+use ariadne::{Color, Label, Report, ReportKind, Source};
+use chumsky::prelude::*;
+use core::panic;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use faststr::FastStr;
 use heck::ToUpperCamelCase;
 use itertools::Itertools;
 use normpath::PathExt;
-use pilota_thrift_parser::{
-    parser::Parser as _,
-    {self as thrift_parser},
-};
+use pilota_thrift_parser::{self as thrift_parser};
 use pilota_thrift_reflect::thrift_reflection;
 use rustc_hash::{FxHashMap, FxHashSet};
 use thrift_parser::Annotations;
@@ -42,11 +42,31 @@ impl ThriftSourceDatabase {
 
     fn parse(&self, path: PathBuf) -> Arc<thrift_parser::File> {
         let text = self.file_text(path.clone());
-        let res = thrift_parser::File::parse(&text);
-        if res.is_err() {
-            println!("cargo:warning={}", path.display());
+        let (res, errs) = thrift_parser::parser::thrift::file()
+            .parse(&text)
+            .into_output_errors();
+
+        if !errs.is_empty() {
+            errs.into_iter().for_each(|e| {
+                Report::build(
+                    ReportKind::Error,
+                    (path.to_str().unwrap(), e.span().into_range()),
+                )
+                .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
+                .with_message(e.to_string())
+                .with_label(
+                    Label::new((path.to_str().unwrap(), e.span().into_range()))
+                        .with_message(e.reason().to_string())
+                        .with_color(Color::Red),
+                )
+                .finish()
+                .print((path.to_str().unwrap(), Source::from(&text)))
+                .unwrap()
+            });
+            panic!("thrift file parse failed");
         }
-        let mut ast = res.unwrap().1;
+
+        let mut ast = res.unwrap();
         ast.path = Arc::from(path);
         ast.uuid = generate_short_uuid();
         let descriptor = thrift_reflection::FileDescriptor::from(&ast);

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -46,22 +46,20 @@ impl ThriftSourceDatabase {
             .parse(&text)
             .into_output_errors();
 
+        let path_str = &path.display().to_string();
         if !errs.is_empty() {
             errs.into_iter().for_each(|e| {
-                Report::build(
-                    ReportKind::Error,
-                    (path.to_str().unwrap(), e.span().into_range()),
-                )
-                .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
-                .with_message(e.to_string())
-                .with_label(
-                    Label::new((path.to_str().unwrap(), e.span().into_range()))
-                        .with_message(e.reason().to_string())
-                        .with_color(Color::Red),
-                )
-                .finish()
-                .print((path.to_str().unwrap(), Source::from(&text)))
-                .unwrap()
+                Report::build(ReportKind::Error, (path_str, e.span().into_range()))
+                    .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
+                    .with_message(e.to_string())
+                    .with_label(
+                        Label::new((path_str, e.span().into_range()))
+                            .with_message(e.reason().to_string())
+                            .with_color(Color::Red),
+                    )
+                    .finish()
+                    .print((path_str, Source::from(&text)))
+                    .unwrap()
             });
             panic!("thrift file parse failed");
         }

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -1,8 +1,6 @@
 use core::panic;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
-use ariadne::{Color, Label, Report, ReportKind, Source};
-use chumsky::prelude::*;
 use faststr::FastStr;
 use heck::ToUpperCamelCase;
 use itertools::Itertools;
@@ -42,26 +40,14 @@ impl ThriftSourceDatabase {
 
     fn parse(&self, path: PathBuf) -> Arc<thrift_parser::File> {
         let text = self.file_text(path.clone());
-        let (res, errs) = thrift_parser::descriptor::File::parse()
-            .parse(&text)
-            .into_output_errors();
+        let res = thrift_parser::FileParser::new(
+            thrift_parser::FileSource::new_with_path(path.clone(), text.as_ref()).unwrap(),
+        )
+        .parse();
 
-        let path_str = &path.display().to_string();
-        if !errs.is_empty() {
-            errs.into_iter().for_each(|e| {
-                Report::build(ReportKind::Error, (path_str, e.span().into_range()))
-                    .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
-                    .with_message(e.to_string())
-                    .with_label(
-                        Label::new((path_str, e.span().into_range()))
-                            .with_message(e.reason().to_string())
-                            .with_color(Color::Red),
-                    )
-                    .finish()
-                    .print((path_str, Source::from(&text)))
-                    .unwrap()
-            });
-            panic!("thrift file parse failed");
+        if res.is_err() {
+            eprintln!("{}", res.err().unwrap());
+            std::process::exit(1);
         }
 
         let mut ast = res.unwrap();

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -42,7 +42,7 @@ impl ThriftSourceDatabase {
 
     fn parse(&self, path: PathBuf) -> Arc<thrift_parser::File> {
         let text = self.file_text(path.clone());
-        let (res, errs) = thrift_parser::parser::thrift::file()
+        let (res, errs) = thrift_parser::descriptor::File::parse()
             .parse(&text)
             .into_output_errors();
 

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -1,8 +1,8 @@
-use ariadne::{Color, Label, Report, ReportKind, Source};
-use chumsky::prelude::*;
 use core::panic;
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
+use ariadne::{Color, Label, Report, ReportKind, Source};
+use chumsky::prelude::*;
 use faststr::FastStr;
 use heck::ToUpperCamelCase;
 use itertools::Itertools;

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -375,7 +375,10 @@ impl Resolver {
             kind = FieldKind::Optional;
         }
 
+        let comments = f.comments.clone();
+
         let f = Arc::from(Field {
+            comments,
             did,
             id: f.id,
             kind,
@@ -592,6 +595,7 @@ impl Resolver {
     #[tracing::instrument(level = "debug", skip(self, s), fields(name = &**s.name))]
     fn lower_message(&mut self, s: &ir::Message) -> Message {
         Message {
+            comments: s.comments.clone(),
             name: s.name.clone(),
             fields: s.fields.iter().map(|f| self.lower_field(f)).collect(),
             is_wrapper: s.is_wrapper,
@@ -606,6 +610,7 @@ impl Resolver {
     fn lower_enum(&mut self, e: &ir::Enum) -> Enum {
         let mut next_discr = 0;
         Enum {
+            comments: e.comments.clone(),
             name: e.name.clone(),
             variants: e
                 .variants
@@ -618,6 +623,7 @@ impl Resolver {
                     }
                     let discr = v.discr.unwrap_or(next_discr);
                     let e = Arc::from(EnumVariant {
+                        comments: v.comments.clone(),
                         id: v.id,
                         did,
                         name: v.name.clone(),
@@ -647,6 +653,7 @@ impl Resolver {
 
     fn lower_service(&mut self, s: &ir::Service) -> Service {
         Service {
+            comments: s.comments.clone(),
             name: s.name.clone(),
             methods: s
                 .methods
@@ -657,6 +664,7 @@ impl Resolver {
                     self.tags.insert(tags_id, m.tags.clone());
                     let old_parent = self.parent_node.replace(def_id);
                     let method = Arc::from(Method {
+                        comments: m.comments.clone(),
                         def_id,
                         source: MethodSource::Own,
                         name: m.name.clone(),
@@ -711,6 +719,7 @@ impl Resolver {
 
     fn lower_type_alias(&mut self, t: &ir::NewType, tags: &Tags) -> NewType {
         NewType {
+            comments: t.comments.clone(),
             name: t.name.clone(),
             ty: {
                 let ty = self.lower_type(&t.ty, false);
@@ -737,6 +746,7 @@ impl Resolver {
 
     fn lower_const(&mut self, c: &ir::Const, tags: &Tags) -> Const {
         Const {
+            comments: c.comments.clone(),
             name: c.name.clone(),
             ty: {
                 let ty = self.lower_type(&c.ty, false);

--- a/pilota-build/test_data/thrift/apache.rs
+++ b/pilota-build/test_data/thrift/apache.rs
@@ -7,6 +7,9 @@ pub mod apache {
 
             pub mod test {
 
+                /**
+                 * Docstring!
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
                 #[repr(transparent)]
                 pub struct Numberz(i32);
@@ -570,6 +573,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI32ArgsSend {
                     pub thing: i32,
@@ -735,6 +743,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param set<i32> thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestSetArgsRecv {
                     pub thing: ::pilota::AHashSet<i32>,
@@ -927,6 +941,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionException {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionException::Err1(
@@ -1129,6 +1152,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestVoidArgsSend {}
                 impl ::pilota::thrift::Message for ThriftTestTestVoidArgsSend {
@@ -1260,6 +1286,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStructArgsRecv {
                     pub thing: Xtruct,
@@ -1430,6 +1461,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMultiResultRecv::Ok(::std::default::Default::default())
@@ -1437,6 +1480,17 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiResultRecv {
+                    /**
+                     * Prints 'testMulti()'
+                     * @param i8 arg0 -
+                     * @param i32 arg1 -
+                     * @param i64 arg2 -
+                     * @param map<i16, string> arg3 -
+                     * @param Numberz arg4 -
+                     * @param UserId arg5 -
+                     * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                     *    and i64_thing = arg2
+                     */
                     Ok(Xtruct),
                 }
 
@@ -1767,6 +1821,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI64ArgsRecv {
                     pub thing: i64,
@@ -1932,6 +1991,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                 * @param Numberz thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestEnumResultRecv {
                     fn default() -> Self {
                         ThriftTestTestEnumResultRecv::Ok(::std::default::Default::default())
@@ -1939,6 +2004,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestEnumResultRecv {
+                    /**
+                     * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                     * @param Numberz thing - the Numberz to print
+                     * @return Numberz - returns the Numberz 'thing'
+                     */
                     Ok(Numberz),
                 }
 
@@ -2082,6 +2152,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                 * sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                 * @param i32 secondsToSleep - the number of seconds to sleep
+                 */
+
                 impl ::std::default::Default for ThriftTestTestOnewayResultSend {
                     fn default() -> Self {
                         ThriftTestTestOnewayResultSend::Ok(::std::default::Default::default())
@@ -2089,6 +2166,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestOnewayResultSend {
+                    /**
+                     * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                     * sleep 'secondsToSleep'
+                     * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                     * @param i32 secondsToSleep - the number of seconds to sleep
+                     */
                     Ok(()),
                 }
 
@@ -2194,6 +2277,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringArgsRecv {
                     pub thing: ::pilota::FastStr,
@@ -2359,6 +2447,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMapResultRecv::Ok(::std::default::Default::default())
@@ -2366,6 +2461,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapResultRecv {
+                    /**
+                     * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<i32,i32> thing - the map<i32,i32> to print
+                     * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                     */
                     Ok(::pilota::AHashMap<i32, i32>),
                 }
 
@@ -2780,6 +2881,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                 * @param binary  thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBinaryResultRecv {
                     fn default() -> Self {
                         ThriftTestTestBinaryResultRecv::Ok(::std::default::Default::default())
@@ -2787,6 +2894,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBinaryResultRecv {
+                    /**
+                     * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                     * @param binary  thing - the binary data to print
+                     * @return binary  - returns the binary 'thing'
+                     */
                     Ok(::pilota::Bytes),
                 }
 
@@ -2930,6 +3042,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for SecondServiceSecondtestStringResultSend {
                     fn default() -> Self {
                         SecondServiceSecondtestStringResultSend::Ok(
@@ -2939,6 +3057,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum SecondServiceSecondtestStringResultSend {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -3085,6 +3208,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                 * @param byte thing - the i8/byte to print
+                 * @return i8 - returns the i8/byte 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestByteResultRecv {
                     fn default() -> Self {
                         ThriftTestTestByteResultRecv::Ok(::std::default::Default::default())
@@ -3092,6 +3222,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestByteResultRecv {
+                    /**
+                     * Prints 'testByte("%d")' with thing as '%d'
+                     * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                     * @param byte thing - the i8/byte to print
+                     * @return i8 - returns the i8/byte 'thing'
+                     */
                     Ok(i8),
                 }
 
@@ -3234,6 +3370,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestExceptionArgsSend {
                     pub arg: ::pilota::FastStr,
@@ -3399,6 +3542,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                 *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestMapMapResultSend::Ok(::std::default::Default::default())
@@ -3406,6 +3556,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapMapResultSend {
+                    /**
+                     * Prints 'testMapMap("%d")' with hello as '%d'
+                     * @param i32 hello - the i32 to print
+                     * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                     *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                     */
                     Ok(::pilota::AHashMap<i32, ::pilota::AHashMap<i32, i32>>),
                 }
 
@@ -3857,6 +4013,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param set<i32> thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestSetResultSend {
                     fn default() -> Self {
                         ThriftTestTestSetResultSend::Ok(::std::default::Default::default())
@@ -3864,6 +4027,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestSetResultSend {
+                    /**
+                     * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param set<i32> thing - the set<i32> to print
+                     * @return set<i32> - returns the set<i32> 'thing'
+                     */
                     Ok(::pilota::AHashSet<i32>),
                 }
 
@@ -4041,6 +4210,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStructResultSend {
                     fn default() -> Self {
                         ThriftTestTestStructResultSend::Ok(::std::default::Default::default())
@@ -4048,6 +4223,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStructResultSend {
+                    /**
+                     * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                     * @param Xtruct thing - the Xtruct to print
+                     * @return Xtruct - returns the Xtruct 'thing'
+                     */
                     Ok(Xtruct),
                 }
 
@@ -4632,6 +4812,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI64ResultSend {
                     fn default() -> Self {
                         ThriftTestTestI64ResultSend::Ok(::std::default::Default::default())
@@ -4639,6 +4825,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI64ResultSend {
+                    /**
+                     * Prints 'testI64("%d")' with thing as '%d'
+                     * @param i64 thing - the i64 to print
+                     * @return i64 - returns the i64 'thing'
+                     */
                     Ok(i64),
                 }
 
@@ -4781,6 +4972,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiExceptionArgsRecv {
                     pub arg0: ::pilota::FastStr,
@@ -4983,6 +5182,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringResultSend {
                     fn default() -> Self {
                         ThriftTestTestStringResultSend::Ok(::std::default::Default::default())
@@ -4990,6 +5195,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringResultSend {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -5133,6 +5343,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiArgsSend {
                     pub arg0: i8,
@@ -5705,6 +5926,7 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub struct OptionalBinary {
+                    //1: optional set<binary> bin_set = []
                     pub bin_map: ::std::option::Option<::pilota::AHashMap<::pilota::Bytes, i32>>,
                 }
                 impl ::pilota::thrift::Message for OptionalBinary {
@@ -5912,6 +6134,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                 * @param Numberz thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestEnumArgsSend {
                     pub thing: Numberz,
@@ -6079,6 +6306,13 @@ pub mod apache {
                     }
                 }
                 pub trait ThriftTest {}
+
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapArgsSend {
                     pub thing: ::pilota::AHashMap<i32, i32>,
@@ -6283,6 +6517,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                 * @param binary  thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBinaryArgsSend {
                     pub thing: ::pilota::Bytes,
@@ -6448,6 +6687,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestTypedefArgsRecv {
                     pub thing: UserId,
@@ -6619,6 +6863,13 @@ pub mod apache {
                     }
                 }
                 pub trait SecondService {}
+
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                 * @param byte thing - the i8/byte to print
+                 * @return i8 - returns the i8/byte 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestByteArgsSend {
                     pub thing: i8,
@@ -6784,6 +7035,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string> to print
+                 * @return map<string,string> - returns the map<string,string> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringMapArgsRecv {
                     pub thing: ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
@@ -7122,6 +7379,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestUuidArgsRecv {
                     pub thing: [u8; 16],
@@ -7287,6 +7549,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                 */
+
                 impl ::std::default::Default for ThriftTestTestInsanityResultRecv {
                     fn default() -> Self {
                         ThriftTestTestInsanityResultRecv::Ok(::std::default::Default::default())
@@ -7294,6 +7568,17 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestInsanityResultRecv {
+                    /**
+                     * So you think you've got this all worked out, eh?
+                     *
+                     * Creates a map with these values and prints it out:
+                     *   { 1 => { 2 => argument,
+                     *            3 => argument,
+                     *          },
+                     *     2 => { 6 => <empty Insanity struct>, },
+                     *   }
+                     * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                     */
                     Ok(::pilota::AHashMap<UserId, ::pilota::AHashMap<Numberz, Insanity>>),
                 }
 
@@ -7757,6 +8042,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI32ArgsRecv {
                     pub thing: i32,
@@ -7922,6 +8212,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param list<i32> thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestListResultRecv {
                     fn default() -> Self {
                         ThriftTestTestListResultRecv::Ok(::std::default::Default::default())
@@ -7929,6 +8226,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestListResultRecv {
+                    /**
+                     * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param list<i32> thing - the list<i32> to print
+                     * @return list<i32> - returns the list<i32> 'thing'
+                     */
                     Ok(::std::vec::Vec<i32>),
                 }
 
@@ -8108,6 +8411,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestVoidArgsRecv {}
                 impl ::pilota::thrift::Message for ThriftTestTestVoidArgsRecv {
@@ -8239,6 +8545,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                 * @param Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestNestResultRecv {
                     fn default() -> Self {
                         ThriftTestTestNestResultRecv::Ok(::std::default::Default::default())
@@ -8246,6 +8558,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestNestResultRecv {
+                    /**
+                     * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                     * @param Xtruct2 thing - the Xtruct2 to print
+                     * @return Xtruct2 - returns the Xtruct2 'thing'
+                     */
                     Ok(Xtruct2),
                 }
 
@@ -8393,6 +8710,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                // the following is expected to fail:
+
+                // const Numberz urNumberz = ONE;
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct UserId(pub i64);
 
@@ -8624,6 +8944,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestDoubleResultRecv {
                     fn default() -> Self {
                         ThriftTestTestDoubleResultRecv::Ok(::std::default::Default::default())
@@ -8631,6 +8957,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestDoubleResultRecv {
+                    /**
+                     * Prints 'testDouble("%f")' with thing as '%f'
+                     * @param double thing - the double to print
+                     * @return double - returns the double 'thing'
+                     */
                     Ok(f64),
                 }
 
@@ -8774,6 +9105,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                 * @param bool  thing - the bool data to print
+                 * @return bool  - returns the bool 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBoolResultRecv {
                     fn default() -> Self {
                         ThriftTestTestBoolResultRecv::Ok(::std::default::Default::default())
@@ -8781,6 +9118,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBoolResultRecv {
+                    /**
+                     * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                     * @param bool  thing - the bool data to print
+                     * @return bool  - returns the bool 'thing'
+                     */
                     Ok(bool),
                 }
 
@@ -9171,6 +9513,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestTypedefResultSend {
                     fn default() -> Self {
                         ThriftTestTestTypedefResultSend::Ok(::std::default::Default::default())
@@ -9178,6 +9526,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestTypedefResultSend {
+                    /**
+                     * Prints 'testTypedef("%d")' with thing as '%d'
+                     * @param UserId thing - the UserId to print
+                     * @return UserId - returns the UserId 'thing'
+                     */
                     Ok(UserId),
                 }
 
@@ -9327,6 +9680,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string> to print
+                 * @return map<string,string> - returns the map<string,string> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestStringMapResultSend::Ok(::std::default::Default::default())
@@ -9334,6 +9694,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringMapResultSend {
+                    /**
+                     * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<string,string> thing - the map<string,string> to print
+                     * @return map<string,string> - returns the map<string,string> 'thing'
+                     */
                     Ok(::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>),
                 }
 
@@ -9529,6 +9895,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestExceptionArgsRecv {
                     pub arg: ::pilota::FastStr,
@@ -9694,6 +10067,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestUuidResultSend {
                     fn default() -> Self {
                         ThriftTestTestUuidResultSend::Ok(::std::default::Default::default())
@@ -9701,6 +10080,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestUuidResultSend {
+                    /**
+                     * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                     * @param uuid  thing - the uuid to print
+                     * @return uuid  - returns the uuid 'thing'
+                     */
                     Ok([u8; 16]),
                 }
 
@@ -10052,6 +10436,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI32ResultSend {
                     fn default() -> Self {
                         ThriftTestTestI32ResultSend::Ok(::std::default::Default::default())
@@ -10059,6 +10449,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI32ResultSend {
+                    /**
+                     * Prints 'testI32("%d")' with thing as '%d'
+                     * @param i32 thing - the i32 to print
+                     * @return i32 - returns the i32 'thing'
+                     */
                     Ok(i32),
                 }
 
@@ -10201,6 +10596,10 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
+
                 impl ::std::default::Default for ThriftTestTestVoidResultSend {
                     fn default() -> Self {
                         ThriftTestTestVoidResultSend::Ok(::std::default::Default::default())
@@ -10208,6 +10607,9 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestVoidResultSend {
+                    /**
+                     * Prints "testVoid()" and returns nothing.
+                     */
                     Ok(()),
                 }
 
@@ -10313,6 +10715,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestInsanityArgsSend {
                     pub argument: Insanity,
@@ -10668,6 +11081,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param list<i32> thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestListArgsSend {
                     pub thing: ::std::vec::Vec<i32>,
@@ -10865,6 +11284,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                 * sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                 * @param i32 secondsToSleep - the number of seconds to sleep
+                 */
+
                 impl ::std::default::Default for ThriftTestTestOnewayResultRecv {
                     fn default() -> Self {
                         ThriftTestTestOnewayResultRecv::Ok(::std::default::Default::default())
@@ -10872,6 +11298,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestOnewayResultRecv {
+                    /**
+                     * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                     * sleep 'secondsToSleep'
+                     * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                     * @param i32 secondsToSleep - the number of seconds to sleep
+                     */
                     Ok(()),
                 }
 
@@ -10977,6 +11409,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                 * @param Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestNestArgsSend {
                     pub thing: Xtruct2,
@@ -11147,6 +11584,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiArgsRecv {
                     pub arg0: i8,
@@ -11750,6 +12198,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
                 #[derive(PartialOrd, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestDoubleArgsSend {
                     pub thing: f64,
@@ -11915,6 +12368,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                 * @param Numberz thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestEnumArgsRecv {
                     pub thing: Numberz,
@@ -12081,6 +12539,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for SecondServiceSecondtestStringResultRecv {
                     fn default() -> Self {
                         SecondServiceSecondtestStringResultRecv::Ok(
@@ -12090,6 +12554,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum SecondServiceSecondtestStringResultRecv {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -12236,6 +12705,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                 * @param bool  thing - the bool data to print
+                 * @return bool  - returns the bool 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBoolArgsSend {
                     pub thing: bool,
@@ -12401,6 +12875,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapArgsRecv {
                     pub thing: ::pilota::AHashMap<i32, i32>,
@@ -12605,6 +13085,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionException {
                     fn default() -> Self {
                         ThriftTestTestExceptionException::Err1(::std::default::Default::default())
@@ -12762,6 +13250,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                 * @param binary  thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBinaryArgsRecv {
                     pub thing: ::pilota::Bytes,
@@ -12927,6 +13420,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                 *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMapMapResultRecv::Ok(::std::default::Default::default())
@@ -12934,6 +13434,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapMapResultRecv {
+                    /**
+                     * Prints 'testMapMap("%d")' with hello as '%d'
+                     * @param i32 hello - the i32 to print
+                     * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                     *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                     */
                     Ok(::pilota::AHashMap<i32, ::pilota::AHashMap<i32, i32>>),
                 }
 
@@ -13376,6 +13882,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                 * @param byte thing - the i8/byte to print
+                 * @return i8 - returns the i8/byte 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestByteArgsRecv {
                     pub thing: i8,
@@ -13541,6 +14053,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param set<i32> thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestSetResultRecv {
                     fn default() -> Self {
                         ThriftTestTestSetResultRecv::Ok(::std::default::Default::default())
@@ -13548,6 +14067,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestSetResultRecv {
+                    /**
+                     * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param set<i32> thing - the set<i32> to print
+                     * @return set<i32> - returns the set<i32> 'thing'
+                     */
                     Ok(::pilota::AHashSet<i32>),
                 }
 
@@ -13883,6 +14408,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStructResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStructResultRecv::Ok(::std::default::Default::default())
@@ -13890,6 +14421,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStructResultRecv {
+                    /**
+                     * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                     * @param Xtruct thing - the Xtruct to print
+                     * @return Xtruct - returns the Xtruct 'thing'
+                     */
                     Ok(Xtruct),
                 }
 
@@ -14298,6 +14834,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI64ResultRecv {
                     fn default() -> Self {
                         ThriftTestTestI64ResultRecv::Ok(::std::default::Default::default())
@@ -14305,6 +14847,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI64ResultRecv {
+                    /**
+                     * Prints 'testI64("%d")' with thing as '%d'
+                     * @param i64 thing - the i64 to print
+                     * @return i64 - returns the i64 'thing'
+                     */
                     Ok(i64),
                 }
 
@@ -14447,6 +14994,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStringResultRecv::Ok(::std::default::Default::default())
@@ -14454,6 +15007,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringResultRecv {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -14597,6 +15155,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiResultSend {
                     fn default() -> Self {
                         ThriftTestTestMultiResultSend::Ok(::std::default::Default::default())
@@ -14604,6 +15174,17 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiResultSend {
+                    /**
+                     * Prints 'testMulti()'
+                     * @param i8 arg0 -
+                     * @param i32 arg1 -
+                     * @param i64 arg2 -
+                     * @param map<i16, string> arg3 -
+                     * @param Numberz arg4 -
+                     * @param UserId arg5 -
+                     * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+                     *    and i64_thing = arg2
+                     */
                     Ok(Xtruct),
                 }
 
@@ -15133,6 +15714,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                 * @param Numberz thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestEnumResultSend {
                     fn default() -> Self {
                         ThriftTestTestEnumResultSend::Ok(::std::default::Default::default())
@@ -15140,6 +15727,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestEnumResultSend {
+                    /**
+                     * Prints 'testEnum("%d")' where thing has been formatted into its numeric value
+                     * @param Numberz thing - the Numberz to print
+                     * @return Numberz - returns the Numberz 'thing'
+                     */
                     Ok(Numberz),
                 }
 
@@ -15283,6 +15875,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                 * sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                 * @param i32 secondsToSleep - the number of seconds to sleep
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestOnewayArgsSend {
                     pub seconds_to_sleep: i32,
@@ -15452,6 +16050,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestMapResultSend::Ok(::std::default::Default::default())
@@ -15459,6 +16064,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapResultSend {
+                    /**
+                     * Prints 'testMap("{%s")' where thing has been formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<i32,i32> thing - the map<i32,i32> to print
+                     * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                     */
                     Ok(::pilota::AHashMap<i32, i32>),
                 }
 
@@ -15650,6 +16261,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionResultSend {
                     fn default() -> Self {
                         ThriftTestTestExceptionResultSend::Ok(::std::default::Default::default())
@@ -15657,6 +16276,13 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestExceptionResultSend {
+                    /**
+                     * Print 'testException(%s)' with arg as '%s'
+                     * @param string arg - a string indication what type of exception to throw
+                     * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                     * else if arg == "TException" throw TException
+                     * else do not throw anything
+                     */
                     Ok(()),
 
                     Err1(Xception),
@@ -15809,6 +16435,7 @@ pub mod apache {
 
                     pub set_field: ::std::option::Option<::pilota::AHashSet<Insanity>>,
 
+                    // Do not insert line break as test/go/Makefile.am is removing this line with pattern match
                     pub list_field: ::std::vec::Vec<
                         ::std::collections::BTreeMap<
                             ::std::collections::BTreeSet<i32>,
@@ -16255,6 +16882,12 @@ pub mod apache {
                     }) +self.binary_field.as_ref().map_or(0, |value| __protocol.bytes_field_len(Some(4), value)) +self.uuid_field.as_ref().map_or(0, |value| __protocol.uuid_field_len(Some(5), *value) ) + __protocol.field_stop_len() + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                 * @param binary  thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBinaryResultSend {
                     fn default() -> Self {
                         ThriftTestTestBinaryResultSend::Ok(::std::default::Default::default())
@@ -16262,6 +16895,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBinaryResultSend {
+                    /**
+                     * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+                     * @param binary  thing - the binary data to print
+                     * @return binary  - returns the binary 'thing'
+                     */
                     Ok(::pilota::Bytes),
                 }
 
@@ -16405,6 +17043,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct SecondServiceSecondtestStringArgsSend {
                     pub thing: ::pilota::FastStr,
@@ -16570,6 +17213,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                 * @param byte thing - the i8/byte to print
+                 * @return i8 - returns the i8/byte 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestByteResultSend {
                     fn default() -> Self {
                         ThriftTestTestByteResultSend::Ok(::std::default::Default::default())
@@ -16577,6 +17227,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestByteResultSend {
+                    /**
+                     * Prints 'testByte("%d")' with thing as '%d'
+                     * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+                     * @param byte thing - the i8/byte to print
+                     * @return i8 - returns the i8/byte 'thing'
+                     */
                     Ok(i8),
                 }
 
@@ -16719,6 +17375,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionResultRecv::Ok(
@@ -16728,6 +17393,14 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiExceptionResultRecv {
+                    /**
+                     * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                     * @param string arg - a string indicating what type of exception to throw
+                     * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                     * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                     * else do not throw anything
+                     * @return Xtruct - an Xtruct with string_thing = arg1
+                     */
                     Ok(Xtruct),
 
                     Err1(Xception),
@@ -17141,6 +17814,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                 *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapMapArgsSend {
                     pub hello: i32,
@@ -17498,6 +18177,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param set<i32> thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestSetArgsSend {
                     pub thing: ::pilota::AHashSet<i32>,
@@ -17690,6 +18375,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStructArgsSend {
                     pub thing: Xtruct,
@@ -17860,6 +18550,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestInsanityArgsRecv {
                     pub argument: Insanity,
@@ -18274,6 +18975,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI64ArgsSend {
                     pub thing: i64,
@@ -18439,6 +19145,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param list<i32> thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestListArgsRecv {
                     pub thing: ::std::vec::Vec<i32>,
@@ -18636,6 +19348,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringArgsSend {
                     pub thing: ::pilota::FastStr,
@@ -18801,6 +19518,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                 * @param Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestNestArgsRecv {
                     pub thing: Xtruct2,
@@ -18971,6 +19693,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of exception to throw
+                 * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionResultRecv {
                     fn default() -> Self {
                         ThriftTestTestExceptionResultRecv::Ok(::std::default::Default::default())
@@ -18978,6 +19708,13 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestExceptionResultRecv {
+                    /**
+                     * Print 'testException(%s)' with arg as '%s'
+                     * @param string arg - a string indication what type of exception to throw
+                     * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+                     * else if arg == "TException" throw TException
+                     * else do not throw anything
+                     */
                     Ok(()),
 
                     Err1(Xception),
@@ -19128,6 +19865,7 @@ pub mod apache {
                 pub struct Xtruct2 {
                     pub byte_thing: ::std::option::Option<i8>,
 
+                    // used to be byte, hence the name
                     pub struct_thing: ::std::option::Option<Xtruct>,
 
                     pub i32_thing: ::std::option::Option<i32>,
@@ -19330,6 +20068,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
                 #[derive(PartialOrd, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestDoubleArgsRecv {
                     pub thing: f64,
@@ -19495,6 +20238,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestTypedefResultRecv {
                     fn default() -> Self {
                         ThriftTestTestTypedefResultRecv::Ok(::std::default::Default::default())
@@ -19502,6 +20251,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestTypedefResultRecv {
+                    /**
+                     * Prints 'testTypedef("%d")' with thing as '%d'
+                     * @param UserId thing - the UserId to print
+                     * @return UserId - returns the UserId 'thing'
+                     */
                     Ok(UserId),
                 }
 
@@ -19651,6 +20405,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                 * @param bool  thing - the bool data to print
+                 * @return bool  - returns the bool 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBoolArgsRecv {
                     pub thing: bool,
@@ -19816,6 +20575,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string> to print
+                 * @return map<string,string> - returns the map<string,string> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStringMapResultRecv::Ok(::std::default::Default::default())
@@ -19823,6 +20589,12 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringMapResultRecv {
+                    /**
+                     * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<string,string> thing - the map<string,string> to print
+                     * @return map<string,string> - returns the map<string,string> 'thing'
+                     */
                     Ok(::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>),
                 }
 
@@ -20018,6 +20790,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestUuidResultRecv {
                     fn default() -> Self {
                         ThriftTestTestUuidResultRecv::Ok(::std::default::Default::default())
@@ -20025,6 +20803,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestUuidResultRecv {
+                    /**
+                     * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                     * @param uuid  thing - the uuid to print
+                     * @return uuid  - returns the uuid 'thing'
+                     */
                     Ok([u8; 16]),
                 }
 
@@ -20668,6 +21451,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI32ResultRecv {
                     fn default() -> Self {
                         ThriftTestTestI32ResultRecv::Ok(::std::default::Default::default())
@@ -20675,6 +21464,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI32ResultRecv {
+                    /**
+                     * Prints 'testI32("%d")' with thing as '%d'
+                     * @param i32 thing - the i32 to print
+                     * @return i32 - returns the i32 'thing'
+                     */
                     Ok(i32),
                 }
 
@@ -20817,6 +21611,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionResultSend {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionResultSend::Ok(
@@ -20826,6 +21629,14 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiExceptionResultSend {
+                    /**
+                     * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                     * @param string arg - a string indicating what type of exception to throw
+                     * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                     * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                     * else do not throw anything
+                     * @return Xtruct - an Xtruct with string_thing = arg1
+                     */
                     Ok(Xtruct),
 
                     Err1(Xception),
@@ -21060,6 +21871,10 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
+
                 impl ::std::default::Default for ThriftTestTestVoidResultRecv {
                     fn default() -> Self {
                         ThriftTestTestVoidResultRecv::Ok(::std::default::Default::default())
@@ -21067,6 +21882,9 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestVoidResultRecv {
+                    /**
+                     * Prints "testVoid()" and returns nothing.
+                     */
                     Ok(()),
                 }
 
@@ -21172,6 +21990,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                 */
+
                 impl ::std::default::Default for ThriftTestTestInsanityResultSend {
                     fn default() -> Self {
                         ThriftTestTestInsanityResultSend::Ok(::std::default::Default::default())
@@ -21179,6 +22009,17 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestInsanityResultSend {
+                    /**
+                     * So you think you've got this all worked out, eh?
+                     *
+                     * Creates a map with these values and prints it out:
+                     *   { 1 => { 2 => argument,
+                     *            3 => argument,
+                     *          },
+                     *     2 => { 6 => <empty Insanity struct>, },
+                     *   }
+                     * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+                     */
                     Ok(::pilota::AHashMap<UserId, ::pilota::AHashMap<Numberz, Insanity>>),
                 }
 
@@ -21642,6 +22483,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                 *  separated by commas and new lines
+                 * @param list<i32> thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestListResultSend {
                     fn default() -> Self {
                         ThriftTestTestListResultSend::Ok(::std::default::Default::default())
@@ -21649,6 +22497,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestListResultSend {
+                    /**
+                     * Prints 'testList("{%s}")' where thing has been formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param list<i32> thing - the list<i32> to print
+                     * @return list<i32> - returns the list<i32> 'thing'
+                     */
                     Ok(::std::vec::Vec<i32>),
                 }
 
@@ -21828,6 +22682,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+                 * @param string arg - a string indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+                 * else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiExceptionArgsSend {
                     pub arg0: ::pilota::FastStr,
@@ -22030,6 +22892,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                 * @param Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestNestResultSend {
                     fn default() -> Self {
                         ThriftTestTestNestResultSend::Ok(::std::default::Default::default())
@@ -22037,6 +22905,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestNestResultSend {
+                    /**
+                     * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+                     * @param Xtruct2 thing - the Xtruct2 to print
+                     * @return Xtruct2 - returns the Xtruct2 'thing'
+                     */
                     Ok(Xtruct2),
                 }
 
@@ -22495,6 +23368,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestDoubleResultSend {
                     fn default() -> Self {
                         ThriftTestTestDoubleResultSend::Ok(::std::default::Default::default())
@@ -22502,6 +23381,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestDoubleResultSend {
+                    /**
+                     * Prints 'testDouble("%f")' with thing as '%f'
+                     * @param double thing - the double to print
+                     * @return double - returns the double 'thing'
+                     */
                     Ok(f64),
                 }
 
@@ -22645,6 +23529,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+                 * sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+                 * @param i32 secondsToSleep - the number of seconds to sleep
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestOnewayArgsRecv {
                     pub seconds_to_sleep: i32,
@@ -22814,6 +23704,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                 * @param bool  thing - the bool data to print
+                 * @return bool  - returns the bool 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBoolResultSend {
                     fn default() -> Self {
                         ThriftTestTestBoolResultSend::Ok(::std::default::Default::default())
@@ -22821,6 +23717,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBoolResultSend {
+                    /**
+                     * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+                     * @param bool  thing - the bool data to print
+                     * @return bool  - returns the bool 'thing'
+                     */
                     Ok(bool),
                 }
 
@@ -23293,6 +24194,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestTypedefArgsSend {
                     pub thing: UserId,
@@ -23463,6 +24369,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct SecondServiceSecondtestStringArgsRecv {
                     pub thing: ::pilota::FastStr,
@@ -23628,6 +24539,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string> to print
+                 * @return map<string,string> - returns the map<string,string> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringMapArgsSend {
                     pub thing: ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
@@ -24017,6 +24934,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given. Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestUuidArgsSend {
                     pub thing: [u8; 16],
@@ -24182,6 +25104,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+                 *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapMapArgsRecv {
                     pub hello: i32,

--- a/pilota-build/test_data/thrift/comments.rs
+++ b/pilota-build/test_data/thrift/comments.rs
@@ -1,0 +1,1465 @@
+pub mod comments {
+    #![allow(warnings, clippy::all)]
+
+    pub mod volo {
+
+        pub mod rpc {
+
+            pub mod example {
+
+                /*
+                 * Item struct represents an item with id, title, content, and extra metadata
+                 */
+
+                // This is a comment for the Item struct
+                #[derive(Debug, Default, Clone, PartialEq)]
+                pub struct Item {
+                    // id of the item
+                    pub id: i64,
+
+                    // title of the item
+
+                    /*
+                     * title of the item
+                     */
+                    pub title: ::pilota::FastStr,
+
+                    // content of the item
+                    pub content: ::pilota::FastStr,
+
+                    // extra metadata of the item
+                    pub extra: ::std::option::Option<
+                        ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
+                    >,
+                }
+                impl ::pilota::thrift::Message for Item {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Item" };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_i64_field(1, *&self.id)?;
+                        __protocol.write_faststr_field(2, (&self.title).clone())?;
+                        __protocol.write_faststr_field(3, (&self.content).clone())?;
+                        if let Some(value) = self.extra.as_ref() {
+                            __protocol.write_map_field(
+                                10,
+                                ::pilota::thrift::TType::Binary,
+                                ::pilota::thrift::TType::Binary,
+                                &value,
+                                |__protocol, key| {
+                                    __protocol.write_faststr((key).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_faststr((val).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+                        let mut var_2 = None;
+                        let mut var_3 = None;
+                        let mut var_10 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I64 =>
+                                    {
+                                        var_1 = Some(__protocol.read_i64()?);
+                                    }
+                                    Some(2)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Binary =>
+                                    {
+                                        var_2 = Some(__protocol.read_faststr()?);
+                                    }
+                                    Some(3)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Binary =>
+                                    {
+                                        var_3 = Some(__protocol.read_faststr()?);
+                                    }
+                                    Some(10)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Map =>
+                                    {
+                                        var_10 = Some({
+                                            let map_ident = __protocol.read_map_begin()?;
+                                            let mut val =
+                                                ::pilota::AHashMap::with_capacity(map_ident.size);
+                                            for _ in 0..map_ident.size {
+                                                val.insert(
+                                                    __protocol.read_faststr()?,
+                                                    __protocol.read_faststr()?,
+                                                );
+                                            }
+                                            __protocol.read_map_end()?;
+                                            val
+                                        });
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!(
+                                    "decode struct `Item` field(#{}) failed, caused by: ",
+                                    field_id
+                                ));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field id is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_2) = var_2 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field title is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_3) = var_3 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field content is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self {
+                            id: var_1,
+                            title: var_2,
+                            content: var_3,
+                            extra: var_10,
+                        };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+                            let mut var_2 = None;
+                            let mut var_3 = None;
+                            let mut var_10 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64  => {
+                    var_1 = Some(__protocol.read_i64().await?);
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::Binary  => {
+                    var_2 = Some(__protocol.read_faststr().await?);
+
+                },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Binary  => {
+                    var_3 = Some(__protocol.read_faststr().await?);
+
+                },Some(10) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_10 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(__protocol.read_faststr().await?, __protocol.read_faststr().await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `Item` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field id is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_2) = var_2 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field title is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_3) = var_3 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field content is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self {
+                                id: var_1,
+                                title: var_2,
+                                content: var_3,
+                                extra: var_10,
+                            };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol
+                            .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
+                            + __protocol.i64_field_len(Some(1), *&self.id)
+                            + __protocol.faststr_field_len(Some(2), &self.title)
+                            + __protocol.faststr_field_len(Some(3), &self.content)
+                            + self.extra.as_ref().map_or(0, |value| {
+                                __protocol.map_field_len(
+                                    Some(10),
+                                    ::pilota::thrift::TType::Binary,
+                                    ::pilota::thrift::TType::Binary,
+                                    value,
+                                    |__protocol, key| __protocol.faststr_len(key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
+                            })
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct TestServiceGetItemArgsRecv {
+                    pub req: GetItemRequest,
+                }
+                impl ::pilota::thrift::Message for TestServiceGetItemArgsRecv {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsRecv",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.req,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsRecv` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field req is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { req: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetItemRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsRecv` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field req is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { req: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsRecv",
+                        }) + __protocol.struct_field_len(Some(1), &self.req)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+
+                impl ::std::default::Default for TestServiceGetItemResultSend {
+                    fn default() -> Self {
+                        TestServiceGetItemResultSend::Ok(::std::default::Default::default())
+                    }
+                }
+                #[derive(Debug, Clone, PartialEq)]
+                pub enum TestServiceGetItemResultSend {
+                    // method to get an item
+                    Ok(GetItemResponse),
+                }
+
+                impl ::pilota::thrift::Message for TestServiceGetItemResultSend {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultSend",
+                        })?;
+                        match self {
+                            TestServiceGetItemResultSend::Ok(value) => {
+                                __protocol.write_struct_field(
+                                    0,
+                                    value,
+                                    ::pilota::thrift::TType::Struct,
+                                )?;
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let mut ret = None;
+                        __protocol.read_struct_begin()?;
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            match field_ident.id {
+                                Some(0) => {
+                                    if ret.is_none() {
+                                        let field_ident =
+                                            ::pilota::thrift::Message::decode(__protocol)?;
+                                        __protocol.struct_len(&field_ident);
+                                        ret = Some(TestServiceGetItemResultSend::Ok(field_ident));
+                                    } else {
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                    }
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+                        }
+                        __protocol.read_field_end()?;
+                        __protocol.read_struct_end()?;
+                        if let Some(ret) = ret {
+                            ::std::result::Result::Ok(ret)
+                        } else {
+                            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received empty union from remote Message",
+                            ))
+                        }
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut ret = None;
+                            __protocol.read_struct_begin().await?;
+                            loop {
+                                let field_ident = __protocol.read_field_begin().await?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    break;
+                                } else {
+                                }
+                                match field_ident.id {
+                                    Some(0) => {
+                                        if ret.is_none() {
+                                            let field_ident = <GetItemResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                            ret =
+                                                Some(TestServiceGetItemResultSend::Ok(field_ident));
+                                        } else {
+                                            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                        }
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type).await?;
+                                    }
+                                }
+                            }
+                            __protocol.read_field_end().await?;
+                            __protocol.read_struct_end().await?;
+                            if let Some(ret) = ret {
+                                ::std::result::Result::Ok(ret)
+                            } else {
+                                ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received empty union from remote Message",
+                                    ),
+                                )
+                            }
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultSend",
+                        }) + match self {
+                            TestServiceGetItemResultSend::Ok(value) => {
+                                __protocol.struct_field_len(Some(0), value)
+                            }
+                        } + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                #[derive(Debug, Default, Clone, PartialEq)]
+                pub struct GetItemResponse {
+                    pub item: Item,
+
+                    pub status: Status,
+                }
+                impl ::pilota::thrift::Message for GetItemResponse {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "GetItemResponse",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.item,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_i32_field(2, (&self.status).inner())?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+                        let mut var_2 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    Some(2)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I32 =>
+                                    {
+                                        var_2 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `GetItemResponse` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field item is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_2) = var_2 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field status is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self {
+                            item: var_1,
+                            status: var_2,
+                        };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+                            let mut var_2 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<Item as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::I32  => {
+                    var_2 = Some(<Status as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetItemResponse` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field item is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_2) = var_2 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field status is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self {
+                                item: var_1,
+                                status: var_2,
+                            };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "GetItemResponse",
+                        }) + __protocol.struct_field_len(Some(1), &self.item)
+                            + __protocol.i32_field_len(Some(2), (&self.status).inner())
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct TestServiceGetItemArgsSend {
+                    pub req: GetItemRequest,
+                }
+                impl ::pilota::thrift::Message for TestServiceGetItemArgsSend {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsSend",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.req,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsSend` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field req is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { req: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetItemRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsSend` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field req is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { req: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsSend",
+                        }) + __protocol.struct_field_len(Some(1), &self.req)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // GetItemRequest struct represents the request for getting an item
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct GetItemRequest {
+                    pub id: i64,
+                }
+                impl ::pilota::thrift::Message for GetItemRequest {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "GetItemRequest",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_i64_field(1, *&self.id)?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I64 =>
+                                    {
+                                        var_1 = Some(__protocol.read_i64()?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!(
+                                    "decode struct `GetItemRequest` field(#{}) failed, caused by: ",
+                                    field_id
+                                ));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field id is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { id: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64  => {
+                    var_1 = Some(__protocol.read_i64().await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetItemRequest` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field id is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { id: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "GetItemRequest",
+                        }) + __protocol.i64_field_len(Some(1), *&self.id)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
+                #[repr(transparent)]
+                pub struct Status(i32);
+
+                impl Status {
+                    pub const SUCCESS: Self = Self(0);
+                    pub const ERROR: Self = Self(1);
+
+                    pub fn inner(&self) -> i32 {
+                        self.0
+                    }
+
+                    pub fn to_string(&self) -> ::std::string::String {
+                        match self {
+                            Self(0) => ::std::string::String::from("SUCCESS"),
+                            Self(1) => ::std::string::String::from("ERROR"),
+                            Self(val) => val.to_string(),
+                        }
+                    }
+
+                    pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
+                        match value {
+                            0 => Some(Self::SUCCESS),
+                            1 => Some(Self::ERROR),
+                            _ => None,
+                        }
+                    }
+                }
+
+                impl ::std::convert::From<i32> for Status {
+                    fn from(value: i32) -> Self {
+                        Self(value)
+                    }
+                }
+
+                impl ::std::convert::From<Status> for i32 {
+                    fn from(value: Status) -> i32 {
+                        value.0
+                    }
+                }
+
+                impl ::pilota::thrift::Message for Status {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_i32(self.inner())?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let value = __protocol.read_i32()?;
+                        ::std::result::Result::Ok(
+                            ::std::convert::TryFrom::try_from(value).map_err(|err| {
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    format!("invalid enum value for Status, value: {}", value),
+                                )
+                            })?,
+                        )
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let value = __protocol.read_i32().await?;
+                            ::std::result::Result::Ok(
+                                ::std::convert::TryFrom::try_from(value).map_err(|err| {
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        format!("invalid enum value for Status, value: {}", value),
+                                    )
+                                })?,
+                            )
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.i32_len(self.inner())
+                    }
+                }
+                pub trait TestService {}
+
+                // method to get an item
+
+                impl ::std::default::Default for TestServiceGetItemResultRecv {
+                    fn default() -> Self {
+                        TestServiceGetItemResultRecv::Ok(::std::default::Default::default())
+                    }
+                }
+                #[derive(Debug, Clone, PartialEq)]
+                pub enum TestServiceGetItemResultRecv {
+                    // method to get an item
+                    Ok(GetItemResponse),
+                }
+
+                impl ::pilota::thrift::Message for TestServiceGetItemResultRecv {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultRecv",
+                        })?;
+                        match self {
+                            TestServiceGetItemResultRecv::Ok(value) => {
+                                __protocol.write_struct_field(
+                                    0,
+                                    value,
+                                    ::pilota::thrift::TType::Struct,
+                                )?;
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let mut ret = None;
+                        __protocol.read_struct_begin()?;
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            match field_ident.id {
+                                Some(0) => {
+                                    if ret.is_none() {
+                                        let field_ident =
+                                            ::pilota::thrift::Message::decode(__protocol)?;
+                                        __protocol.struct_len(&field_ident);
+                                        ret = Some(TestServiceGetItemResultRecv::Ok(field_ident));
+                                    } else {
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                    }
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+                        }
+                        __protocol.read_field_end()?;
+                        __protocol.read_struct_end()?;
+                        if let Some(ret) = ret {
+                            ::std::result::Result::Ok(ret)
+                        } else {
+                            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received empty union from remote Message",
+                            ))
+                        }
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut ret = None;
+                            __protocol.read_struct_begin().await?;
+                            loop {
+                                let field_ident = __protocol.read_field_begin().await?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    break;
+                                } else {
+                                }
+                                match field_ident.id {
+                                    Some(0) => {
+                                        if ret.is_none() {
+                                            let field_ident = <GetItemResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                            ret =
+                                                Some(TestServiceGetItemResultRecv::Ok(field_ident));
+                                        } else {
+                                            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                        }
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type).await?;
+                                    }
+                                }
+                            }
+                            __protocol.read_field_end().await?;
+                            __protocol.read_struct_end().await?;
+                            if let Some(ret) = ret {
+                                ::std::result::Result::Ok(ret)
+                            } else {
+                                ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received empty union from remote Message",
+                                    ),
+                                )
+                            }
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultRecv",
+                        }) + match self {
+                            TestServiceGetItemResultRecv::Ok(value) => {
+                                __protocol.struct_field_len(Some(0), value)
+                            }
+                        } + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift/comments.thrift
+++ b/pilota-build/test_data/thrift/comments.thrift
@@ -1,0 +1,46 @@
+namespace rs volo.rpc.example
+
+/*
+ * Item struct represents an item with id, title, content, and extra metadata
+ */
+
+// This is a comment for the Item struct
+struct Item {
+    // id of the item
+    1: required i64 id,
+    // title of the item
+
+    /*
+     * title of the item
+     */
+    2: required string title,
+    // content of the item
+    3: required string content,
+    // extra metadata of the item
+    10: optional map<string, string> extra,
+}
+
+// Status enum represents the status of an operation
+enum Status {
+    // Success status
+    SUCCESS = 0,
+    // Error status
+    ERROR = 1,
+}
+
+// GetItemRequest struct represents the request for getting an item
+struct GetItemRequest {
+    1: required i64 id,
+}
+
+// GetItemResponse struct represents the response for getting an item
+struct GetItemResponse {
+    1: required Item item,
+    2: required Status status,
+}
+
+// Test Service
+service TestService {
+    // method to get an item
+    GetItemResponse getItem(1: GetItemRequest req),
+}

--- a/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
@@ -529,6 +529,7 @@ pub mod r#gen {
 
             pub email: ::pilota::FastStr,
 
+            //4: required image.Image avatar,
             pub common_data: super::common::CommonData,
         }
         impl ::pilota::thrift::Message for Author {

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/message_Article.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/message_Article.rs
@@ -10,6 +10,7 @@ pub struct Article {
 
     pub status: Status,
 
+    //6: required list<image.Image> images,
     pub common_data: ::common::common::CommonData,
 }
 impl ::pilota::thrift::Message for Article {

--- a/pilota-thrift-fieldmask/Cargo.toml
+++ b/pilota-thrift-fieldmask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-fieldmask"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-fieldmask/Cargo.toml
+++ b/pilota-thrift-fieldmask/Cargo.toml
@@ -28,3 +28,4 @@ ahash.workspace = true
 faststr.workspace = true
 thiserror.workspace = true
 serde.workspace = true
+chumsky.workspace = true

--- a/pilota-thrift-fieldmask/src/fieldmask.rs
+++ b/pilota-thrift-fieldmask/src/fieldmask.rs
@@ -1509,7 +1509,6 @@ mod tests {
     use std::{path::PathBuf, sync::Arc};
 
     use chumsky::prelude::*;
-    use pilota_thrift_parser::parser::*;
 
     use super::*;
 
@@ -1645,7 +1644,9 @@ mod tests {
     #[test]
     fn test_get_path() {
         let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
-        let mut ast = thrift::file().parse(&content).unwrap();
+        let mut ast = pilota_thrift_parser::descriptor::File::parse()
+            .parse(&content)
+            .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/fieldmask.thrift")
                 .canonicalize()
@@ -1656,7 +1657,9 @@ mod tests {
         pilota_thrift_reflect::service::Register::register(key, desc.clone());
 
         let content = std::fs::read_to_string("../examples/idl/base.thrift").unwrap();
-        let mut ast = thrift::file().parse(&content).unwrap();
+        let mut ast = pilota_thrift_parser::descriptor::File::parse()
+            .parse(&content)
+            .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/base.thrift")
                 .canonicalize()

--- a/pilota-thrift-fieldmask/src/fieldmask.rs
+++ b/pilota-thrift-fieldmask/src/fieldmask.rs
@@ -1508,7 +1508,8 @@ impl FieldMask {
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
-    use pilota_thrift_parser::parser::Parser as _;
+    use chumsky::prelude::*;
+    use pilota_thrift_parser::parser::*;
 
     use super::*;
 
@@ -1644,7 +1645,7 @@ mod tests {
     #[test]
     fn test_get_path() {
         let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::File::parse(&content).unwrap().1;
+        let mut ast = thrift::file().parse(&content).unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/fieldmask.thrift")
                 .canonicalize()
@@ -1655,7 +1656,7 @@ mod tests {
         pilota_thrift_reflect::service::Register::register(key, desc.clone());
 
         let content = std::fs::read_to_string("../examples/idl/base.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::File::parse(&content).unwrap().1;
+        let mut ast = thrift::file().parse(&content).unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/base.thrift")
                 .canonicalize()

--- a/pilota-thrift-fieldmask/src/fieldmask.rs
+++ b/pilota-thrift-fieldmask/src/fieldmask.rs
@@ -1644,9 +1644,15 @@ mod tests {
     #[test]
     fn test_get_path() {
         let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::descriptor::File::parse()
-            .parse(&content)
-            .unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/fieldmask.thrift")
                 .canonicalize()
@@ -1657,9 +1663,15 @@ mod tests {
         pilota_thrift_reflect::service::Register::register(key, desc.clone());
 
         let content = std::fs::read_to_string("../examples/idl/base.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::descriptor::File::parse()
-            .parse(&content)
-            .unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/base.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/base.thrift")
                 .canonicalize()

--- a/pilota-thrift-parser/.cargo/config.toml
+++ b/pilota-thrift-parser/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(windows)']
+rustflags = ["-C", "link-args=/STACK:8388608"]

--- a/pilota-thrift-parser/.cargo/config.toml
+++ b/pilota-thrift-parser/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.'cfg(windows)']
-rustflags = ["-C", "link-args=/STACK:8388608"]

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -18,8 +18,10 @@ keywords = ["serialization", "thrift", "parser"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-nom.workspace = true
-bytes.workspace = true
-faststr.workspace = true
-chumsky.workspace = true
+anyhow.workspace = true
 ariadne.workspace = true
+bytes.workspace = true
+chumsky.workspace = true
+faststr.workspace = true
+nom.workspace = true
+thiserror.workspace = true

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -21,3 +21,5 @@ maintenance = { status = "actively-developed" }
 nom.workspace = true
 bytes.workspace = true
 faststr.workspace = true
+chumsky.workspace = true
+ariadne.workspace = true

--- a/pilota-thrift-parser/src/descriptor/constant.rs
+++ b/pilota-thrift-parser/src/descriptor/constant.rs
@@ -15,6 +15,7 @@ pub enum ConstValue {
 
 #[derive(Debug)]
 pub struct Constant {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub r#type: Type,
     pub value: ConstValue,

--- a/pilota-thrift-parser/src/descriptor/enum_.rs
+++ b/pilota-thrift-parser/src/descriptor/enum_.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 pub use super::{Annotations, Ident, IntConstant};
 
 #[derive(Debug)]
 pub struct EnumValue {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub value: Option<IntConstant>,
     pub annotations: Annotations,
@@ -9,6 +12,7 @@ pub struct EnumValue {
 
 #[derive(Debug)]
 pub struct Enum {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub values: Vec<EnumValue>,
     pub annotations: Annotations,

--- a/pilota-thrift-parser/src/descriptor/field.rs
+++ b/pilota-thrift-parser/src/descriptor/field.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::{Annotations, ConstValue, Ident, Type};
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -10,6 +12,7 @@ pub enum Attribute {
 
 #[derive(Debug, Clone)]
 pub struct Field {
+    pub comments: Arc<String>,
     pub id: i32,
     pub name: Ident,
     pub attribute: Attribute,

--- a/pilota-thrift-parser/src/descriptor/function.rs
+++ b/pilota-thrift-parser/src/descriptor/function.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use super::{Annotations, Field, Ident, Type};
 
 #[derive(Debug)]
 pub struct Function {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub oneway: bool,
     pub result_type: Type,

--- a/pilota-thrift-parser/src/descriptor/include.rs
+++ b/pilota-thrift-parser/src/descriptor/include.rs
@@ -1,9 +1,15 @@
+use std::sync::Arc;
+
 use super::Literal;
 
 #[derive(Debug)]
 pub struct Include {
+    pub comments: Arc<String>,
     pub path: Literal,
 }
 
 #[derive(Debug)]
-pub struct CppInclude(pub Literal);
+pub struct CppInclude {
+    pub comments: Arc<String>,
+    pub path: Literal,
+}

--- a/pilota-thrift-parser/src/descriptor/namespace.rs
+++ b/pilota-thrift-parser/src/descriptor/namespace.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{Annotations, Path};
 
 #[derive(Debug, Clone)]
@@ -5,6 +7,7 @@ pub struct Scope(pub String);
 
 #[derive(Debug, Clone)]
 pub struct Namespace {
+    pub comments: Arc<String>,
     pub scope: Scope,
     pub name: Path,
     pub annotations: Option<Annotations>,

--- a/pilota-thrift-parser/src/descriptor/service.rs
+++ b/pilota-thrift-parser/src/descriptor/service.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use super::{Annotations, Function, Ident, Path};
 
 #[derive(Debug)]
 pub struct Service {
+    pub comments: Arc<String>,
     pub name: Ident,
     pub extends: Option<Path>,
     pub functions: Vec<Function>,

--- a/pilota-thrift-parser/src/descriptor/struct_.rs
+++ b/pilota-thrift-parser/src/descriptor/struct_.rs
@@ -1,22 +1,28 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use super::{Annotations, Field, Ident};
 
 #[derive(Debug)]
-pub struct Struct(pub StructLike);
+pub struct Struct {
+    pub comments: Arc<String>,
+    pub struct_like: StructLike,
+}
 
 macro_rules! struct_like {
     ($name: ty) => {
         impl Deref for $name {
             type Target = StructLike;
             fn deref(&self) -> &StructLike {
-                &self.0
+                &self.struct_like
             }
         }
 
         impl DerefMut for $name {
             fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.0
+                &mut self.struct_like
             }
         }
     };
@@ -25,12 +31,18 @@ macro_rules! struct_like {
 struct_like!(Struct);
 
 #[derive(Debug)]
-pub struct Union(pub StructLike);
+pub struct Union {
+    pub comments: Arc<String>,
+    pub struct_like: StructLike,
+}
 
 struct_like!(Union);
 
 #[derive(Debug)]
-pub struct Exception(pub StructLike);
+pub struct Exception {
+    pub comments: Arc<String>,
+    pub struct_like: StructLike,
+}
 
 struct_like!(Exception);
 

--- a/pilota-thrift-parser/src/descriptor/typedef.rs
+++ b/pilota-thrift-parser/src/descriptor/typedef.rs
@@ -1,7 +1,10 @@
+use std::sync::Arc;
+
 use super::{Annotations, Ident, Type};
 
 #[derive(Debug)]
 pub struct Typedef {
+    pub comments: Arc<String>,
     pub r#type: Type,
     pub alias: Ident,
     pub annotations: Annotations,

--- a/pilota-thrift-parser/src/lib.rs
+++ b/pilota-thrift-parser/src/lib.rs
@@ -7,3 +7,7 @@ pub mod descriptor;
 pub mod parser;
 
 pub use descriptor::*;
+pub use parser::{
+    error::Error,
+    thrift::{FileParser, FileSource},
+};

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 impl Annotation {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
         let key = Ident::ident_with_dot();
 
         let value = Literal::parse();
@@ -33,7 +33,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_annotations() {
-        let _a = Annotation::parse()
+        let _a = Annotation::get_parser()
             .parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#)
             .unwrap();
 
@@ -42,7 +42,7 @@ mod tests {
             python.type ="DenseFoo",
             java.final="",
             )"#;
-        let res = Annotation::parse().parse(input).unwrap();
+        let res = Annotation::get_parser().parse(input).unwrap();
         assert_eq!(res.len(), 3);
     }
 }

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -1,64 +1,53 @@
-use nom::{
-    IResult,
-    bytes::complete::{tag, take_while},
-    character::complete::satisfy,
-    combinator::{map, opt, recognize},
-    multi::many1,
-    sequence::tuple,
-};
+use chumsky::prelude::*;
 
 use crate::{
-    descriptor::{Annotation, Annotations, Literal},
+    descriptor::{Annotation, Annotations},
     parser::*,
 };
 
-impl Parser for Annotations {
-    // (foo = 'bar', x = "1")
-    fn parse(input: &str) -> IResult<&str, Annotations> {
-        map(
-            tuple((
-                tag("("),
-                many1(map(
-                    tuple((
-                        opt(blank),
-                        recognize(tuple((
-                            satisfy(|c| c.is_ascii_alphabetic() || c == '_'),
-                            take_while(|c: char| c.is_ascii_alphanumeric() || c == '_' || c == '.'),
-                        ))),
-                        opt(blank),
-                        tag("="),
-                        opt(blank),
-                        Literal::parse,
-                        opt(blank),
-                        opt(list_separator),
-                    )),
-                    |(_, p, _, _, _, lit, _, _)| Annotation {
-                        key: p.to_owned(),
-                        value: lit,
-                    },
-                )),
-                tag(")"),
-            )),
-            |(_, annotations, _)| Annotations(annotations),
-        )(input)
-    }
+pub fn parse<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
+    just("(")
+        .ignore_then(
+            blank()
+                .or_not()
+                .ignore_then(any().filter(|c: &char| c.is_ascii_alphabetic() || *c == '_'))
+                .then(
+                    any()
+                        .filter(|c: &char| c.is_ascii_alphanumeric() || *c == '_' || *c == '.')
+                        .repeated(),
+                )
+                .to_slice()
+                .map(|s| s.to_string())
+                .then_ignore(blank().or_not())
+                .then_ignore(just("="))
+                .then_ignore(blank().or_not())
+                .then(literal::parse())
+                .padded_by(blank())
+                .then_ignore(list_separator().or_not())
+                .map(|(key, value)| Annotation { key, value })
+                .repeated()
+                .at_least(1)
+                .collect::<Vec<Annotation>>(),
+        )
+        .then_ignore(just(")"))
+        .map(Annotations)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::parser::Parser, Annotations};
-
+    use super::*;
     #[test]
     fn test_annotations() {
-        let _a = Annotations::parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#).unwrap();
+        let _a = parse()
+            .parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#)
+            .unwrap();
 
         let input = r#"(
             cpp.type = "DenseFoo",
             python.type = "DenseFoo",
             java.final = "",
             )"#;
-        let (remain, a) = Annotations::parse(input).unwrap();
-        assert!(remain.is_empty());
-        assert_eq!(a.len(), 3);
+        let res = parse().parse(input).unwrap();
+        assert_eq!(res.len(), 3);
     }
 }

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -1,28 +1,31 @@
 use chumsky::prelude::*;
 
 use crate::{
+    Literal,
     descriptor::{Annotation, Annotations},
     parser::*,
 };
 
-pub fn parse<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
-    let key = identifier::ident_with_dot();
+impl Annotation {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
+        let key = Ident::ident_with_dot();
 
-    let value = literal::parse();
+        let value = Literal::parse();
 
-    just("(")
-        .ignore_then(
-            key.padded_by(blank().or_not())
-                .then_ignore(just("=").padded_by(blank().or_not()))
-                .then(value)
-                .then_ignore(list_separator().padded_by(blank().or_not()).or_not())
-                .map(|(key, value)| Annotation { key, value })
-                .repeated()
-                .at_least(1)
-                .collect::<Vec<Annotation>>(),
-        )
-        .then_ignore(just(")"))
-        .map(Annotations)
+        just("(")
+            .ignore_then(
+                key.padded_by(blank().or_not())
+                    .then_ignore(just("=").padded_by(blank().or_not()))
+                    .then(value)
+                    .then_ignore(list_separator().padded_by(blank().or_not()).or_not())
+                    .map(|(key, value)| Annotation { key, value })
+                    .repeated()
+                    .at_least(1)
+                    .collect::<Vec<Annotation>>(),
+            )
+            .then_ignore(just(")"))
+            .map(Annotations)
+    }
 }
 
 #[cfg(test)]
@@ -30,7 +33,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_annotations() {
-        let _a = parse()
+        let _a = Annotation::parse()
             .parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#)
             .unwrap();
 
@@ -39,7 +42,7 @@ mod tests {
             python.type ="DenseFoo",
             java.final="",
             )"#;
-        let res = parse().parse(input).unwrap();
+        let res = Annotation::parse().parse(input).unwrap();
         assert_eq!(res.len(), 3);
     }
 }

--- a/pilota-thrift-parser/src/parser/constant.rs
+++ b/pilota-thrift-parser/src/parser/constant.rs
@@ -1,141 +1,122 @@
-use std::{num::ParseIntError, str::FromStr};
-
-use nom::{
-    IResult,
-    branch::alt,
-    bytes::complete::{tag, tag_no_case},
-    character::complete::{digit1, hex_digit1},
-    combinator::{map, map_res, opt, recognize},
-    multi::many0,
-    sequence::{delimited, preceded, tuple},
-};
+use chumsky::prelude::*;
 
 use super::super::{
-    descriptor::{
-        Annotations, ConstValue, Constant, DoubleConstant, Ident, IntConstant, Literal, Type,
-    },
+    descriptor::{ConstValue, Constant, DoubleConstant, IntConstant},
     parser::*,
 };
 
-impl Parser for ConstValue {
-    fn parse(input: &str) -> IResult<&str, ConstValue> {
-        alt((
-            map(Literal::parse, ConstValue::String),
-            map(tag("true"), |_| ConstValue::Bool(true)),
-            map(tag("false"), |_| ConstValue::Bool(false)),
-            map(Path::parse, ConstValue::Path),
-            map(DoubleConstant::parse, ConstValue::Double),
-            map(IntConstant::parse, ConstValue::Int),
-            map(
-                tuple((
-                    tag("["),
-                    many0(map(
-                        tuple((
-                            opt(blank),
-                            ConstValue::parse,
-                            opt(blank),
-                            opt(list_separator),
-                        )),
-                        |(_, elements, _, _)| elements,
-                    )),
-                    opt(blank),
-                    tag("]"),
-                )),
-                |(_, elements, _, _)| ConstValue::List(elements),
-            ),
-            map(
-                tuple((
-                    tag("{"),
-                    many0(map(
-                        tuple((
-                            opt(blank),
-                            ConstValue::parse,
-                            opt(blank),
-                            tag(":"),
-                            opt(blank),
-                            ConstValue::parse,
-                            opt(blank),
-                            opt(list_separator),
-                        )),
-                        |(_, key, _, _, _, value, _, _)| (key, value),
-                    )),
-                    opt(blank),
-                    tag("}"),
-                )),
-                |(_, key_value_pairs, _, _)| ConstValue::Map(key_value_pairs),
-            ),
-        ))(input)
-    }
+pub fn const_value<'a>() -> impl Parser<'a, &'a str, ConstValue, extra::Err<Rich<'a, char>>> {
+    recursive(|const_value| {
+        choice((
+            literal::parse().map(ConstValue::String),
+            just("true").to(ConstValue::Bool(true)),
+            just("false").to(ConstValue::Bool(false)),
+            path().map(ConstValue::Path),
+            double_constant().map(ConstValue::Double),
+            int_constant().map(ConstValue::Int),
+            just("[")
+                .ignore_then(
+                    blank()
+                        .or_not()
+                        .ignore_then(const_value.clone())
+                        .then_ignore(blank().or_not())
+                        .then_ignore(list_separator().or_not())
+                        .repeated()
+                        .collect(),
+                )
+                .then_ignore(blank().or_not())
+                .then_ignore(just("]"))
+                .map(|elements| ConstValue::List(elements)),
+            just("{")
+                .ignore_then(
+                    blank()
+                        .or_not()
+                        .ignore_then(const_value.clone())
+                        .then_ignore(blank().or_not())
+                        .then_ignore(just(":"))
+                        .then_ignore(blank().or_not())
+                        .then(const_value.clone())
+                        .then_ignore(blank().or_not())
+                        .then_ignore(list_separator().or_not())
+                        .repeated()
+                        .collect(),
+                )
+                .then_ignore(blank().or_not())
+                .then_ignore(just("}"))
+                .map(|elements| ConstValue::Map(elements)),
+        ))
+        .boxed()
+    })
 }
 
-impl Parser for Constant {
-    fn parse(input: &str) -> IResult<&str, Constant> {
-        map(
-            tuple((
-                tag("const"),
-                preceded(blank, Type::parse),
-                preceded(blank, Ident::parse),
-                preceded(opt(blank), tag("=")),
-                preceded(opt(blank), ConstValue::parse),
-                opt(blank),
-                opt(Annotations::parse),
-                opt(list_separator),
-            )),
-            |(_, r#type, name, _, value, _, annotations, _)| Constant {
-                name,
-                r#type,
-                value,
-                annotations: annotations.unwrap_or_default(),
-            },
-        )(input)
-    }
+pub fn constant<'a>() -> impl Parser<'a, &'a str, Constant, extra::Err<Rich<'a, char>>> {
+    just("const")
+        .ignore_then(blank())
+        .ignore_then(ty::r#type())
+        .then_ignore(blank())
+        .then(identifier::parse())
+        .then_ignore(blank().or_not())
+        .then_ignore(just("="))
+        .then_ignore(blank().or_not())
+        .then(const_value())
+        .then_ignore(blank().or_not())
+        .then(annotation::parse().or_not())
+        .then_ignore(list_separator().or_not())
+        .map(|(((r#type, name), value), annotations)| Constant {
+            name: Ident(Arc::from(name)),
+            r#type,
+            value,
+            annotations: annotations.unwrap_or_default(),
+        })
 }
 
-impl Parser for IntConstant {
-    fn parse(input: &str) -> IResult<&str, IntConstant> {
-        alt((
-            preceded(tag("-"), map(IntConstant::parse, |d| IntConstant(-d.0))),
-            preceded(
-                tag("0x"),
-                map_res(hex_digit1, |d| i64::from_str_radix(d, 16).map(IntConstant)),
-            ),
-            map_res(digit1, |d| {
-                let d = FromStr::from_str(d)?;
-                Ok::<_, ParseIntError>(IntConstant(d))
-            }),
-        ))(input)
-    }
+pub fn int_constant<'a>() -> impl Parser<'a, &'a str, IntConstant, extra::Err<Rich<'a, char>>> {
+    recursive(|int_constant| {
+        choice((
+            just("-")
+                .ignore_then(int_constant)
+                .map(|d: IntConstant| IntConstant(-d.0)),
+            just("0x")
+                .ignore_then(
+                    any()
+                        .filter(|c: &char| c.is_ascii_hexdigit())
+                        .repeated()
+                        .at_least(1)
+                        .collect::<String>(),
+                )
+                .map(|d| IntConstant(i64::from_str_radix(d.as_str(), 16).unwrap())),
+            any()
+                .filter(|c: &char| c.is_ascii_digit())
+                .repeated()
+                .at_least(1)
+                .collect::<String>()
+                .map(|d| IntConstant(i64::from_str_radix(d.as_str(), 10).unwrap())),
+        ))
+    })
 }
 
-impl Parser for DoubleConstant {
-    fn parse(input: &str) -> IResult<&str, DoubleConstant> {
-        map_res(
-            recognize(tuple((
-                opt(tag("-")),
-                opt(tag("+")),
-                alt((
-                    delimited(
-                        digit1,
-                        tag("."),
-                        tuple((
-                            opt(digit1),
-                            opt(tuple((tag_no_case("e"), IntConstant::parse))),
-                        )),
-                    ),
-                    delimited(
-                        opt(digit1),
-                        tag("."),
-                        tuple((digit1, opt(tuple((tag_no_case("e"), IntConstant::parse))))),
-                    ),
-                    delimited(digit1, tag_no_case("e"), IntConstant::parse),
-                )),
-            ))),
-            |d_str| -> Result<DoubleConstant, std::num::ParseFloatError> {
-                Ok(DoubleConstant(d_str.to_owned().into()))
-            },
-        )(input)
-        // map(double, DoubleConstant)(input)
-    }
+pub fn double_constant<'a>() -> impl Parser<'a, &'a str, DoubleConstant, extra::Err<Rich<'a, char>>>
+{
+    let digits = any()
+        .filter(|c: &char| c.is_ascii_digit())
+        .repeated()
+        .at_least(1);
+    let sign = one_of("+-").or_not();
+    let integer_part = digits;
+    let fractional_part = just('.').then(digits);
+    let exponent_part = one_of("eE").then(one_of("+-").or_not()).then(digits);
+    let with_fraction = sign
+        .then(integer_part)
+        .then(fractional_part)
+        .then(exponent_part.or_not())
+        .to_slice()
+        .map(|s: &str| DoubleConstant(Arc::from(s.to_string())));
+    let with_exponent_only = sign
+        .then(integer_part)
+        .then(exponent_part)
+        .to_slice()
+        .map(|s: &str| DoubleConstant(Arc::from(s.to_string())));
+    choice((with_fraction, with_exponent_only))
 }
 
 #[cfg(test)]
@@ -145,48 +126,55 @@ mod tests {
 
     #[test]
     fn test_int_constant() {
-        let _i = IntConstant::parse("0x").unwrap().1;
-        let _i = IntConstant::parse("1.01e10").unwrap().1;
+        let _i = int_constant().parse("0x01").unwrap();
+        let _i = int_constant().parse("1").unwrap();
     }
+
+    #[test]
+    fn test_list_constant() {
+        let _i = const_value().parse("[1, 2]").unwrap();
+        let _i = const_value().parse("[1, 0xBC]").unwrap();
+    }
+
     #[test]
     fn test_map() {
         let input = r#"const map<i32,set<i32>> aXa1 = {1:[1,1], 2:[2,2]}"#;
-        let _c = Constant::parse(input).unwrap().1;
+        let _c = constant().parse(input).unwrap();
     }
 
     #[test]
     fn test_list() {
         let input = r#"const list<i32> aXa1 = [1,2]"#;
-        let _c = Constant::parse(input).unwrap().1;
+        let _c = constant().parse(input).unwrap();
     }
 
     #[test]
     fn test_set() {
         let input = r#"const set<i32> aXa1 = [1,2]"#;
-        let _c = Constant::parse(input).unwrap().1;
+        let _c = constant().parse(input).unwrap();
     }
 
     #[test]
     fn test_bool() {
         let input = r#"const bool aXa1 = true"#;
-        let _c = Constant::parse(input).unwrap().1;
+        let _c = constant().parse(input).unwrap();
     }
 
     #[test]
     fn test_i64() {
-        let input = r#"const i64 aXa1 = 1"#;
-        let _c = Constant::parse(input).unwrap().1;
+        let input = r#"const i64 aXa1 = 0x1"#;
+        let _c = constant().parse(input).unwrap();
     }
 
     #[test]
     fn test_f64() {
         let input = r#"const double aXa1 = 1.01e10"#;
-        let _c = Constant::parse(input).unwrap().1;
+        let _c = constant().parse(input).unwrap();
     }
 
     #[test]
     fn test_str() {
         let input = r#"const string aXa1 = "hello""#;
-        let _c = Constant::parse(input).unwrap().1;
+        let _c = constant().parse(input).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/constant.rs
+++ b/pilota-thrift-parser/src/parser/constant.rs
@@ -4,115 +4,123 @@ use super::super::{
     descriptor::{ConstValue, Constant, DoubleConstant, IntConstant},
     parser::*,
 };
+use crate::{Annotation, Literal, Type};
 
-pub fn const_value<'a>() -> impl Parser<'a, &'a str, ConstValue, extra::Err<Rich<'a, char>>> {
-    recursive(|const_value| {
-        let list_value = just("[")
-            .ignore_then(
-                const_value
-                    .clone()
-                    .padded_by(blank().or_not())
-                    .then_ignore(list_separator().or_not())
-                    .repeated()
-                    .collect(),
-            )
-            .then_ignore(blank().or_not())
-            .then_ignore(just("]"))
-            .map(|elements| ConstValue::List(elements));
-
-        let map_value = just("{")
-            .ignore_then(
-                const_value
-                    .clone()
-                    .padded_by(blank().or_not())
-                    .then_ignore(just(":"))
-                    .then(const_value.clone().padded_by(blank().or_not()))
-                    .then_ignore(list_separator().or_not())
-                    .repeated()
-                    .collect(),
-            )
-            .then_ignore(blank().or_not())
-            .then_ignore(just("}"))
-            .map(|elements| ConstValue::Map(elements));
-
-        choice((
-            literal::parse().map(ConstValue::String),
-            just("true").to(ConstValue::Bool(true)),
-            just("false").to(ConstValue::Bool(false)),
-            path().map(ConstValue::Path),
-            double_constant().map(ConstValue::Double),
-            int_constant().map(ConstValue::Int),
-            list_value,
-            map_value,
-        ))
-        .boxed()
-    })
-}
-
-pub fn constant<'a>() -> impl Parser<'a, &'a str, Constant, extra::Err<Rich<'a, char>>> {
-    just("const")
-        .ignore_then(ty::r#type().padded_by(blank()))
-        .then(identifier::parse())
-        .then_ignore(just("=").padded_by(blank().or_not()))
-        .then(const_value())
-        .then_ignore(blank().or_not())
-        .then(annotation::parse().or_not())
-        .then_ignore(list_separator().padded_by(blank().or_not()).or_not())
-        .map(|(((r#type, name), value), annotations)| Constant {
-            name: Ident(Arc::from(name)),
-            r#type,
-            value,
-            annotations: annotations.unwrap_or_default(),
-        })
-}
-
-pub fn int_constant<'a>() -> impl Parser<'a, &'a str, IntConstant, extra::Err<Rich<'a, char>>> {
-    recursive(|int_constant| {
-        choice((
-            just("-")
-                .ignore_then(int_constant)
-                .map(|d: IntConstant| IntConstant(-d.0)),
-            just("0x")
+impl ConstValue {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, ConstValue, extra::Err<Rich<'a, char>>> {
+        recursive(|const_value| {
+            let list_value = just("[")
                 .ignore_then(
-                    any()
-                        .filter(|c: &char| c.is_ascii_hexdigit())
+                    const_value
+                        .clone()
+                        .padded_by(blank().or_not())
+                        .then_ignore(list_separator().or_not())
                         .repeated()
-                        .at_least(1)
-                        .collect::<String>(),
+                        .collect(),
                 )
-                .map(|d| IntConstant(i64::from_str_radix(d.as_str(), 16).unwrap())),
-            any()
-                .filter(|c: &char| c.is_ascii_digit())
-                .repeated()
-                .at_least(1)
-                .collect::<String>()
-                .map(|d| IntConstant(i64::from_str_radix(d.as_str(), 10).unwrap())),
-        ))
-    })
+                .then_ignore(blank().or_not())
+                .then_ignore(just("]"))
+                .map(|elements| ConstValue::List(elements));
+
+            let map_value = just("{")
+                .ignore_then(
+                    const_value
+                        .clone()
+                        .padded_by(blank().or_not())
+                        .then_ignore(just(":"))
+                        .then(const_value.clone().padded_by(blank().or_not()))
+                        .then_ignore(list_separator().or_not())
+                        .repeated()
+                        .collect(),
+                )
+                .then_ignore(blank().or_not())
+                .then_ignore(just("}"))
+                .map(|elements| ConstValue::Map(elements));
+
+            choice((
+                Literal::parse().map(ConstValue::String),
+                just("true").to(ConstValue::Bool(true)),
+                just("false").to(ConstValue::Bool(false)),
+                Path::parse().map(ConstValue::Path),
+                DoubleConstant::parse().map(ConstValue::Double),
+                IntConstant::parse().map(ConstValue::Int),
+                list_value,
+                map_value,
+            ))
+            .boxed()
+        })
+    }
 }
 
-pub fn double_constant<'a>() -> impl Parser<'a, &'a str, DoubleConstant, extra::Err<Rich<'a, char>>>
-{
-    let digits = any()
-        .filter(|c: &char| c.is_ascii_digit())
-        .repeated()
-        .at_least(1);
-    let sign = one_of("+-").or_not();
-    let integer_part = digits;
-    let fractional_part = just('.').then(digits);
-    let exponent_part = one_of("eE").then(one_of("+-").or_not()).then(digits);
-    let with_fraction = sign
-        .then(integer_part)
-        .then(fractional_part)
-        .then(exponent_part.or_not())
-        .to_slice()
-        .map(|s: &str| DoubleConstant(Arc::from(s.to_string())));
-    let with_exponent_only = sign
-        .then(integer_part)
-        .then(exponent_part)
-        .to_slice()
-        .map(|s: &str| DoubleConstant(Arc::from(s.to_string())));
-    choice((with_fraction, with_exponent_only))
+impl Constant {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Constant, extra::Err<Rich<'a, char>>> {
+        just("const")
+            .ignore_then(Type::parse().padded_by(blank()))
+            .then(Ident::parse())
+            .then_ignore(just("=").padded_by(blank().or_not()))
+            .then(ConstValue::parse())
+            .then_ignore(blank().or_not())
+            .then(Annotation::parse().or_not())
+            .then_ignore(list_separator().padded_by(blank().or_not()).or_not())
+            .map(|(((r#type, name), value), annotations)| Constant {
+                name: Ident(Arc::from(name)),
+                r#type,
+                value,
+                annotations: annotations.unwrap_or_default(),
+            })
+    }
+}
+
+impl IntConstant {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, IntConstant, extra::Err<Rich<'a, char>>> {
+        recursive(|int_constant| {
+            choice((
+                just("-")
+                    .ignore_then(int_constant)
+                    .map(|d: IntConstant| IntConstant(-d.0)),
+                just("0x")
+                    .ignore_then(
+                        any()
+                            .filter(|c: &char| c.is_ascii_hexdigit())
+                            .repeated()
+                            .at_least(1)
+                            .collect::<String>(),
+                    )
+                    .map(|d| IntConstant(i64::from_str_radix(d.as_str(), 16).unwrap())),
+                any()
+                    .filter(|c: &char| c.is_ascii_digit())
+                    .repeated()
+                    .at_least(1)
+                    .collect::<String>()
+                    .map(|d| IntConstant(i64::from_str_radix(d.as_str(), 10).unwrap())),
+            ))
+        })
+    }
+}
+
+impl DoubleConstant {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, DoubleConstant, extra::Err<Rich<'a, char>>> {
+        let digits = any()
+            .filter(|c: &char| c.is_ascii_digit())
+            .repeated()
+            .at_least(1);
+        let sign = one_of("+-").or_not();
+        let integer_part = digits;
+        let fractional_part = just('.').then(digits);
+        let exponent_part = one_of("eE").then(one_of("+-").or_not()).then(digits);
+        let with_fraction = sign
+            .then(integer_part)
+            .then(fractional_part)
+            .then(exponent_part.or_not())
+            .to_slice()
+            .map(|s: &str| DoubleConstant(Arc::from(s.to_string())));
+        let with_exponent_only = sign
+            .then(integer_part)
+            .then(exponent_part)
+            .to_slice()
+            .map(|s: &str| DoubleConstant(Arc::from(s.to_string())));
+        choice((with_fraction, with_exponent_only))
+    }
 }
 
 #[cfg(test)]
@@ -122,55 +130,55 @@ mod tests {
 
     #[test]
     fn test_int_constant() {
-        let _i = int_constant().parse("0x01").unwrap();
-        let _i = int_constant().parse("1").unwrap();
+        let _i = IntConstant::parse().parse("0x01").unwrap();
+        let _i = IntConstant::parse().parse("1").unwrap();
     }
 
     #[test]
     fn test_list_constant() {
-        let _i = const_value().parse("[1, 2]").unwrap();
-        let _i = const_value().parse("[1, 0xBC]").unwrap();
+        let _i = ConstValue::parse().parse("[1, 2]").unwrap();
+        let _i = ConstValue::parse().parse("[1, 0xBC]").unwrap();
     }
 
     #[test]
     fn test_map() {
         let input = r#"const map<i32,set<i32>> aXa1 = {1:[1,1], 2:[2,2]}"#;
-        let _c = constant().parse(input).unwrap();
+        let _c = Constant::parse().parse(input).unwrap();
     }
 
     #[test]
     fn test_list() {
         let input = r#"const list<i32> aXa1 = [1,2]"#;
-        let _c = constant().parse(input).unwrap();
+        let _c = Constant::parse().parse(input).unwrap();
     }
 
     #[test]
     fn test_set() {
         let input = r#"const set<i32> aXa1 = [1,2]"#;
-        let _c = constant().parse(input).unwrap();
+        let _c = Constant::parse().parse(input).unwrap();
     }
 
     #[test]
     fn test_bool() {
         let input = r#"const bool aXa1 = true"#;
-        let _c = constant().parse(input).unwrap();
+        let _c = Constant::parse().parse(input).unwrap();
     }
 
     #[test]
     fn test_i64() {
         let input = r#"const i64 aXa1 = 0x1"#;
-        let _c = constant().parse(input).unwrap();
+        let _c = Constant::parse().parse(input).unwrap();
     }
 
     #[test]
     fn test_f64() {
         let input = r#"const double aXa1 = 1.01e10"#;
-        let _c = constant().parse(input).unwrap();
+        let _c = Constant::parse().parse(input).unwrap();
     }
 
     #[test]
     fn test_str() {
         let input = r#"const string aXa1 = "hello""#;
-        let _c = constant().parse(input).unwrap();
+        let _c = Constant::parse().parse(input).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/constant.rs
+++ b/pilota-thrift-parser/src/parser/constant.rs
@@ -63,7 +63,7 @@ impl Constant {
             .then(Annotation::parse().or_not())
             .then_ignore(list_separator().padded_by(blank().or_not()).or_not())
             .map(|(((r#type, name), value), annotations)| Constant {
-                name: Ident(Arc::from(name)),
+                name: Ident(name.into()),
                 r#type,
                 value,
                 annotations: annotations.unwrap_or_default(),
@@ -113,12 +113,12 @@ impl DoubleConstant {
             .then(fractional_part)
             .then(exponent_part.or_not())
             .to_slice()
-            .map(|s: &str| DoubleConstant(Arc::from(s.to_string())));
+            .map(|s: &str| DoubleConstant(s.into()));
         let with_exponent_only = sign
             .then(integer_part)
             .then(exponent_part)
             .to_slice()
-            .map(|s: &str| DoubleConstant(Arc::from(s.to_string())));
+            .map(|s: &str| DoubleConstant(s.into()));
         choice((with_fraction, with_exponent_only))
     }
 }

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -8,10 +8,8 @@ use super::super::{
 };
 
 pub fn enum_value<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
-    blank()
-        .or_not()
-        .ignore_then(identifier::parse())
-        .then_ignore(blank().or_not())
+    identifier::parse()
+        .padded_by(blank().or_not())
         .then(
             just("=")
                 .ignore_then(blank().or_not())

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -1,11 +1,10 @@
 use chumsky::prelude::*;
 
-use crate::parser::constant::int_constant;
-
 use super::super::{
     descriptor::{Enum, EnumValue},
     parser::*,
 };
+use crate::parser::constant::int_constant;
 
 pub fn enum_value<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
     identifier::parse()

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -7,8 +7,8 @@ use super::super::{
 use crate::{Annotation, IntConstant};
 
 impl EnumValue {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
+        Ident::get_parser()
             .padded_by(blank().or_not())
             .then(
                 just("=")
@@ -17,7 +17,7 @@ impl EnumValue {
                     .or_not(),
             )
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|((name, value), annotations)| EnumValue {
                 name: Ident(name.into()),
@@ -28,17 +28,17 @@ impl EnumValue {
 }
 
 impl Enum {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
         just("enum")
             .ignore_then(blank())
-            .ignore_then(Ident::parse())
+            .ignore_then(Ident::get_parser())
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
-            .then(EnumValue::parse().repeated().collect())
+            .then(EnumValue::get_parser().repeated().collect())
             .then_ignore(blank().or_not())
             .then_ignore(just("}"))
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .map(|((name, values), annotations)| Enum {
                 name: Ident(name.into()),
                 values,
@@ -52,7 +52,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_enum() {
-        let _ = Enum::parse()
+        let _ = Enum::get_parser()
             .parse(
                 r#"enum Sex {
                             UNKNOWN = 0,
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_enum2() {
-        let _ = Enum::parse()
+        let _ = Enum::get_parser()
             .parse(
                 r#"enum Index {
                             A = 0x01,

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -20,7 +20,7 @@ impl EnumValue {
             .then(Annotation::parse().or_not())
             .then_ignore(list_separator().or_not())
             .map(|((name, value), annotations)| EnumValue {
-                name: Ident(Arc::from(name)),
+                name: Ident(name.into()),
                 value,
                 annotations: annotations.unwrap_or_default(),
             })
@@ -40,7 +40,7 @@ impl Enum {
             .then_ignore(blank().or_not())
             .then(Annotation::parse().or_not())
             .map(|((name, values), annotations)| Enum {
-                name: Ident(Arc::from(name)),
+                name: Ident(name.into()),
                 values,
                 annotations: annotations.unwrap_or_default(),
             })

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -4,43 +4,47 @@ use super::super::{
     descriptor::{Enum, EnumValue},
     parser::*,
 };
-use crate::parser::constant::int_constant;
+use crate::{Annotation, IntConstant};
 
-pub fn enum_value<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
-    identifier::parse()
-        .padded_by(blank().or_not())
-        .then(
-            just("=")
-                .ignore_then(blank().or_not())
-                .ignore_then(int_constant())
-                .or_not(),
-        )
-        .then_ignore(blank().or_not())
-        .then(annotation::parse().or_not())
-        .then_ignore(list_separator().or_not())
-        .map(|((name, value), annotations)| EnumValue {
-            name: Ident(Arc::from(name)),
-            value,
-            annotations: annotations.unwrap_or_default(),
-        })
+impl EnumValue {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
+        Ident::parse()
+            .padded_by(blank().or_not())
+            .then(
+                just("=")
+                    .ignore_then(blank().or_not())
+                    .ignore_then(IntConstant::parse())
+                    .or_not(),
+            )
+            .then_ignore(blank().or_not())
+            .then(Annotation::parse().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(|((name, value), annotations)| EnumValue {
+                name: Ident(Arc::from(name)),
+                value,
+                annotations: annotations.unwrap_or_default(),
+            })
+    }
 }
 
-pub fn parse<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
-    just("enum")
-        .ignore_then(blank())
-        .ignore_then(identifier::parse())
-        .then_ignore(blank().or_not())
-        .then_ignore(just("{"))
-        .then(enum_value().repeated().collect())
-        .then_ignore(blank().or_not())
-        .then_ignore(just("}"))
-        .then_ignore(blank().or_not())
-        .then(annotation::parse().or_not())
-        .map(|((name, values), annotations)| Enum {
-            name: Ident(Arc::from(name)),
-            values,
-            annotations: annotations.unwrap_or_default(),
-        })
+impl Enum {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
+        just("enum")
+            .ignore_then(blank())
+            .ignore_then(Ident::parse())
+            .then_ignore(blank().or_not())
+            .then_ignore(just("{"))
+            .then(EnumValue::parse().repeated().collect())
+            .then_ignore(blank().or_not())
+            .then_ignore(just("}"))
+            .then_ignore(blank().or_not())
+            .then(Annotation::parse().or_not())
+            .map(|((name, values), annotations)| Enum {
+                name: Ident(Arc::from(name)),
+                values,
+                annotations: annotations.unwrap_or_default(),
+            })
+    }
 }
 
 #[cfg(test)]
@@ -48,7 +52,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_enum() {
-        let _ = enum_::parse()
+        let _ = Enum::parse()
             .parse(
                 r#"enum Sex {
                             UNKNOWN = 0,
@@ -61,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_enum2() {
-        let _ = enum_::parse()
+        let _ = Enum::parse()
             .parse(
                 r#"enum Index {
                             A = 0x01,

--- a/pilota-thrift-parser/src/parser/error.rs
+++ b/pilota-thrift-parser/src/parser/error.rs
@@ -1,0 +1,28 @@
+use faststr::FastStr;
+
+#[derive(thiserror::Error)]
+pub enum Error {
+    #[error("IO error: {0}")]
+    IO(std::io::Error),
+    #[error("File not found: {0}")]
+    FileNotFound(std::path::PathBuf),
+    #[error("Syntax error: {source}")]
+    Syntax {
+        summary: FastStr,
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+// for unwrap
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Syntax { summary, .. } => {
+                write!(f, "{}", summary)
+            }
+            Error::IO(error) => write!(f, "{}", error),
+            Error::FileNotFound(path_buf) => write!(f, "{}", path_buf.display()),
+        }
+    }
+}

--- a/pilota-thrift-parser/src/parser/field.rs
+++ b/pilota-thrift-parser/src/parser/field.rs
@@ -36,7 +36,7 @@ impl Field {
                     id: id.parse().unwrap(),
                     attribute: attribute.unwrap_or_default(),
                     ty: r#type,
-                    name: Ident(Arc::from(name)),
+                    name: Ident(name.into()),
                     default: value,
                     annotations: annotations.unwrap_or_default(),
                 },

--- a/pilota-thrift-parser/src/parser/field.rs
+++ b/pilota-thrift-parser/src/parser/field.rs
@@ -15,25 +15,17 @@ pub fn attribute<'a>() -> impl Parser<'a, &'a str, Attribute, extra::Err<Rich<'a
 pub fn parse<'a>() -> impl Parser<'a, &'a str, Field, extra::Err<Rich<'a, char>>> {
     // 1: required i32 name = 123;
     text::int(10)
-        .then_ignore(blank().or_not())
-        .then_ignore(just(":"))
-        .then_ignore(blank().or_not())
+        .then_ignore(just(":").padded_by(blank().or_not()))
         .then(attribute().or_not())
-        .then_ignore(blank().or_not())
-        .then(ty::r#type())
-        .then_ignore(blank().or_not())
+        .then(ty::r#type().padded_by(blank().or_not()))
         .then(identifier::parse())
         .then(
-            blank()
-                .or_not()
-                .ignore_then(just("="))
-                .ignore_then(blank().or_not())
+            just("=")
+                .padded_by(blank().or_not())
                 .ignore_then(constant::const_value())
                 .or_not(),
         )
-        .then_ignore(blank().or_not())
-        .then(annotation::parse().or_not())
-        .then_ignore(blank().or_not())
+        .then(annotation::parse().or_not().padded_by(blank().or_not()))
         .then_ignore(list_separator().or_not())
         .map(
             |(((((id, attribute), r#type), name), value), annotations)| Field {

--- a/pilota-thrift-parser/src/parser/field.rs
+++ b/pilota-thrift-parser/src/parser/field.rs
@@ -4,39 +4,44 @@ use super::super::{
     descriptor::{Attribute, Field},
     parser::*,
 };
+use crate::{Annotation, ConstValue, Type};
 
-pub fn attribute<'a>() -> impl Parser<'a, &'a str, Attribute, extra::Err<Rich<'a, char>>> {
-    choice((
-        just("required").to(Attribute::Required),
-        just("optional").to(Attribute::Optional),
-    ))
+impl Attribute {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Attribute, extra::Err<Rich<'a, char>>> {
+        choice((
+            just("required").to(Attribute::Required),
+            just("optional").to(Attribute::Optional),
+        ))
+    }
 }
 
-pub fn parse<'a>() -> impl Parser<'a, &'a str, Field, extra::Err<Rich<'a, char>>> {
-    // 1: required i32 name = 123;
-    text::int(10)
-        .then_ignore(just(":").padded_by(blank().or_not()))
-        .then(attribute().or_not())
-        .then(ty::r#type().padded_by(blank().or_not()))
-        .then(identifier::parse())
-        .then(
-            just("=")
-                .padded_by(blank().or_not())
-                .ignore_then(constant::const_value())
-                .or_not(),
-        )
-        .then(annotation::parse().or_not().padded_by(blank().or_not()))
-        .then_ignore(list_separator().or_not())
-        .map(
-            |(((((id, attribute), r#type), name), value), annotations)| Field {
-                id: id.parse().unwrap(),
-                attribute: attribute.unwrap_or_default(),
-                ty: r#type,
-                name: Ident(Arc::from(name)),
-                default: value,
-                annotations: annotations.unwrap_or_default(),
-            },
-        )
+impl Field {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Field, extra::Err<Rich<'a, char>>> {
+        // 1: required i32 name = 123;
+        text::int(10)
+            .then_ignore(just(":").padded_by(blank().or_not()))
+            .then(Attribute::parse().or_not())
+            .then(Type::parse().padded_by(blank().or_not()))
+            .then(Ident::parse())
+            .then(
+                just("=")
+                    .padded_by(blank().or_not())
+                    .ignore_then(ConstValue::parse())
+                    .or_not(),
+            )
+            .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+            .then_ignore(list_separator().or_not())
+            .map(
+                |(((((id, attribute), r#type), name), value), annotations)| Field {
+                    id: id.parse().unwrap(),
+                    attribute: attribute.unwrap_or_default(),
+                    ty: r#type,
+                    name: Ident(Arc::from(name)),
+                    default: value,
+                    annotations: annotations.unwrap_or_default(),
+                },
+            )
+    }
 }
 
 #[cfg(test)]
@@ -46,21 +51,21 @@ mod tests {
 
     #[test]
     fn test_field() {
-        let _f = field::parse()
+        let _f = Field::parse()
             .parse(r#"1: required string(foo="1", bar='2') LogID = "xxx" (foo = '1', bar="2"),"#)
             .unwrap();
     }
 
     #[test]
     fn test_field2() {
-        let _f = field::parse()
+        let _f = Field::parse()
             .parse(r#"1: set<i64> Ids (go.tag = "json:\"Ids\" split:\"type=tenant\""),"#)
             .unwrap();
     }
 
     #[test]
     fn test_field3() {
-        let _f = field::parse()
+        let _f = Field::parse()
             .parse(r#"2: required bytet_i.Injection Injection,"#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -1,12 +1,11 @@
 use chumsky::prelude::*;
 
-use crate::parser::*;
-
 use super::super::{
     Attribute,
     descriptor::Function,
     parser::{Parser, blank, list_separator},
 };
+use crate::parser::*;
 
 pub fn parse<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
     let fields = field::parse()

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -47,7 +47,7 @@ impl Function {
                         }
                     });
                     Function {
-                        name: Ident(Arc::from(name)),
+                        name: Ident(name.into()),
                         oneway: ow,
                         result_type: r#type,
                         arguments: args,

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -8,8 +8,8 @@ use super::super::{
 use crate::{Annotation, Field, Type, parser::*};
 
 impl Function {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
-        let fields = Field::parse()
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
+        let fields = Field::get_parser()
             .padded_by(blank().or_not())
             .repeated()
             .at_least(1)
@@ -26,16 +26,16 @@ impl Function {
         just("oneway")
             .then_ignore(blank())
             .or_not()
-            .then(Type::parse())
+            .then(Type::get_parser())
             .then_ignore(blank())
-            .then(Ident::parse())
+            .then(Ident::get_parser())
             .then_ignore(just("(").padded_by(blank().or_not()))
             .then(fields.clone().or_not())
             .then_ignore(just(")"))
             .padded_by(blank().or_not())
             .then(throws.or_not())
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(
                 |(((((oneway, r#type), name), arguments), throws), annotations)| {
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_func() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(
                 r#"map<i64, shared.ProcessingStatus> processUserData(
                             1: required list<UserProfile> profiles,
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_func2() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(
                 r#"oneway void pingServer(
                             1: required string(go.tag = 'json:"source_service"') source,
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_func3() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(r#"Err test_enum_var_type_name_conflict (1: Request req);"#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -5,56 +5,58 @@ use super::super::{
     descriptor::Function,
     parser::{Parser, blank, list_separator},
 };
-use crate::parser::*;
+use crate::{Annotation, Field, Type, parser::*};
 
-pub fn parse<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
-    let fields = field::parse()
-        .padded_by(blank().or_not())
-        .repeated()
-        .at_least(1)
-        .collect::<Vec<_>>()
-        .boxed();
+impl Function {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
+        let fields = Field::parse()
+            .padded_by(blank().or_not())
+            .repeated()
+            .at_least(1)
+            .collect::<Vec<_>>()
+            .boxed();
 
-    let throws = just("throws")
-        .ignore_then(blank().or_not())
-        .ignore_then(just("("))
-        .ignore_then(fields.clone())
-        .then_ignore(blank().or_not())
-        .then_ignore(just(")"));
+        let throws = just("throws")
+            .ignore_then(blank().or_not())
+            .ignore_then(just("("))
+            .ignore_then(fields.clone())
+            .then_ignore(blank().or_not())
+            .then_ignore(just(")"));
 
-    just("oneway")
-        .then_ignore(blank())
-        .or_not()
-        .then(ty::r#type())
-        .then_ignore(blank())
-        .then(identifier::parse())
-        .then_ignore(just("(").padded_by(blank().or_not()))
-        .then(fields.clone().or_not())
-        .then_ignore(just(")"))
-        .padded_by(blank().or_not())
-        .then(throws.or_not())
-        .then_ignore(blank().or_not())
-        .then(annotation::parse().or_not())
-        .then_ignore(list_separator().or_not())
-        .map(
-            |(((((oneway, r#type), name), arguments), throws), annotations)| {
-                let ow = oneway.is_some();
-                let mut args = arguments.unwrap_or_default();
-                args.iter_mut().for_each(|f| {
-                    if f.attribute == Attribute::Default {
-                        f.attribute = Attribute::Required
+        just("oneway")
+            .then_ignore(blank())
+            .or_not()
+            .then(Type::parse())
+            .then_ignore(blank())
+            .then(Ident::parse())
+            .then_ignore(just("(").padded_by(blank().or_not()))
+            .then(fields.clone().or_not())
+            .then_ignore(just(")"))
+            .padded_by(blank().or_not())
+            .then(throws.or_not())
+            .then_ignore(blank().or_not())
+            .then(Annotation::parse().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(
+                |(((((oneway, r#type), name), arguments), throws), annotations)| {
+                    let ow = oneway.is_some();
+                    let mut args = arguments.unwrap_or_default();
+                    args.iter_mut().for_each(|f| {
+                        if f.attribute == Attribute::Default {
+                            f.attribute = Attribute::Required
+                        }
+                    });
+                    Function {
+                        name: Ident(Arc::from(name)),
+                        oneway: ow,
+                        result_type: r#type,
+                        arguments: args,
+                        throws: throws.unwrap_or_default(),
+                        annotations: annotations.unwrap_or_default(),
                     }
-                });
-                Function {
-                    name: Ident(Arc::from(name)),
-                    oneway: ow,
-                    result_type: r#type,
-                    arguments: args,
-                    throws: throws.unwrap_or_default(),
-                    annotations: annotations.unwrap_or_default(),
-                }
-            },
-        )
+                },
+            )
+    }
 }
 
 #[cfg(test)]
@@ -64,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_func() {
-        let _f = function::parse()
+        let _f = Function::parse()
             .parse(
                 r#"map<i64, shared.ProcessingStatus> processUserData(
                             1: required list<UserProfile> profiles,
@@ -77,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_func2() {
-        let _f = function::parse()
+        let _f = Function::parse()
             .parse(
                 r#"oneway void pingServer(
                             1: required string(go.tag = 'json:"source_service"') source,
@@ -89,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_func3() {
-        let _f = function::parse()
+        let _f = Function::parse()
             .parse(r#"Err test_enum_var_type_name_conflict (1: Request req);"#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/identifier.rs
+++ b/pilota-thrift-parser/src/parser/identifier.rs
@@ -1,52 +1,29 @@
-use nom::{
-    IResult, bytes::complete::take_while, character::complete::satisfy, combinator::recognize,
-    sequence::tuple,
-};
+use chumsky::prelude::*;
 
-use super::super::{descriptor::Ident, parser::*};
-
-/// Identifier is not strictly following the BNF: ( Letter | '_' ) ( Letter |
-/// Digit | '.' | '_' )* Instead, "_" and "_123" are not allowed since in rust
-/// they are invalid parameter names.
-impl Parser for Ident {
-    fn parse(input: &str) -> IResult<&str, Ident> {
-        map(
-            recognize(tuple((
-                satisfy(|c| c.is_ascii_alphabetic() || c == '_'),
-                take_while(|c: char| c.is_ascii_alphanumeric() || c == '_'),
-            ))),
-            |ident: &str| -> Ident { Ident(ident.into()) },
-        )(input)
-    }
+pub fn parse<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+    text::ascii::ident().map(|ident: &str| ident.to_string())
 }
 
 #[cfg(test)]
 mod test {
+    use crate::parser::path;
+
     use super::*;
 
     #[test]
     fn test_identifier() {
-        assert_eq!(Ident::parse("abc").unwrap().1, "abc");
-        assert_eq!(Ident::parse("a1d").unwrap().1, "a1d");
-        assert_eq!(Ident::parse("foo_bar").unwrap().1, "foo_bar");
-        assert_eq!(Ident::parse("foo_bar =").unwrap().1, "foo_bar");
-        assert_eq!(Ident::parse("foo_bar=").unwrap().1, "foo_bar");
-        assert_eq!(Ident::parse("foo_bar{").unwrap().1, "foo_bar");
-        assert_eq!(Ident::parse("foo_bar;").unwrap().1, "foo_bar");
-        assert!(Ident::parse("1foo_bar").is_err());
-        assert!(Ident::parse("").is_err());
+        assert_eq!(parse().parse("abc").unwrap(), "abc");
+        assert_eq!(parse().parse("a1d").unwrap(), "a1d");
+        assert_eq!(parse().parse("foo_bar").unwrap(), "foo_bar");
 
-        assert_eq!(Ident::parse("_ihciah,").unwrap().1, "_ihciah");
-        assert_eq!(Ident::parse("ihciah,").unwrap().1, "ihciah");
-        assert_eq!(Ident::parse("_123").unwrap().1, "_123");
-        assert_eq!(Ident::parse("_").unwrap().1, "_");
-        assert!(Ident::parse("123").is_err());
+        assert_eq!(parse().parse("_123").unwrap(), "_123");
+        assert_eq!(parse().parse("_").unwrap(), "_");
     }
 
     #[test]
     fn test_path() {
         assert_eq!(
-            &*Path::parse("prefix.foo_bar").unwrap().1.segments,
+            &*path().parse("prefix.foo_bar").unwrap().segments,
             ["prefix", "foo_bar"]
         );
     }

--- a/pilota-thrift-parser/src/parser/identifier.rs
+++ b/pilota-thrift-parser/src/parser/identifier.rs
@@ -1,40 +1,44 @@
 use chumsky::prelude::*;
 
-pub fn parse<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
-    text::ascii::ident().map(|ident: &str| ident.to_string())
-}
+use crate::Ident;
 
-pub fn ident_with_dot<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
-    any()
-        .filter(|c: &char| c.is_ascii_alphabetic() || *c == '_')
-        .then(
-            any()
-                .filter(|c: &char| c.is_ascii_alphanumeric() || *c == '_' || *c == '.')
-                .repeated(),
-        )
-        .to_slice()
-        .map(|s: &str| s.to_string())
+impl Ident {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+        text::ascii::ident().map(|ident: &str| ident.to_string())
+    }
+
+    pub fn ident_with_dot<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+        any()
+            .filter(|c: &char| c.is_ascii_alphabetic() || *c == '_')
+            .then(
+                any()
+                    .filter(|c: &char| c.is_ascii_alphanumeric() || *c == '_' || *c == '.')
+                    .repeated(),
+            )
+            .to_slice()
+            .map(|s: &str| s.to_string())
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::parser::path;
+    use crate::Path;
 
     #[test]
     fn test_identifier() {
-        assert_eq!(parse().parse("abc").unwrap(), "abc");
-        assert_eq!(parse().parse("a1d").unwrap(), "a1d");
-        assert_eq!(parse().parse("foo_bar").unwrap(), "foo_bar");
+        assert_eq!(Ident::parse().parse("abc").unwrap(), "abc");
+        assert_eq!(Ident::parse().parse("a1d").unwrap(), "a1d");
+        assert_eq!(Ident::parse().parse("foo_bar").unwrap(), "foo_bar");
 
-        assert_eq!(parse().parse("_123").unwrap(), "_123");
-        assert_eq!(parse().parse("_").unwrap(), "_");
+        assert_eq!(Ident::parse().parse("_123").unwrap(), "_123");
+        assert_eq!(Ident::parse().parse("_").unwrap(), "_");
     }
 
     #[test]
     fn test_path() {
         assert_eq!(
-            &*path().parse("prefix.foo_bar").unwrap().segments,
+            &*Path::parse().parse("prefix.foo_bar").unwrap().segments,
             ["prefix", "foo_bar"]
         );
     }

--- a/pilota-thrift-parser/src/parser/identifier.rs
+++ b/pilota-thrift-parser/src/parser/identifier.rs
@@ -3,7 +3,7 @@ use chumsky::prelude::*;
 use crate::Ident;
 
 impl Ident {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
         text::ascii::ident().map(|ident: &str| ident.to_string())
     }
 
@@ -27,12 +27,12 @@ mod test {
 
     #[test]
     fn test_identifier() {
-        assert_eq!(Ident::parse().parse("abc").unwrap(), "abc");
-        assert_eq!(Ident::parse().parse("a1d").unwrap(), "a1d");
-        assert_eq!(Ident::parse().parse("foo_bar").unwrap(), "foo_bar");
+        assert_eq!(Ident::get_parser().parse("abc").unwrap(), "abc");
+        assert_eq!(Ident::get_parser().parse("a1d").unwrap(), "a1d");
+        assert_eq!(Ident::get_parser().parse("foo_bar").unwrap(), "foo_bar");
 
-        assert_eq!(Ident::parse().parse("_123").unwrap(), "_123");
-        assert_eq!(Ident::parse().parse("_").unwrap(), "_");
+        assert_eq!(Ident::get_parser().parse("_123").unwrap(), "_123");
+        assert_eq!(Ident::get_parser().parse("_").unwrap(), "_");
     }
 
     #[test]

--- a/pilota-thrift-parser/src/parser/identifier.rs
+++ b/pilota-thrift-parser/src/parser/identifier.rs
@@ -4,6 +4,18 @@ pub fn parse<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>
     text::ascii::ident().map(|ident: &str| ident.to_string())
 }
 
+pub fn ident_with_dot<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+    any()
+        .filter(|c: &char| c.is_ascii_alphabetic() || *c == '_')
+        .then(
+            any()
+                .filter(|c: &char| c.is_ascii_alphanumeric() || *c == '_' || *c == '.')
+                .repeated(),
+        )
+        .to_slice()
+        .map(|s: &str| s.to_string())
+}
+
 #[cfg(test)]
 mod test {
     use crate::parser::path;

--- a/pilota-thrift-parser/src/parser/identifier.rs
+++ b/pilota-thrift-parser/src/parser/identifier.rs
@@ -18,9 +18,8 @@ pub fn ident_with_dot<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<
 
 #[cfg(test)]
 mod test {
-    use crate::parser::path;
-
     use super::*;
+    use crate::parser::path;
 
     #[test]
     fn test_identifier() {

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chumsky::prelude::*;
 
 use super::super::{
@@ -8,23 +10,37 @@ use crate::Literal;
 
 impl Include {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
-        just("include")
-            .ignore_then(blank())
-            .ignore_then(Literal::parse())
+        comment()
+            .repeated()
+            .collect::<Vec<_>>()
+            .then_ignore(blank().or_not())
+            .then_ignore(just("include"))
+            .then_ignore(blank())
+            .then(Literal::parse())
             .then_ignore(blank().or_not())
             .then_ignore(list_separator().or_not())
-            .map(|path| Include { path })
+            .map(|(comments, path)| Include {
+                comments: Arc::new(comments.join("\n\n")),
+                path,
+            })
     }
 }
 
 impl CppInclude {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, CppInclude, extra::Err<Rich<'a, char>>> {
-        just("cpp_include")
-            .ignore_then(blank())
-            .ignore_then(Literal::parse())
+        comment()
+            .repeated()
+            .collect::<Vec<_>>()
+            .then_ignore(blank().or_not())
+            .then_ignore(just("cpp_include"))
+            .then_ignore(blank())
+            .then(Literal::parse())
             .then_ignore(blank().or_not())
             .then_ignore(list_separator().or_not())
-            .map(CppInclude)
+            .map(|(comments, path)| CppInclude {
+                comments: Arc::new(comments.join("\n\n")),
+                path,
+            })
     }
 }
 

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -7,7 +7,7 @@ use super::super::{
 use crate::Literal;
 
 impl Include {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
         just("include")
             .ignore_then(blank())
             .ignore_then(Literal::parse())
@@ -24,7 +24,7 @@ impl CppInclude {
             .ignore_then(Literal::parse())
             .then_ignore(blank().or_not())
             .then_ignore(list_separator().or_not())
-            .map(|path| CppInclude(path))
+            .map(CppInclude)
     }
 }
 
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn test_include() {
-        let _f = Include::parse()
+        let _f = Include::get_parser()
             .parse(r#"include "shared.thrift""#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -4,23 +4,28 @@ use super::super::{
     descriptor::{CppInclude, Include},
     parser::*,
 };
+use crate::Literal;
 
-pub fn include<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
-    just("include")
-        .ignore_then(blank())
-        .ignore_then(literal::parse())
-        .then_ignore(blank().or_not())
-        .then_ignore(list_separator().or_not())
-        .map(|path| Include { path })
+impl Include {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
+        just("include")
+            .ignore_then(blank())
+            .ignore_then(Literal::parse())
+            .then_ignore(blank().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(|path| Include { path })
+    }
 }
 
-pub fn cpp_include<'a>() -> impl Parser<'a, &'a str, CppInclude, extra::Err<Rich<'a, char>>> {
-    just("cpp_include")
-        .ignore_then(blank())
-        .ignore_then(literal::parse())
-        .then_ignore(blank().or_not())
-        .then_ignore(list_separator().or_not())
-        .map(|path| CppInclude(path))
+impl CppInclude {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, CppInclude, extra::Err<Rich<'a, char>>> {
+        just("cpp_include")
+            .ignore_then(blank())
+            .ignore_then(Literal::parse())
+            .then_ignore(blank().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(|path| CppInclude(path))
+    }
 }
 
 #[cfg(test)]
@@ -30,12 +35,14 @@ mod tests {
 
     #[test]
     fn test_include() {
-        let _f = include().parse(r#"include "shared.thrift""#).unwrap();
+        let _f = Include::parse()
+            .parse(r#"include "shared.thrift""#)
+            .unwrap();
     }
 
     #[test]
     fn test_cpp_include() {
-        let _f = cpp_include()
+        let _f = CppInclude::parse()
             .parse(r#"cpp_include "shared.thrift""#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -1,34 +1,39 @@
-use nom::{
-    IResult,
-    bytes::complete::tag,
-    combinator::{map, opt},
-    sequence::tuple,
-};
-
 use super::super::{
-    descriptor::{CppInclude, Include, Literal},
+    descriptor::{CppInclude, Include},
     parser::*,
 };
+use chumsky::prelude::*;
 
-impl Parser for Include {
-    fn parse(input: &str) -> IResult<&str, Include> {
-        map(
-            tuple((tag("include"), blank, Literal::parse, opt(list_separator))),
-            |(_, _, path, _)| Include { path },
-        )(input)
-    }
+pub fn include<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
+    just("include")
+        .ignore_then(blank())
+        .ignore_then(literal::parse())
+        .then_ignore(blank().or_not())
+        .then_ignore(list_separator().or_not())
+        .map(|path| Include { path })
 }
 
-impl Parser for CppInclude {
-    fn parse(input: &str) -> IResult<&str, CppInclude> {
-        map(
-            tuple((
-                tag("cpp_include"),
-                blank,
-                Literal::parse,
-                opt(list_separator),
-            )),
-            |(_, _, path, _)| CppInclude(path),
-        )(input)
+pub fn cpp_include<'a>() -> impl Parser<'a, &'a str, CppInclude, extra::Err<Rich<'a, char>>> {
+    just("cpp_include")
+        .ignore_then(blank())
+        .ignore_then(literal::parse())
+        .then_ignore(blank().or_not())
+        .then_ignore(list_separator().or_not())
+        .map(|path| CppInclude(path))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_include() {
+        let _f = include().parse(r#"include "shared.thrift""#).unwrap();
+    }
+
+    #[test]
+    fn test_cpp_include() {
+        let _f = cpp_include().parse(r#"cpp_include "shared.thrift""#).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -1,8 +1,9 @@
+use chumsky::prelude::*;
+
 use super::super::{
     descriptor::{CppInclude, Include},
     parser::*,
 };
-use chumsky::prelude::*;
 
 pub fn include<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
     just("include")
@@ -34,6 +35,8 @@ mod tests {
 
     #[test]
     fn test_cpp_include() {
-        let _f = cpp_include().parse(r#"cpp_include "shared.thrift""#).unwrap();
+        let _f = cpp_include()
+            .parse(r#"cpp_include "shared.thrift""#)
+            .unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/literal.rs
+++ b/pilota-thrift-parser/src/parser/literal.rs
@@ -1,5 +1,6 @@
-use super::super::descriptor::Literal;
 use chumsky::prelude::*;
+
+use super::super::descriptor::Literal;
 
 fn quoted_string<'a>(quote: char) -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
     let normal_char = none_of([quote, '\\']);

--- a/pilota-thrift-parser/src/parser/literal.rs
+++ b/pilota-thrift-parser/src/parser/literal.rs
@@ -27,8 +27,10 @@ fn double_quote<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, ch
     quoted_string('"')
 }
 
-pub fn parse<'a>() -> impl Parser<'a, &'a str, Literal, extra::Err<Rich<'a, char>>> {
-    single_quote().map(Literal).or(double_quote().map(Literal))
+impl Literal {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Literal, extra::Err<Rich<'a, char>>> {
+        single_quote().map(Literal).or(double_quote().map(Literal))
+    }
 }
 
 #[cfg(test)]
@@ -37,11 +39,11 @@ mod tests {
 
     #[test]
     fn test_literal() {
-        let _ = parse().parse(r#""hello""#).unwrap();
-        let _ = parse().parse(r#"'hello'"#).unwrap();
-        let _ = parse().parse(r#"'hello\'world'"#).unwrap();
-        let _ = parse().parse(r#"'hello\nworld'"#).unwrap();
-        let _ = parse().parse(r#"'hello\\world'"#).unwrap();
-        let _ = parse().parse(r#"'hello\"world'"#).unwrap();
+        let _ = Literal::parse().parse(r#""hello""#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\'world'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\nworld'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\\world'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\"world'"#).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -13,57 +13,79 @@ mod literal;
 mod namespace;
 mod service;
 mod struct_;
-mod thrift;
+pub mod thrift;
 mod ty;
 mod typedef;
 
+use chumsky::prelude::*;
 use std::sync::Arc;
 
-use nom::{
-    IResult,
-    branch::alt,
-    bytes::complete::{tag, take_till, take_until},
-    character::complete::{multispace1, one_of, satisfy},
-    combinator::{map, opt},
-    multi::{many0, many1, separated_list1},
-    sequence::{preceded, terminated, tuple},
-};
+use crate::Ident;
 
-use super::descriptor::{Ident, Path};
+use super::descriptor::Path;
 
-/// combinator for parsing thrift idl
-pub trait Parser: Sized {
-    /// parse from input idl
-    fn parse(input: &str) -> IResult<&str, Self>;
-}
-
-impl Parser for Path {
-    fn parse(input: &str) -> IResult<&str, Self> {
-        map(
-            separated_list1(tuple((opt(blank), tag("."), opt(blank))), Ident::parse),
-            |idents| Path {
+pub(crate) fn path<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
+    identifier::parse()
+        .separated_by(just('.').padded_by(blank()))
+        .at_least(1)
+        .collect()
+        .map(|s: Vec<String>| {
+            let idents: Vec<Ident> = s.into_iter().map(Ident::from).collect();
+            Path {
                 segments: Arc::from(idents),
-            },
-        )(input)
+            }
+        })
+        .padded_by(blank())
+}
+
+pub fn list_separator<'a>() -> impl Parser<'a, &'a str, char, extra::Err<Rich<'a, char>>> {
+    one_of(",;").then(blank().or_not()).map(|(sep, _)| sep)
+}
+
+pub fn blank<'a>() -> impl Parser<'a, &'a str, (), extra::Err<Rich<'a, char>>> {
+    choice((
+        just("//")
+            .then(any().and_is(just('\n').not()).repeated())
+            .ignored(),
+        just("#")
+            .then(any().and_is(just('\n').not()).repeated())
+            .ignored(),
+        just("/*")
+            .then(any().and_is(just("*/").not()).repeated())
+            .then(just("*/"))
+            .ignored(),
+        one_of(" \t\r\n").ignored(),
+    ))
+    .repeated()
+    .ignored()
+}
+
+pub fn not_alphanumeric_or_underscore<'a>()
+-> impl Parser<'a, &'a str, char, extra::Err<Rich<'a, char>>> {
+    any()
+        .rewind()
+        .filter(|c: &char| !c.is_alphanumeric() && *c != '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blank() {
+        let _ = blank().parse(" \t\r\n").unwrap();
     }
-}
 
-pub(crate) fn list_separator(input: &str) -> IResult<&str, char> {
-    map(tuple((one_of(",;"), opt(blank))), |(sep, _)| sep)(input)
-}
+    #[test]
+    fn test_path() {
+        let p = path().parse("foo.bar.baz").unwrap();
+        assert_eq!(p.segments.len(), 3);
+        assert_eq!(p.segments[0].as_str(), "foo");
+        assert_eq!(p.segments[1].as_str(), "bar");
+        assert_eq!(p.segments[2].as_str(), "baz");
 
-fn comment(input: &str) -> IResult<&str, &str> {
-    alt((
-        preceded(tag("//"), take_till(|c| c == '\n')),
-        preceded(tag("/*"), terminated(take_until("*/"), tag("*/"))),
-        preceded(tag("#"), take_till(|c| c == '\n')),
-    ))(input)
-}
-
-pub(crate) fn blank(input: &str) -> IResult<&str, ()> {
-    map(many1(alt((comment, multispace1))), |_| ())(input)
-}
-
-pub(crate) fn alphanumeric_or_underscore(input: &str) -> IResult<&str, char> {
-    satisfy(|c: char| c.is_alphanumeric() || c == '_')(input)
+        let p = path().parse("foo").unwrap();
+        assert_eq!(p.segments.len(), 1);
+        assert_eq!(p.segments[0].as_str(), "foo");
+    }
 }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -33,7 +33,7 @@ impl Path {
             .map(|s: Vec<String>| {
                 let idents: Vec<Ident> = s.into_iter().map(Ident::from).collect();
                 Path {
-                    segments: Arc::from(idents),
+                    segments: idents.into(),
                 }
             })
             .padded_by(blank())

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -17,12 +17,12 @@ pub mod thrift;
 mod ty;
 mod typedef;
 
-use chumsky::prelude::*;
 use std::sync::Arc;
 
-use crate::Ident;
+use chumsky::prelude::*;
 
 use super::descriptor::Path;
+use crate::Ident;
 
 pub(crate) fn path<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
     identifier::parse()

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -44,21 +44,39 @@ pub fn list_separator<'a>() -> impl Parser<'a, &'a str, char, extra::Err<Rich<'a
 }
 
 pub fn blank<'a>() -> impl Parser<'a, &'a str, (), extra::Err<Rich<'a, char>>> {
+    one_of(" \t\r\n").repeated().ignored()
+}
+
+pub fn comment<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
     choice((
         just("//")
-            .then(any().and_is(just('\n').not()).repeated())
-            .ignored(),
+            .then(
+                any()
+                    .and_is(just('\n').not())
+                    .repeated()
+                    .collect::<String>(),
+            )
+            .then(just("\n").or_not())
+            .map(|((start, content), end)| format!("{}{}{}", start, content, end.unwrap_or("\n"))),
         just("#")
-            .then(any().and_is(just('\n').not()).repeated())
-            .ignored(),
+            .then(
+                any()
+                    .and_is(just('\n').not())
+                    .repeated()
+                    .collect::<String>(),
+            )
+            .then(just("\n").or_not())
+            .map(|((start, content), end)| format!("{}{}{}", start, content, end.unwrap_or("\n"))),
         just("/*")
-            .then(any().and_is(just("*/").not()).repeated())
+            .then(
+                any()
+                    .and_is(just("*/").not())
+                    .repeated()
+                    .collect::<String>(),
+            )
             .then(just("*/"))
-            .ignored(),
-        one_of(" \t\r\n").ignored(),
+            .map(|((start, content), end)| format!("{}{}{}", start, content, end)),
     ))
-    .repeated()
-    .ignored()
 }
 
 pub fn not_alphanumeric_or_underscore<'a>()

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -24,18 +24,20 @@ use chumsky::prelude::*;
 use super::descriptor::Path;
 use crate::Ident;
 
-pub(crate) fn path<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
-    identifier::parse()
-        .separated_by(just('.').padded_by(blank()))
-        .at_least(1)
-        .collect()
-        .map(|s: Vec<String>| {
-            let idents: Vec<Ident> = s.into_iter().map(Ident::from).collect();
-            Path {
-                segments: Arc::from(idents),
-            }
-        })
-        .padded_by(blank())
+impl Path {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
+        Ident::parse()
+            .separated_by(just('.').padded_by(blank()))
+            .at_least(1)
+            .collect()
+            .map(|s: Vec<String>| {
+                let idents: Vec<Ident> = s.into_iter().map(Ident::from).collect();
+                Path {
+                    segments: Arc::from(idents),
+                }
+            })
+            .padded_by(blank())
+    }
 }
 
 pub fn list_separator<'a>() -> impl Parser<'a, &'a str, char, extra::Err<Rich<'a, char>>> {
@@ -78,13 +80,13 @@ mod tests {
 
     #[test]
     fn test_path() {
-        let p = path().parse("foo.bar.baz").unwrap();
+        let p = Path::parse().parse("foo.bar.baz").unwrap();
         assert_eq!(p.segments.len(), 3);
         assert_eq!(p.segments[0].as_str(), "foo");
         assert_eq!(p.segments[1].as_str(), "bar");
         assert_eq!(p.segments[2].as_str(), "baz");
 
-        let p = path().parse("foo").unwrap();
+        let p = Path::parse().parse("foo").unwrap();
         assert_eq!(p.segments.len(), 1);
         assert_eq!(p.segments[0].as_str(), "foo");
     }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -5,6 +5,7 @@
 mod annotation;
 mod constant;
 mod enum_;
+pub mod error;
 mod field;
 mod function;
 mod identifier;
@@ -24,7 +25,7 @@ use crate::Ident;
 
 impl Path {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+        Ident::get_parser()
             .separated_by(just('.').padded_by(blank()))
             .at_least(1)
             .collect()

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -17,8 +17,6 @@ pub mod thrift;
 mod ty;
 mod typedef;
 
-use std::sync::Arc;
-
 use chumsky::prelude::*;
 
 use super::descriptor::Path;

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -1,41 +1,36 @@
-use nom::{
-    IResult,
-    bytes::complete::tag,
-    combinator::{map, opt},
-    sequence::{preceded, tuple},
-};
+use chumsky::prelude::*;
 
-use super::super::{descriptor::Annotations, parser::*};
+use super::super::parser::*;
 use crate::{Namespace, Scope};
 
-impl Parser for Namespace {
-    fn parse(input: &str) -> IResult<&str, Namespace> {
-        map(
-            tuple((
-                tag("namespace"),
-                preceded(blank, Scope::parse),
-                preceded(blank, Path::parse),
-                opt(blank),
-                opt(Annotations::parse),
-                opt(blank),
-                opt(list_separator),
-            )),
-            |(_, scope, name, _, annotations, _, _)| Namespace {
-                scope,
-                name,
-                annotations,
-            },
-        )(input)
-    }
+pub fn parse<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
+    just("namespace")
+        .ignore_then(blank())
+        .ignore_then(scope())
+        .then_ignore(blank())
+        .then(path())
+        .then_ignore(blank().or_not())
+        .then(annotation::parse().or_not())
+        .then_ignore(blank().or_not())
+        .then_ignore(list_separator().or_not())
+        .map(|((scope, name), annotations)| Namespace {
+            scope,
+            name,
+            annotations,
+        })
 }
 
-impl Parser for Scope {
-    fn parse(input: &str) -> IResult<&str, Scope> {
-        map(
-            nom::bytes::complete::take_while1(|c: char| !c.is_whitespace()),
-            |s: &str| Scope(s.into()),
-        )(input)
-    }
+fn is_white_space(c: &char) -> bool {
+    *c == ' ' || *c == '\t' || *c == '\n' || *c == '\r'
+}
+
+fn scope<'a>() -> impl Parser<'a, &'a str, Scope, extra::Err<Rich<'a, char>>> {
+    any()
+        .filter(|c: &char| !is_white_space(c))
+        .repeated()
+        .at_least(1)
+        .collect::<String>()
+        .map(|s: String| Scope(s))
 }
 
 #[cfg(test)]
@@ -43,38 +38,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_scope() {
-        let input = "cocoa ";
-        let (remaining, scope) = Scope::parse(input).unwrap();
-        assert_eq!(scope.0, "cocoa");
-        assert_eq!(remaining, " ");
-
-        let input = "*";
-        let (_, scope) = Scope::parse(input).unwrap();
-        assert_eq!(scope.0, "*");
-
-        let input = "py.twisted";
-        let (_, scope) = Scope::parse(input).unwrap();
-        assert_eq!(scope.0, "py.twisted");
-
-        let input = "  ";
-        let res = Scope::parse(input);
-        assert!(res.is_err());
-    }
-
-    #[test]
     fn test_namespace() {
-        let input = "namespace cocoa java.lang.Object";
-        let (_, namespace) = Namespace::parse(input).unwrap();
-        assert_eq!(namespace.scope.0, "cocoa");
-        assert_eq!(
-            namespace
-                .name
-                .segments
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>(),
-            vec!["java", "lang", "Object"]
-        );
+        let _ = parse().parse("namespace * foo.bar").unwrap();
+        let _ = parse().parse("namespace py.twisted ThriftTest").unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -1,32 +1,36 @@
 use chumsky::prelude::*;
 
 use super::super::parser::*;
-use crate::{Namespace, Scope};
+use crate::{Annotation, Namespace, Scope};
 
-pub fn parse<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
-    just("namespace")
-        .ignore_then(scope().padded_by(blank()))
-        .then(path())
-        .then(annotation::parse().or_not().padded_by(blank().or_not()))
-        .then_ignore(list_separator().or_not())
-        .map(|((scope, name), annotations)| Namespace {
-            scope,
-            name,
-            annotations,
-        })
+impl Namespace {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
+        just("namespace")
+            .ignore_then(Scope::parse().padded_by(blank()))
+            .then(Path::parse())
+            .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+            .then_ignore(list_separator().or_not())
+            .map(|((scope, name), annotations)| Namespace {
+                scope,
+                name,
+                annotations,
+            })
+    }
 }
 
 fn is_white_space(c: &char) -> bool {
     *c == ' ' || *c == '\t' || *c == '\n' || *c == '\r'
 }
 
-fn scope<'a>() -> impl Parser<'a, &'a str, Scope, extra::Err<Rich<'a, char>>> {
-    any()
-        .filter(|c: &char| !is_white_space(c))
-        .repeated()
-        .at_least(1)
-        .collect::<String>()
-        .map(|s: String| Scope(s))
+impl Scope {
+    fn parse<'a>() -> impl Parser<'a, &'a str, Scope, extra::Err<Rich<'a, char>>> {
+        any()
+            .filter(|c: &char| !is_white_space(c))
+            .repeated()
+            .at_least(1)
+            .collect::<String>()
+            .map(|s: String| Scope(s))
+    }
 }
 
 #[cfg(test)]
@@ -35,7 +39,9 @@ mod tests {
 
     #[test]
     fn test_namespace() {
-        let _ = parse().parse("namespace * foo.bar").unwrap();
-        let _ = parse().parse("namespace py.twisted ThriftTest").unwrap();
+        let _ = Namespace::parse().parse("namespace * foo.bar").unwrap();
+        let _ = Namespace::parse()
+            .parse("namespace py.twisted ThriftTest")
+            .unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -4,11 +4,15 @@ use super::super::parser::*;
 use crate::{Annotation, Namespace, Scope};
 
 impl Namespace {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
         just("namespace")
             .ignore_then(Scope::parse().padded_by(blank()))
             .then(Path::parse())
-            .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+            .then(
+                Annotation::get_parser()
+                    .or_not()
+                    .padded_by(blank().or_not()),
+            )
             .then_ignore(list_separator().or_not())
             .map(|((scope, name), annotations)| Namespace {
                 scope,
@@ -39,8 +43,10 @@ mod tests {
 
     #[test]
     fn test_namespace() {
-        let _ = Namespace::parse().parse("namespace * foo.bar").unwrap();
-        let _ = Namespace::parse()
+        let _ = Namespace::get_parser()
+            .parse("namespace * foo.bar")
+            .unwrap();
+        let _ = Namespace::get_parser()
             .parse("namespace py.twisted ThriftTest")
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -5,13 +5,9 @@ use crate::{Namespace, Scope};
 
 pub fn parse<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
     just("namespace")
-        .ignore_then(blank())
-        .ignore_then(scope())
-        .then_ignore(blank())
+        .ignore_then(scope().padded_by(blank()))
         .then(path())
-        .then_ignore(blank().or_not())
-        .then(annotation::parse().or_not())
-        .then_ignore(blank().or_not())
+        .then(annotation::parse().or_not().padded_by(blank().or_not()))
         .then_ignore(list_separator().or_not())
         .map(|((scope, name), annotations)| Namespace {
             scope,

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -1,8 +1,7 @@
 use chumsky::prelude::*;
 
-use crate::Ident;
-
 use super::super::{descriptor::Service, parser::*};
+use crate::Ident;
 
 pub fn parse<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
     let extends = just("extends").padded_by(blank()).ignore_then(path());

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -4,25 +4,25 @@ use super::super::{descriptor::Service, parser::*};
 use crate::{Annotation, Function, Ident};
 
 impl Service {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
         let extends = just("extends")
             .padded_by(blank())
             .ignore_then(Path::parse());
         let functions = blank()
             .or_not()
-            .ignore_then(Function::parse())
+            .ignore_then(Function::get_parser())
             .repeated()
             .collect::<Vec<_>>();
 
         just("service")
             .ignore_then(blank())
-            .ignore_then(Ident::parse())
+            .ignore_then(Ident::get_parser())
             .then(extends.or_not())
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
             .then(functions)
             .then_ignore(just("}").padded_by(blank().or_not()))
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|(((name, extends), functions), annotations)| Service {
                 name: Ident(name.into()),
@@ -38,7 +38,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_service() {
-        let _ = Service::parse().parse(
+        let _ = Service::get_parser().parse(
             r#"service ComplexService {
 
                         /**
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn test_service2() {
-        let _ = Service::parse()
+        let _ = Service::get_parser()
             .parse(
                 r#"service Test {
                             Err test_enum(1: Ok req);

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -25,7 +25,7 @@ impl Service {
             .then(Annotation::parse().or_not())
             .then_ignore(list_separator().or_not())
             .map(|(((name, extends), functions), annotations)| Service {
-                name: Ident(Arc::from(name)),
+                name: Ident(name.into()),
                 extends,
                 functions,
                 annotations: annotations.unwrap_or_default(),

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -7,7 +7,7 @@ use super::super::{
 use crate::{Annotation, Field, Ident};
 
 impl Struct {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Struct, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Struct, extra::Err<Rich<'a, char>>> {
         just("struct")
             .ignore_then(blank())
             .ignore_then(StructLike::parse())
@@ -35,17 +35,17 @@ impl Exception {
 
 impl StructLike {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, StructLike, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+        Ident::get_parser()
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
             .then(
                 blank()
-                    .ignore_then(Field::parse())
+                    .ignore_then(Field::get_parser())
                     .repeated()
                     .collect::<Vec<_>>(),
             )
             .then_ignore(just("}").padded_by(blank().or_not()))
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|((name, fields), annotations)| StructLike {
                 name: Ident(name.into()),
@@ -72,7 +72,7 @@ mod tests {
         }
         "#;
 
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -81,7 +81,7 @@ mod tests {
             // 1
         }
         "#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -90,7 +90,7 @@ mod tests {
             1: string user_id (go.tag = 'json:\"user_id,omitempty\"'),
             2: string __files (go.tag = 'json:\"__files,omitempty\"'),
         }"#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -99,6 +99,6 @@ mod tests {
             1: required string(pilota.annotation="test") Service,      // required service
             2: required bytet_i.Injection Injection,
         }"#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -38,9 +38,7 @@ pub fn struct_like<'a>() -> impl Parser<'a, &'a str, StructLike, extra::Err<Rich
                 .repeated()
                 .collect::<Vec<_>>(),
         )
-        .then_ignore(blank().or_not())
-        .then_ignore(just("}"))
-        .then_ignore(blank().or_not())
+        .then_ignore(just("}").padded_by(blank().or_not()))
         .then(annotation::parse().or_not())
         .then_ignore(list_separator().or_not())
         .map(|((name, fields), annotations)| StructLike {

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -1,11 +1,10 @@
 use chumsky::prelude::*;
 
-use crate::Ident;
-
 use super::super::{
     descriptor::{Exception, Struct, StructLike, Union},
     parser::*,
 };
+use crate::Ident;
 
 pub fn r#struct<'a>() -> impl Parser<'a, &'a str, Struct, extra::Err<Rich<'a, char>>> {
     just("struct")

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -48,7 +48,7 @@ impl StructLike {
             .then(Annotation::parse().or_not())
             .then_ignore(list_separator().or_not())
             .map(|((name, fields), annotations)| StructLike {
-                name: Ident(Arc::from(name)),
+                name: Ident(name.into()),
                 fields,
                 annotations: annotations.unwrap_or_default(),
             })

--- a/pilota-thrift-parser/src/parser/thrift.rs
+++ b/pilota-thrift-parser/src/parser/thrift.rs
@@ -1,29 +1,193 @@
+use std::path::PathBuf;
+
+use ariadne::{Color, Label, Report, ReportKind, Source};
 use chumsky::prelude::*;
+use faststr::FastStr;
 
 use super::super::{descriptor::File, parser::*};
 use crate::{
-    Constant, CppInclude, Enum, Exception, Include, Item, Namespace, Service, Struct, Union,
+    Constant, CppInclude, Enum, Exception, Include, Item, Namespace, Service, Struct, Typedef,
+    Union,
 };
 
 impl Item {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, Item, extra::Err<Rich<'a, char>>> {
         choice((
-            Include::parse().map(Item::Include),
+            Include::get_parser().map(Item::Include),
             CppInclude::parse().map(Item::CppInclude),
-            Namespace::parse().map(Item::Namespace),
-            typedef::type_def().map(Item::Typedef),
-            Constant::parse().map(Item::Constant),
-            Enum::parse().map(Item::Enum),
-            Struct::parse().map(Item::Struct),
+            Namespace::get_parser().map(Item::Namespace),
+            Typedef::get_parser().map(Item::Typedef),
+            Constant::get_parser().map(Item::Constant),
+            Enum::get_parser().map(Item::Enum),
+            Struct::get_parser().map(Item::Struct),
             Union::parse().map(Item::Union),
             Exception::parse().map(Item::Exception),
-            Service::parse().map(Item::Service),
+            Service::get_parser().map(Item::Service),
         ))
     }
 }
 
+pub struct FileSource<'a> {
+    path: Option<PathBuf>,
+    content: &'a str,
+}
+
+impl<'a> FileSource<'a> {
+    pub fn new(inline: &'a str) -> Self {
+        Self {
+            path: None,
+            content: inline,
+        }
+    }
+
+    pub fn new_with_path(path: PathBuf, content: &'a str) -> Result<Self, error::Error> {
+        if !path.exists() {
+            return Err(error::Error::FileNotFound(path));
+        }
+
+        Ok(Self {
+            path: Some(path),
+            content,
+        })
+    }
+}
+
+pub struct FileParser<'a> {
+    pub source: FileSource<'a>,
+}
+
+impl<'a> FileParser<'a> {
+    pub fn new(source: FileSource<'a>) -> Self {
+        Self { source }
+    }
+
+    pub fn parse(&self) -> Result<File, error::Error> {
+        let (ast, errs) = File::get_parser()
+            .parse(self.source.content)
+            .into_output_errors();
+
+        let path_str = match &self.source.path {
+            Some(path) => &path.display().to_string(),
+            None => "inline",
+        };
+
+        if !errs.is_empty() {
+            let mut report_strings = Vec::with_capacity(errs.len() + 1);
+
+            let title = if errs.len() == 1 {
+                format!("Failed to parse thrift file: {}", path_str)
+            } else {
+                format!(
+                    "Failed to parse thrift file: {} ({} errors found)",
+                    path_str,
+                    errs.len()
+                )
+            };
+            report_strings.push(title);
+            report_strings.push(String::new());
+
+            for (i, e) in errs.iter().enumerate() {
+                if errs.len() > 1 {
+                    let error_header = format!("Error {}:", i + 1);
+                    report_strings.push(error_header.clone());
+                }
+
+                let mut buffer = Vec::new();
+                Report::build(ReportKind::Error, (path_str, e.span().into_range()))
+                    .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
+                    .with_message(e.to_string())
+                    .with_label(
+                        Label::new((path_str, e.span().into_range()))
+                            .with_message(e.reason().to_string())
+                            .with_color(Color::Red),
+                    )
+                    .finish()
+                    .write((path_str, Source::from(self.source.content)), &mut buffer)
+                    .unwrap();
+                report_strings.push(String::from_utf8_lossy(&buffer).to_string());
+
+                if i < errs.len() - 1 {
+                    report_strings.push(String::new());
+                }
+            }
+
+            let report = report_strings.join("\n").into();
+            let summary = create_error_summary(&errs, path_str, self.source.content).into();
+            let custom_error = CustomSyntaxError { report };
+
+            return Err(error::Error::Syntax {
+                summary,
+                source: anyhow::anyhow!(custom_error),
+            });
+        }
+
+        Ok(ast.unwrap())
+    }
+}
+
+fn create_error_summary(errs: &[chumsky::error::Rich<char>], path_str: &str, text: &str) -> String {
+    if errs.is_empty() {
+        return String::new();
+    }
+
+    let mut summary = format!("Failed to parse thrift file: {}", path_str);
+
+    if errs.len() == 1 {
+        let err = &errs[0];
+        // 计算行号和列号
+        let (line, col) = calculate_line_col(err.span().start, text);
+        summary.push_str(&format!(" at line {}:{} - {}", line, col, err.reason()));
+    } else {
+        summary.push_str(&format!(" ({} errors found):", errs.len()));
+        for (i, err) in errs.iter().enumerate() {
+            let (line, col) = calculate_line_col(err.span().start, text);
+            summary.push_str(&format!(
+                "\n  {}. Line {}:{} - {}",
+                i + 1,
+                line,
+                col,
+                err.reason()
+            ));
+        }
+    }
+
+    summary
+}
+
+fn calculate_line_col(pos: usize, text: &str) -> (usize, usize) {
+    let mut line = 1;
+    let mut col = 1;
+
+    for (i, ch) in text.char_indices() {
+        if i >= pos {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+
+    (line, col)
+}
+
+#[derive(Debug)]
+pub struct CustomSyntaxError {
+    pub report: FastStr,
+}
+
+impl std::fmt::Display for CustomSyntaxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.report)
+    }
+}
+
+impl std::error::Error for CustomSyntaxError {}
+
 impl File {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, File, extra::Err<Rich<'a, char>>> {
+    pub(crate) fn get_parser<'a>() -> impl Parser<'a, &'a str, File, extra::Err<Rich<'a, char>>> {
         let item_or_none = blank()
             .or_not()
             .ignore_then(Item::parse())
@@ -35,9 +199,10 @@ impl File {
             .then_ignore(blank().or_not())
             .then_ignore(end())
             .map(|items: Vec<Item>| {
-                let mut file = File::default();
-
-                file.items = items;
+                let mut file = File {
+                    items,
+                    ..Default::default()
+                };
 
                 let mut namespaces = file.items.iter().filter_map(|i| match i {
                     Item::Namespace(ns) => Some(ns),
@@ -138,7 +303,7 @@ mod tests {
             BizResponse BizMethod3(1: BizRequest req)(api.post = '/life/client/:action/:biz/other', api.baseurl = 'ib.snssdk.com', api.param = 'true', api.serializer = 'json')
         }
         "#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
@@ -177,7 +342,7 @@ const list<string> TEST_LIST = [
 service Service {
   MyStruct testEpisode(1:MyStruct arg)
 },"#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
@@ -202,7 +367,7 @@ service Service {
 
         # comment 2
         "#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))

--- a/pilota-thrift-parser/src/parser/thrift.rs
+++ b/pilota-thrift-parser/src/parser/thrift.rs
@@ -398,6 +398,7 @@ enum Index {
     B,
 }
 
+// Test Service
 service TestService {
     Test test(1: TEST req);
 }"#;

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -79,10 +79,7 @@ impl Type {
 
             ty_parser
                 .then(Annotation::parse().or_not().padded_by(blank().or_not()))
-                .map(|(ty, an)| {
-                    // println!("type: {:?}, an: {:?}", ty, an);
-                    Type(ty, an.unwrap_or_default())
-                })
+                .map(|(ty, an)| Type(ty, an.unwrap_or_default()))
                 .boxed()
         })
         .boxed()

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -33,7 +33,7 @@ impl Type {
                 just("double").to(Ty::Double),
                 just("uuid").to(Ty::Uuid),
             ))
-            .then_ignore(any().and_is(not_alphanumeric_or_underscore()).rewind());
+            .then_ignore(not_alphanumeric_or_underscore());
 
             let list = just("list")
                 .ignore_then(just("<").padded_by(blank().or_not()))

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -18,7 +18,7 @@ impl CppType {
 }
 
 impl Type {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
         recursive(|self_parser| {
             let base_ty = choice((
                 just("string").to(Ty::String),
@@ -78,7 +78,11 @@ impl Type {
             let ty_parser = choice((base_ty, list, set, map_parser, Path::parse().map(Ty::Path)));
 
             ty_parser
-                .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+                .then(
+                    Annotation::get_parser()
+                        .or_not()
+                        .padded_by(blank().or_not()),
+                )
                 .map(|(ty, an)| Type(ty, an.unwrap_or_default()))
                 .boxed()
         })
@@ -94,14 +98,14 @@ mod tests {
 
     #[test]
     fn test_type() {
-        let parser = Type::parse();
+        let parser = Type::get_parser();
         let input = "map<i32, string>";
         let _res = parser.parse(input).unwrap();
     }
 
     #[test]
     fn test_type_path() {
-        let parser = Type::parse();
+        let parser = Type::get_parser();
         let input = "bytet_i.Injection";
         let _res = parser.parse(input).unwrap();
     }

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -1,5 +1,6 @@
-use chumsky::prelude::*;
 use std::sync::Arc;
+
+use chumsky::prelude::*;
 
 use super::super::{
     descriptor::{CppType, Ty, Type},

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -6,82 +6,87 @@ use super::super::{
     descriptor::{CppType, Ty, Type},
     parser::*,
 };
+use crate::{Annotation, Literal};
 
-pub fn cpp_type<'a>() -> impl Parser<'a, &'a str, CppType, extra::Err<Rich<'a, char>>> {
-    just("cpp_type")
-        .ignore_then(blank())
-        .ignore_then(literal::parse())
-        .map(CppType)
+impl CppType {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, CppType, extra::Err<Rich<'a, char>>> {
+        just("cpp_type")
+            .ignore_then(blank())
+            .ignore_then(Literal::parse())
+            .map(CppType)
+    }
 }
 
-pub fn r#type<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
-    recursive(|self_parser| {
-        let base_ty = choice((
-            just("string").to(Ty::String),
-            just("void").to(Ty::Void),
-            just("byte").to(Ty::Byte),
-            just("bool").to(Ty::Bool),
-            just("binary").to(Ty::Binary),
-            just("i8").to(Ty::I8),
-            just("i16").to(Ty::I16),
-            just("i32").to(Ty::I32),
-            just("i64").to(Ty::I64),
-            just("double").to(Ty::Double),
-            just("uuid").to(Ty::Uuid),
-        ))
-        .then_ignore(any().and_is(not_alphanumeric_or_underscore()).rewind());
+impl Type {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
+        recursive(|self_parser| {
+            let base_ty = choice((
+                just("string").to(Ty::String),
+                just("void").to(Ty::Void),
+                just("byte").to(Ty::Byte),
+                just("bool").to(Ty::Bool),
+                just("binary").to(Ty::Binary),
+                just("i8").to(Ty::I8),
+                just("i16").to(Ty::I16),
+                just("i32").to(Ty::I32),
+                just("i64").to(Ty::I64),
+                just("double").to(Ty::Double),
+                just("uuid").to(Ty::Uuid),
+            ))
+            .then_ignore(any().and_is(not_alphanumeric_or_underscore()).rewind());
 
-        let list = just("list")
-            .ignore_then(just("<").padded_by(blank().or_not()))
-            .ignore_then(self_parser.clone())
-            .then_ignore(blank().or_not())
-            .then_ignore(just(">"))
-            .then(blank().ignore_then(cpp_type()).or_not())
-            .map(|(inner_type, cpp_type)| Ty::List {
-                value: Arc::new(inner_type),
-                cpp_type,
-            })
-            .boxed();
+            let list = just("list")
+                .ignore_then(just("<").padded_by(blank().or_not()))
+                .ignore_then(self_parser.clone())
+                .then_ignore(blank().or_not())
+                .then_ignore(just(">"))
+                .then(blank().ignore_then(CppType::parse()).or_not())
+                .map(|(inner_type, cpp_type)| Ty::List {
+                    value: Arc::new(inner_type),
+                    cpp_type,
+                })
+                .boxed();
 
-        let set = just("set")
-            .ignore_then(blank().ignore_then(cpp_type()).or_not())
-            .then_ignore(just("<"))
-            .padded_by(blank().or_not())
-            .then(self_parser.clone())
-            .then_ignore(blank().or_not())
-            .then_ignore(just(">"))
-            .map(|(cpp_type, inner_type)| Ty::Set {
-                value: Arc::new(inner_type),
-                cpp_type,
-            })
-            .boxed();
+            let set = just("set")
+                .ignore_then(blank().ignore_then(CppType::parse()).or_not())
+                .then_ignore(just("<"))
+                .padded_by(blank().or_not())
+                .then(self_parser.clone())
+                .then_ignore(blank().or_not())
+                .then_ignore(just(">"))
+                .map(|(cpp_type, inner_type)| Ty::Set {
+                    value: Arc::new(inner_type),
+                    cpp_type,
+                })
+                .boxed();
 
-        let map_parser = just("map")
-            .ignore_then(blank().ignore_then(cpp_type()).or_not())
-            .then_ignore(just("<").padded_by(blank().or_not()))
-            .then(self_parser.clone())
-            .then_ignore(list_separator().padded_by(blank().or_not()))
-            .then(self_parser.clone())
-            .then_ignore(blank().or_not())
-            .then_ignore(just(">"))
-            .map(|((cpp_type, key_type), value_type)| Ty::Map {
-                key: Arc::new(key_type),
-                value: Arc::new(value_type),
-                cpp_type,
-            })
-            .boxed();
+            let map_parser = just("map")
+                .ignore_then(blank().ignore_then(CppType::parse()).or_not())
+                .then_ignore(just("<").padded_by(blank().or_not()))
+                .then(self_parser.clone())
+                .then_ignore(list_separator().padded_by(blank().or_not()))
+                .then(self_parser.clone())
+                .then_ignore(blank().or_not())
+                .then_ignore(just(">"))
+                .map(|((cpp_type, key_type), value_type)| Ty::Map {
+                    key: Arc::new(key_type),
+                    value: Arc::new(value_type),
+                    cpp_type,
+                })
+                .boxed();
 
-        let ty_parser = choice((base_ty, list, set, map_parser, path().map(Ty::Path)));
+            let ty_parser = choice((base_ty, list, set, map_parser, Path::parse().map(Ty::Path)));
 
-        ty_parser
-            .then(annotation::parse().or_not().padded_by(blank().or_not()))
-            .map(|(ty, an)| {
-                // println!("type: {:?}, an: {:?}", ty, an);
-                Type(ty, an.unwrap_or_default())
-            })
-            .boxed()
-    })
-    .boxed()
+            ty_parser
+                .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+                .map(|(ty, an)| {
+                    // println!("type: {:?}, an: {:?}", ty, an);
+                    Type(ty, an.unwrap_or_default())
+                })
+                .boxed()
+        })
+        .boxed()
+    }
 }
 
 //test
@@ -92,14 +97,14 @@ mod tests {
 
     #[test]
     fn test_type() {
-        let parser = r#type();
+        let parser = Type::parse();
         let input = "map<i32, string>";
         let _res = parser.parse(input).unwrap();
     }
 
     #[test]
     fn test_type_path() {
-        let parser = r#type();
+        let parser = Type::parse();
         let input = "bytet_i.Injection";
         let _res = parser.parse(input).unwrap();
     }

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -6,9 +6,7 @@ use super::super::{descriptor::Typedef, parser::*};
 
 pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
     just("typedef")
-        .ignore_then(blank())
-        .ignore_then(ty::r#type())
-        .then_ignore(blank())
+        .ignore_then(ty::r#type().padded_by(blank()))
         .then(identifier::parse())
         .then_ignore(blank().or_not())
         .then(annotation::parse().or_not())

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -12,7 +12,7 @@ pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, c
         .then_ignore(list_separator().or_not())
         .map(|((r#type, alias), annotations)| Typedef {
             r#type,
-            alias: Ident(Arc::from(alias)),
+            alias: Ident(alias.into()),
             annotations: annotations.unwrap_or_default(),
         })
 }

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -3,18 +3,20 @@ use chumsky::prelude::*;
 use super::super::{descriptor::Typedef, parser::*};
 use crate::{Annotation, Type, descriptor::Ident};
 
-pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
-    just("typedef")
-        .ignore_then(Type::parse().padded_by(blank()))
-        .then(Ident::parse())
-        .then_ignore(blank().or_not())
-        .then(Annotation::parse().or_not())
-        .then_ignore(list_separator().or_not())
-        .map(|((r#type, alias), annotations)| Typedef {
-            r#type,
-            alias: Ident(alias.into()),
-            annotations: annotations.unwrap_or_default(),
-        })
+impl Typedef {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
+        just("typedef")
+            .ignore_then(Type::get_parser().padded_by(blank()))
+            .then(Ident::get_parser())
+            .then_ignore(blank().or_not())
+            .then(Annotation::get_parser().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(|((r#type, alias), annotations)| Typedef {
+                r#type,
+                alias: Ident(alias.into()),
+                annotations: annotations.unwrap_or_default(),
+            })
+    }
 }
 
 #[cfg(test)]
@@ -23,6 +25,6 @@ mod tests {
 
     #[test]
     fn test_type_def() {
-        let _td = type_def().parse("typedef i32 Int32,").unwrap();
+        let _td = Typedef::get_parser().parse("typedef i32 Int32,").unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -1,8 +1,7 @@
 use chumsky::prelude::*;
 
-use crate::descriptor::Ident;
-
 use super::super::{descriptor::Typedef, parser::*};
+use crate::descriptor::Ident;
 
 pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
     just("typedef")

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -1,33 +1,31 @@
-use nom::{
-    IResult,
-    bytes::complete::tag,
-    combinator::{map, opt},
-    sequence::tuple,
-};
+use chumsky::prelude::*;
 
-use super::super::{
-    descriptor::{Annotations, Ident, Type, Typedef},
-    parser::*,
-};
+use crate::descriptor::Ident;
 
-impl Parser for Typedef {
-    fn parse(input: &str) -> IResult<&str, Typedef> {
-        map(
-            tuple((
-                tag("typedef"),
-                blank,
-                Type::parse,
-                blank,
-                Ident::parse,
-                opt(blank),
-                opt(Annotations::parse),
-                opt(list_separator),
-            )),
-            |(_, _, r#type, _, alias, _, annotations, _)| Typedef {
-                r#type,
-                alias,
-                annotations: annotations.unwrap_or_default(),
-            },
-        )(input)
+use super::super::{descriptor::Typedef, parser::*};
+
+pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
+    just("typedef")
+        .ignore_then(blank())
+        .ignore_then(ty::r#type())
+        .then_ignore(blank())
+        .then(identifier::parse())
+        .then_ignore(blank().or_not())
+        .then(annotation::parse().or_not())
+        .then_ignore(list_separator().or_not())
+        .map(|((r#type, alias), annotations)| Typedef {
+            r#type,
+            alias: Ident(Arc::from(alias)),
+            annotations: annotations.unwrap_or_default(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_type_def() {
+        let _td = type_def().parse("typedef i32 Int32,").unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chumsky::prelude::*;
 
 use super::super::{descriptor::Typedef, parser::*};
@@ -5,13 +7,19 @@ use crate::{Annotation, Type, descriptor::Ident};
 
 impl Typedef {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
-        just("typedef")
-            .ignore_then(Type::get_parser().padded_by(blank()))
+        comment()
+            .repeated()
+            .collect::<Vec<_>>()
+            .then_ignore(blank().or_not())
+            .then_ignore(just("typedef"))
+            .then_ignore(blank())
+            .then(Type::get_parser().padded_by(blank()))
             .then(Ident::get_parser())
             .then_ignore(blank().or_not())
             .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
-            .map(|((r#type, alias), annotations)| Typedef {
+            .map(|(((comments, r#type), alias), annotations)| Typedef {
+                comments: Arc::new(comments.join("\n\n")),
                 r#type,
                 alias: Ident(alias.into()),
                 annotations: annotations.unwrap_or_default(),

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -1,14 +1,14 @@
 use chumsky::prelude::*;
 
 use super::super::{descriptor::Typedef, parser::*};
-use crate::descriptor::Ident;
+use crate::{Annotation, Type, descriptor::Ident};
 
 pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
     just("typedef")
-        .ignore_then(ty::r#type().padded_by(blank()))
-        .then(identifier::parse())
+        .ignore_then(Type::parse().padded_by(blank()))
+        .then(Ident::parse())
         .then_ignore(blank().or_not())
-        .then(annotation::parse().or_not())
+        .then(Annotation::parse().or_not())
         .then_ignore(list_separator().or_not())
         .map(|((r#type, alias), annotations)| Typedef {
             r#type,

--- a/pilota-thrift-reflect/Cargo.toml
+++ b/pilota-thrift-reflect/Cargo.toml
@@ -27,6 +27,7 @@ bytes.workspace = true
 dashmap.workspace = true
 faststr.workspace = true
 thiserror.workspace = true
+chumsky.workspace = true
 
 [build-dependencies]
 # pilota-build = { path = "../pilota-build" }

--- a/pilota-thrift-reflect/examples/idl/apache.thrift
+++ b/pilota-thrift-reflect/examples/idl/apache.thrift
@@ -63,8 +63,7 @@ const Numberz myNumberz = Numberz.ONE;
 
 typedef i64 UserId
 
-struct Bonk
-{
+struct Bonk {
   1: string message,
   2: i32 type
 }

--- a/pilota-thrift-reflect/examples/main.rs
+++ b/pilota-thrift-reflect/examples/main.rs
@@ -9,7 +9,7 @@ fn main() {
     println!("{}", idl_path.display());
 
     let content = std::fs::read_to_string(&idl_path).unwrap();
-    let mut parsed_file = pilota_thrift_parser::parser::thrift::file()
+    let mut parsed_file = pilota_thrift_parser::descriptor::File::parse()
         .parse(&content)
         .unwrap();
     parsed_file.path = idl_path.into();

--- a/pilota-thrift-reflect/examples/main.rs
+++ b/pilota-thrift-reflect/examples/main.rs
@@ -1,15 +1,17 @@
 use std::path::PathBuf;
 
 use bytes::BytesMut;
+use chumsky::prelude::*;
 use pilota::thrift::Message as _;
-use pilota_thrift_parser::parser::Parser as _;
 
 fn main() {
     let idl_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/idl/apache.thrift");
     println!("{}", idl_path.display());
 
     let content = std::fs::read_to_string(&idl_path).unwrap();
-    let mut parsed_file = pilota_thrift_parser::File::parse(&content).unwrap().1;
+    let mut parsed_file = pilota_thrift_parser::parser::thrift::file()
+        .parse(&content)
+        .unwrap();
     parsed_file.path = idl_path.into();
 
     let descriptor: pilota_thrift_reflect::thrift_reflection::FileDescriptor =

--- a/pilota-thrift-reflect/examples/main.rs
+++ b/pilota-thrift-reflect/examples/main.rs
@@ -9,9 +9,22 @@ fn main() {
     println!("{}", idl_path.display());
 
     let content = std::fs::read_to_string(&idl_path).unwrap();
-    let mut parsed_file = pilota_thrift_parser::descriptor::File::parse()
-        .parse(&content)
-        .unwrap();
+    let ret = pilota_thrift_parser::parser::thrift::FileParser::new(
+        pilota_thrift_parser::FileSource::new_with_path(idl_path.clone(), &content).unwrap(),
+    )
+    .parse();
+    let mut parsed_file = match ret {
+        Ok(parsed_file) => parsed_file,
+        Err(e) => {
+            eprintln!("{}", e);
+            return;
+        }
+    };
+    // let mut parsed_file =
+    // pilota_thrift_parser::parser::thrift::FileParser::new(idl_path.clone())
+    //     .parse()
+    //     .unwrap();
+
     parsed_file.path = idl_path.into();
 
     let descriptor: pilota_thrift_reflect::thrift_reflection::FileDescriptor =

--- a/pilota/src/pb/extension.rs
+++ b/pilota/src/pb/extension.rs
@@ -81,7 +81,7 @@ impl OptionValueExtractor for UInt64OptionValueExtractor {
     type Value = u64;
     fn get_from_unknown(value: protobuf::UnknownValueRef) -> Result<Self::Value, DecodeError> {
         match value {
-            protobuf::UnknownValueRef::Varint(v) => Ok(v as u64),
+            protobuf::UnknownValueRef::Varint(v) => Ok(v),
             _ => Err(DecodeError::new("invalid value for u64")),
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

Currently, the Pilota build completely ignores comments in the user's IDL, which makes it harder for users to understand the meaning and usage of each field.
It is necessary to preserve all comments from the IDL in the generated code, including those for structs, enums, fields, services, methods, and types.

## Solution

