### PR TITLE
refactor(pilota-thirft-parser): better parser errors with chumsky and codegen with comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,19 @@ checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "ariadne"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
 
 [[package]]
 name = "async-recursion"
@@ -156,10 +166,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chumsky"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14377e276b2c8300513dff55ba4cc4142b44e5d6de6d00eb5b2307d650bb4ec1"
+dependencies = [
+ "hashbrown 0.15.5",
+ "regex-automata 0.3.9",
+ "serde",
+ "stacker",
+ "unicode-ident",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "ciborium"
@@ -190,18 +224,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.48"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.48"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -361,6 +395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,7 +427,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -424,12 +464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
-
-[[package]]
 name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,12 +495,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -525,9 +559,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -590,7 +624,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.4.10",
 ]
 
 [[package]]
@@ -666,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "normpath"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+checksum = "c178369371fd7db523726931e50d430b560e3059665abc537ba3277e9274c9c4"
 dependencies = [
  "windows-sys 0.61.0",
 ]
@@ -847,6 +881,8 @@ version = "0.12.15"
 dependencies = [
  "ahash",
  "anyhow",
+ "ariadne",
+ "chumsky",
  "criterion",
  "dashmap",
  "diffy",
@@ -887,6 +923,7 @@ name = "pilota-thrift-fieldmask"
 version = "0.1.2"
 dependencies = [
  "ahash",
+ "chumsky",
  "faststr",
  "nom",
  "pilota",
@@ -898,9 +935,11 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
+ "ariadne",
  "bytes",
+ "chumsky",
  "faststr",
  "nom",
 ]
@@ -911,6 +950,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "bytes",
+ "chumsky",
  "dashmap",
  "faststr",
  "pilota",
@@ -978,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -990,7 +1030,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.6",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1030,6 +1070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1176,8 +1225,19 @@ checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -1188,8 +1248,14 @@ checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.6",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -1366,38 +1432,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seize"
-version = "0.5.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+checksum = "e4b8d813387d566f627f3ea1b914c068aac94c40ae27ec43f5f33bde65abefe7"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.226"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1406,24 +1462,23 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -1447,6 +1502,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simdutf8"
@@ -1473,6 +1534,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -1604,12 +1678,12 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.7"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap",
- "serde_core",
+ "serde",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
@@ -1619,27 +1693,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tracing"
@@ -1693,7 +1767,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata",
+ "regex-automata 0.4.10",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1710,9 +1784,21 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1769,27 +1855,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.7+wasi-0.2.4"
+version = "0.14.5+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.0+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1800,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
 dependencies = [
  "bumpalo",
  "log",
@@ -1814,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1824,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1837,18 +1923,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1980,9 +2066,15 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
 dependencies = [
+ "concolor",
  "unicode-width",
  "yansi",
 ]
@@ -114,7 +115,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -131,6 +132,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -167,9 +174,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -246,6 +253,26 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
+name = "concolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b946244a988c390a94667ae0e3958411fa40cc46ea496a929b263d883f5f9c3"
+dependencies = [
+ "bitflags 1.3.2",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
+dependencies = [
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "criterion"
@@ -427,7 +454,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -479,6 +506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -528,9 +561,20 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -559,9 +603,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "6247da8b8658ad4e73a186e747fcc5fc2a29f979d6fe6269127fdb5fd08298d0"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -787,7 +831,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -920,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-fieldmask"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "ahash",
  "chumsky",
@@ -937,11 +981,13 @@ dependencies = [
 name = "pilota-thrift-parser"
 version = "0.12.2"
 dependencies = [
+ "anyhow",
  "ariadne",
  "bytes",
  "chumsky",
  "faststr",
  "nom",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -1024,7 +1070,7 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.9.4",
  "lazy_static",
  "num-traits",
  "rand 0.9.2",
@@ -1214,7 +1260,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -1322,7 +1368,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1335,7 +1381,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -1432,28 +1478,38 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seize"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b8d813387d566f627f3ea1b914c068aac94c40ae27ec43f5f33bde65abefe7"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1462,23 +1518,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "2789234a13a53fc4be1b51ea1bab45a3c338bdb884862a257d10e5a74ae009e6"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1678,12 +1735,12 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
@@ -1693,11 +1750,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "a197c0ec7d131bfc6f7e82c8442ba1595aeab35da7adbf05b6b73cd06a16b6be"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1784,9 +1841,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1855,27 +1912,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "4ad224d2776649cfb4f4471124f8176e54c1cca67a88108e30a0cd98b90e7ad3"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1886,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "3a1364104bdcd3c03f22b16a3b1c9620891469f5e9f09bc38b2db121e593e732"
 dependencies = [
  "bumpalo",
  "log",
@@ -1900,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "0d7ab4ca3e367bb1ed84ddbd83cc6e41e115f8337ed047239578210214e36c76"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1910,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "4a518014843a19e2dbbd0ed5dfb6b99b23fb886b14e6192a00803a3e14c552b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1923,18 +1980,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "255eb0aa4cc2eea3662a00c2bbd66e93911b7361d5e0fcd62385acfd7e15dcee"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "50462a022f46851b81d5441d1a6f5bac0b21a1d72d64bd4906fbdd4bf7230ec7"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1969,11 +2026,20 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1982,7 +2048,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1996,19 +2062,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2018,9 +2105,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2036,9 +2135,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2048,9 +2159,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2066,9 +2189,9 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 ahash = "0.8"
 anyhow = "1"
+ariadne = "0.5"
 async-recursion = "1"
 bytes = { version = "1", features = ["serde"] }
+chumsky = "0.10"
 criterion = { version = "0.7", features = ["html_reports"] }
 dashmap = "6"
 diffy = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.85.0"
 [workspace.dependencies]
 ahash = "0.8"
 anyhow = "1"
-ariadne = "0.5"
+ariadne = { version = "0.5", features = ["auto-color"] }
 async-recursion = "1"
 bytes = { version = "1", features = ["serde"] }
 chumsky = "0.10"

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -50,6 +50,8 @@ tracing-subscriber.workspace = true
 
 protobuf-parse.workspace = true
 protobuf.workspace = true
+chumsky.workspace = true
+ariadne.workspace = true
 
 [dev-dependencies]
 pilota-thrift-fieldmask = { path = "../pilota-thrift-fieldmask" }

--- a/pilota-build/examples/salsa_cache_demo.rs
+++ b/pilota-build/examples/salsa_cache_demo.rs
@@ -31,8 +31,12 @@ fn main() {
 
     // Create a service item
     let service = rir::Item::Service(rir::Service {
+        leading_comments: "".into(),
+        trailing_comments: "".into(),
         name: "TestService".into(),
         methods: vec![Arc::new(Method {
+            leading_comments: "".into(),
+            trailing_comments: "".into(),
             def_id: DefId::from_u32(1),
             name: "method1".into(),
             args: vec![],

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -644,11 +644,10 @@ where
                     }
                 }
 
-                // 2.3 items
-                if this.config.split {
-                    Self::write_split_mod(this, base_dir, mod_path, items, &mut stream, &mut dup);
+                if this.split {
+                    Self::write_split_mod(this, base_dir, p, &def_ids, &mut stream, &mut dup);
                 } else {
-                    for def_id in items.iter() {
+                    for def_id in def_ids.iter() {
                         this.write_item(&mut stream, *def_id, &mut dup)
                     }
                 }

--- a/pilota-build/src/db.rs
+++ b/pilota-build/src/db.rs
@@ -490,6 +490,8 @@ mod tests {
             fields,
             is_wrapper: false,
             item_exts: ItemExts::Thrift,
+            leading_comments: FastStr::new(""),
+            trailing_comments: FastStr::new(""),
         }))
     }
 
@@ -511,6 +513,7 @@ mod tests {
             uses: vec![],
             descriptor: Bytes::new(),
             extensions: FileExts::Thrift,
+            comments: FastStr::new(""),
         })
     }
 
@@ -584,6 +587,8 @@ mod tests {
             tags_id: TagId::from_u32(0),
             default: None,
             item_exts: ItemExts::Thrift,
+            leading_comments: FastStr::new(""),
+            trailing_comments: FastStr::new(""),
         });
         let referrer_item = make_message_item("Ref", vec![dep_field]);
 

--- a/pilota-build/src/fmt.rs
+++ b/pilota-build/src/fmt.rs
@@ -13,6 +13,8 @@ pub fn fmt_file<P: AsRef<Path>>(file: P) {
     };
 
     let result = Command::new(std::env::var("RUSTFMT").unwrap_or_else(|_| "rustfmt".to_owned()))
+        .arg("--config")
+        .arg("wrap_comments=true")
         .arg("--emit")
         .arg("files")
         .arg("--edition")

--- a/pilota-build/src/ir/mod.rs
+++ b/pilota-build/src/ir/mod.rs
@@ -3,7 +3,7 @@
 use std::{fmt::Display, sync::Arc};
 
 use itertools::Itertools;
-use pilota::Bytes;
+use pilota::{Bytes, FastStr};
 
 use crate::{
     symbol::{EnumRepr, FileId, Ident, Symbol},
@@ -90,14 +90,18 @@ pub struct Method {
     pub oneway: bool,
     pub exceptions: Option<Path>,
     pub tags: Arc<Tags>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ext::ItemExts,
 }
 
 #[derive(Clone, Debug)]
 pub struct Service {
+    pub leading_comments: FastStr,
     pub name: Ident,
     pub methods: Vec<Method>,
     pub extend: Vec<Path>,
+    pub trailing_comments: FastStr,
     pub item_exts: ext::ItemExts,
 }
 
@@ -106,6 +110,8 @@ pub struct Const {
     pub name: Ident,
     pub ty: Ty,
     pub lit: Literal,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 #[derive(Clone, Debug)]
@@ -122,6 +128,8 @@ pub struct Field {
     pub kind: FieldKind,
     pub tags: Arc<Tags>,
     pub default: Option<Literal>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ext::ItemExts,
 }
 
@@ -131,6 +139,8 @@ pub struct Message {
     pub fields: Vec<Field>,
     pub is_wrapper: bool,
     pub item_exts: ext::ItemExts,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 #[derive(Clone, Debug)]
@@ -140,6 +150,8 @@ pub struct EnumVariant {
     pub discr: Option<i64>,
     pub fields: Vec<Ty>,
     pub tags: Arc<Tags>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ext::ItemExts,
 }
 
@@ -148,6 +160,8 @@ pub struct Enum {
     pub name: Ident,
     pub variants: Vec<EnumVariant>,
     pub repr: Option<EnumRepr>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ext::ItemExts,
 }
 
@@ -155,6 +169,8 @@ pub struct Enum {
 pub struct NewType {
     pub name: Ident,
     pub ty: Ty,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 /// Mod is for protobuf nested messages
@@ -220,4 +236,5 @@ pub struct File {
     pub uses: Vec<(Path, FileId)>,
     pub descriptor: Bytes,
     pub extensions: ext::FileExts,
+    pub comments: FastStr,
 }

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -1309,6 +1309,8 @@ mod tests {
             fields: Vec::new(),
             is_wrapper: false,
             item_exts: ItemExts::Thrift,
+            leading_comments: FastStr::new(""),
+            trailing_comments: FastStr::new(""),
         }));
 
         let dep_node = rir::Node {
@@ -1336,6 +1338,8 @@ mod tests {
             tags_id: tag_id,
             default: None,
             item_exts: ItemExts::Thrift,
+            leading_comments: FastStr::new(""),
+            trailing_comments: FastStr::new(""),
         });
 
         let root_message = Arc::new(rir::Item::Message(Message {
@@ -1343,6 +1347,8 @@ mod tests {
             fields: vec![field],
             is_wrapper: false,
             item_exts: ItemExts::Thrift,
+            leading_comments: FastStr::new(""),
+            trailing_comments: FastStr::new(""),
         }));
 
         let root_node = rir::Node {
@@ -1367,6 +1373,7 @@ mod tests {
             uses: Vec::new(),
             descriptor: Bytes::new(),
             extensions: FileExts::Thrift,
+            comments: FastStr::new(""),
         };
 
         let file_arc = Arc::new(file);

--- a/pilota-build/src/middle/rir.rs
+++ b/pilota-build/src/middle/rir.rs
@@ -1,5 +1,6 @@
 use std::{ops::Deref, sync::Arc};
 
+use faststr::FastStr;
 use pilota::Bytes;
 
 use super::ty::Ty;
@@ -50,6 +51,8 @@ pub struct Method {
     pub oneway: bool,
     pub exceptions: Option<Path>,
     pub source: MethodSource,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ItemExts,
 }
 
@@ -58,6 +61,8 @@ pub struct Service {
     pub name: Ident,
     pub methods: Vec<Arc<Method>>,
     pub extend: Vec<Path>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ItemExts,
 }
 
@@ -66,6 +71,8 @@ pub struct Const {
     pub name: Ident,
     pub ty: Ty,
     pub lit: Literal,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Copy)]
@@ -83,6 +90,8 @@ pub struct Field {
     pub kind: FieldKind,
     pub tags_id: TagId,
     pub default: Option<Literal>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ItemExts,
 }
 
@@ -102,6 +111,8 @@ pub struct Message {
     pub fields: Vec<Arc<Field>>,
     pub is_wrapper: bool,
     pub item_exts: ItemExts,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -111,6 +122,8 @@ pub struct EnumVariant {
     pub name: Ident,
     pub discr: Option<i64>,
     pub fields: Vec<Ty>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ItemExts,
 }
 
@@ -119,6 +132,8 @@ pub struct Enum {
     pub name: Ident,
     pub variants: Vec<Arc<EnumVariant>>,
     pub repr: Option<EnumRepr>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
     pub item_exts: ItemExts,
 }
 
@@ -126,6 +141,8 @@ pub struct Enum {
 pub struct NewType {
     pub name: Ident,
     pub ty: Ty,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -206,6 +223,7 @@ pub struct File {
     pub uses: Vec<FileId>,
     pub descriptor: Bytes,
     pub extensions: FileExts,
+    pub comments: FastStr,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -318,11 +318,15 @@ impl Lower {
             related_items: Default::default(),
             tags: Arc::new(self.extract_enum_tags(e)),
             kind: ir::ItemKind::Enum(ir::Enum {
+                leading_comments: "".into(),
+                trailing_comments: "".into(),
                 name: FastStr::new(e.name()).into(),
                 variants: e
                     .value
                     .iter()
                     .map(|v| ir::EnumVariant {
+                        leading_comments: "".into(),
+                        trailing_comments: "".into(),
                         id: v.number,
                         name: FastStr::new(v.name()).into(),
                         discr: v.number.map(|v| v as i64),
@@ -399,11 +403,15 @@ impl Lower {
                     related_items: Default::default(),
                     tags: Arc::new(crate::tags!(OneOf)),
                     kind: ir::ItemKind::Enum(ir::Enum {
+                        leading_comments: "".into(),
+                        trailing_comments: "".into(),
                         name: FastStr::new(d.name()).into(),
                         repr: None,
                         variants: fields
                             .iter()
                             .map(|(_, f)| ir::EnumVariant {
+                                leading_comments: "".into(),
+                                trailing_comments: "".into(),
                                 discr: None,
                                 id: f.number,
                                 name: FastStr::new(f.name()).into(),
@@ -434,6 +442,8 @@ impl Lower {
                 extra_fields.push((
                     fields[0].0,
                     ir::Field {
+                        leading_comments: "".into(),
+                        trailing_comments: "".into(),
                         name: FastStr::new(d.name()).into(),
                         id: -1,
                         ty: ir::Ty {
@@ -481,6 +491,8 @@ impl Lower {
             related_items: Default::default(),
             tags: Arc::new(self.extract_message_tags(message)),
             kind: ir::ItemKind::Message(ir::Message {
+                leading_comments: "".into(),
+                trailing_comments: "".into(),
                 fields: fields
                     .iter()
                     .map(|(idx, f)| {
@@ -519,6 +531,8 @@ impl Lower {
                         (
                             *idx,
                             ir::Field {
+                                leading_comments: "".into(),
+                                trailing_comments: "".into(),
                                 default: None,
                                 id: f.number(),
                                 name: FastStr::new(f.name()).into(),
@@ -571,6 +585,8 @@ impl Lower {
                     related_items: Default::default(),
                     tags: Arc::new(Tags::default()),
                     kind: ir::ItemKind::Const(ir::Const {
+                        leading_comments: "".into(),
+                        trailing_comments: "".into(),
                         name: FastStr::new(format!("__PILOTA_PB_EXT_{}", name)).into(),
                         ty: ir::Ty {
                             kind: ir::TyKind::String,
@@ -605,6 +621,8 @@ impl Lower {
             tags: Arc::new(service_tags),
             related_items: Default::default(),
             kind: ir::ItemKind::Service(ir::Service {
+                leading_comments: "".into(),
+                trailing_comments: "".into(),
                 name: FastStr::new(service.name()).into(),
                 methods: service
                     .method
@@ -624,6 +642,8 @@ impl Lower {
                         }
 
                         ir::Method {
+                            leading_comments: "".into(),
+                            trailing_comments: "".into(),
                             name: FastStr::new(m.name()).into(),
                             tags: Arc::new(tags),
                             args: vec![ir::Arg {
@@ -748,6 +768,7 @@ impl Lower {
                             f.options.special_fields.unknown_fields(),
                         ),
                     }),
+                    comments: FastStr::from("".to_string()),
                 };
 
                 if f.items.is_empty() && f.extensions.has_extendees() {
@@ -755,6 +776,8 @@ impl Lower {
                         related_items: Default::default(),
                         tags: Arc::new(Tags::default()),
                         kind: ir::ItemKind::Const(ir::Const {
+                            leading_comments: "".into(),
+                            trailing_comments: "".into(),
                             name: FastStr::new(format!("__PILOTA_PB_EXT_{}", file_id.as_u32()))
                                 .into(),
                             ty: ir::Ty {

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -164,6 +164,8 @@ impl ThriftLower {
             .collect::<FxHashSet<_>>();
 
         let kind = ir::ItemKind::Service(ir::Service {
+            leading_comments: service.leading_comments.clone(),
+            trailing_comments: service.trailing_comments.clone(),
             name: self.lower_ident(&service.name),
             extend: service
                 .extends
@@ -190,6 +192,8 @@ impl ThriftLower {
                 .throws
                 .iter()
                 .map(|f| ir::EnumVariant {
+                    leading_comments: f.leading_comments.clone(),
+                    trailing_comments: f.trailing_comments.clone(),
                     id: Some(f.id),
                     name: if f.name.is_empty() {
                         match &f.ty.0 {
@@ -223,8 +227,12 @@ impl ThriftLower {
 
             let name: Ident = format!("{}{}ResultRecv", service_name, method_name).into();
             let kind = ir::ItemKind::Enum(ir::Enum {
+                leading_comments: f.leading_comments.clone(),
+                trailing_comments: f.trailing_comments.clone(),
                 name: name.clone(),
                 variants: std::iter::once(ir::EnumVariant {
+                    leading_comments: f.leading_comments.clone(),
+                    trailing_comments: f.trailing_comments.clone(),
                     id: Some(0),
                     name: "Ok".into(),
                     tags: Default::default(),
@@ -245,8 +253,12 @@ impl ThriftLower {
 
             let name: Ident = format!("{service_name}{method_name}ResultSend").into();
             let kind = ir::ItemKind::Enum(ir::Enum {
+                leading_comments: f.leading_comments.clone(),
+                trailing_comments: f.trailing_comments.clone(),
                 name: name.clone(),
                 variants: std::iter::once(ir::EnumVariant {
+                    leading_comments: f.leading_comments.clone(),
+                    trailing_comments: f.trailing_comments.clone(),
                     id: Some(0),
                     name: "Ok".into(),
                     tags: Default::default(),
@@ -268,6 +280,8 @@ impl ThriftLower {
             if !exception.is_empty() {
                 let name: Ident = format!("{service_name}{method_name}Exception").into();
                 let kind = ir::ItemKind::Enum(ir::Enum {
+                    leading_comments: f.leading_comments.clone(),
+                    trailing_comments: f.trailing_comments.clone(),
                     name: name.clone(),
                     variants: exception,
                     repr: None,
@@ -282,6 +296,8 @@ impl ThriftLower {
 
             let name: Ident = format!("{service_name}{method_name}ArgsSend").into();
             let kind = ir::ItemKind::Message(ir::Message {
+                leading_comments: f.leading_comments.clone(),
+                trailing_comments: f.trailing_comments.clone(),
                 name: name.clone(),
                 fields: f
                     .arguments
@@ -299,6 +315,8 @@ impl ThriftLower {
 
             let name: Ident = format!("{service_name}{method_name}ArgsRecv").into();
             let kind = ir::ItemKind::Message(ir::Message {
+                leading_comments: f.leading_comments.clone(),
+                trailing_comments: f.trailing_comments.clone(),
                 name: name.clone(),
                 fields: f
                     .arguments
@@ -341,6 +359,8 @@ impl ThriftLower {
         };
 
         ir::Method {
+            leading_comments: method.leading_comments.clone(),
+            trailing_comments: method.trailing_comments.clone(),
             name: self.lower_ident(&method.name),
             args: method
                 .arguments
@@ -381,11 +401,15 @@ impl ThriftLower {
 
     fn lower_enum(&self, e: &thrift_parser::Enum) -> ir::Enum {
         ir::Enum {
+            leading_comments: e.leading_comments.clone(),
+            trailing_comments: e.trailing_comments.clone(),
             name: self.lower_ident(&e.name),
             variants: e
                 .values
                 .iter()
                 .map(|v| ir::EnumVariant {
+                    leading_comments: v.leading_comments.clone(),
+                    trailing_comments: v.trailing_comments.clone(),
                     id: None,
                     name: self.lower_ident(&v.name),
                     discr: v.value.map(|v| v.0),
@@ -419,6 +443,8 @@ impl ThriftLower {
 
     fn lower_const(&self, c: &thrift_parser::Constant) -> ir::Const {
         ir::Const {
+            leading_comments: c.leading_comments.clone(),
+            trailing_comments: c.trailing_comments.clone(),
             name: self.lower_ident(&c.name),
             ty: self.lower_ty(&c.r#type),
             lit: self.lower_lit(&c.value),
@@ -427,6 +453,8 @@ impl ThriftLower {
 
     fn lower_typedef(&self, t: &thrift_parser::Typedef) -> ir::NewType {
         ir::NewType {
+            leading_comments: t.leading_comments.clone(),
+            trailing_comments: t.trailing_comments.clone(),
             name: self.lower_ident(&t.alias),
             ty: self.lower_ty(&t.r#type),
         }
@@ -439,7 +467,7 @@ impl ThriftLower {
             thrift_parser::Item::Enum(e) => ir::ItemKind::Enum(self.lower_enum(e)),
             thrift_parser::Item::Struct(s) => ir::ItemKind::Message(self.lower_struct(s)),
             thrift_parser::Item::Union(u) => ir::ItemKind::Enum(self.lower_union(u)),
-            thrift_parser::Item::Exception(s) => ir::ItemKind::Message(self.lower_struct(s)),
+            thrift_parser::Item::Exception(e) => ir::ItemKind::Message(self.lower_exception(e)),
             thrift_parser::Item::Service(s) => return self.lower_service(s),
             _ => return vec![],
         };
@@ -464,11 +492,15 @@ impl ThriftLower {
 
     fn lower_union(&self, union: &thrift_parser::Union) -> Enum {
         Enum {
+            leading_comments: union.leading_comments.clone(),
+            trailing_comments: union.trailing_comments.clone(),
             name: self.lower_ident(&union.name),
             variants: union
                 .fields
                 .iter()
                 .map(|f| EnumVariant {
+                    leading_comments: f.leading_comments.clone(),
+                    trailing_comments: f.trailing_comments.clone(),
                     id: Some(f.id),
                     name: self.lower_ident(&f.name),
                     discr: None,
@@ -537,6 +569,8 @@ impl ThriftLower {
         }
 
         ir::Field {
+            leading_comments: f.leading_comments.clone(),
+            trailing_comments: f.trailing_comments.clone(),
             name: self.lower_ident(&f.name),
             id: f.id,
             ty: self.lower_method_relative_ty(&f.ty, arc_wrapper),
@@ -557,6 +591,8 @@ impl ThriftLower {
 
     fn lower_field_with_tags(&self, f: &thrift_parser::Field, tags: Tags) -> ir::Field {
         ir::Field {
+            leading_comments: f.leading_comments.clone(),
+            trailing_comments: f.trailing_comments.clone(),
             name: self.lower_ident(&f.name),
             id: f.id,
             ty: self.lower_ty(&f.ty),
@@ -590,7 +626,7 @@ impl ThriftLower {
         tags
     }
 
-    fn lower_struct(&self, s: &thrift_parser::StructLike) -> ir::Message {
+    fn lower_struct(&self, s: &thrift_parser::Struct) -> ir::Message {
         let mut seen_ids = FxHashSet::default();
         for field in &s.fields {
             if !seen_ids.insert(field.id) {
@@ -602,8 +638,31 @@ impl ThriftLower {
             }
         }
         ir::Message {
+            leading_comments: s.leading_comments.clone(),
+            trailing_comments: s.trailing_comments.clone(),
             name: self.lower_ident(&s.name),
             fields: s.fields.iter().map(|f| self.lower_field(f)).collect(),
+            is_wrapper: false,
+            item_exts: ext::ItemExts::Thrift,
+        }
+    }
+
+    fn lower_exception(&self, e: &thrift_parser::Exception) -> ir::Message {
+        let mut seen_ids = FxHashSet::default();
+        for field in &e.fields {
+            if !seen_ids.insert(field.id) {
+                panic!(
+                    "duplicate ID `{}` in struct `{}`",
+                    field.id,
+                    self.lower_ident(&e.name),
+                );
+            }
+        }
+        ir::Message {
+            leading_comments: e.leading_comments.clone(),
+            trailing_comments: e.trailing_comments.clone(),
+            name: self.lower_ident(&e.name),
+            fields: e.fields.iter().map(|f| self.lower_field(f)).collect(),
             is_wrapper: false,
             item_exts: ext::ItemExts::Thrift,
         }
@@ -751,6 +810,7 @@ impl Lower<Arc<thrift_parser::File>> for ThriftLower {
                 uses,
                 descriptor: f.descriptor.clone(),
                 extensions: FileExts::Thrift,
+                comments: f.comments.clone(),
             };
 
             this.service_name_duplicates.clear();

--- a/pilota-build/src/resolve.rs
+++ b/pilota-build/src/resolve.rs
@@ -441,6 +441,8 @@ impl Resolver {
         }
 
         let f = Arc::from(Field {
+            leading_comments: f.leading_comments.clone(),
+            trailing_comments: f.trailing_comments.clone(),
             did,
             id: f.id,
             kind,
@@ -658,6 +660,8 @@ impl Resolver {
     #[tracing::instrument(level = "debug", skip(self, s), fields(name = &**s.name))]
     fn lower_message(&mut self, s: &ir::Message) -> Message {
         Message {
+            leading_comments: s.leading_comments.clone(),
+            trailing_comments: s.trailing_comments.clone(),
             name: s.name.clone(),
             fields: s.fields.iter().map(|f| self.lower_field(f)).collect(),
             is_wrapper: s.is_wrapper,
@@ -668,6 +672,8 @@ impl Resolver {
     fn lower_enum(&mut self, e: &ir::Enum) -> Enum {
         let mut next_discr = 0;
         Enum {
+            leading_comments: e.leading_comments.clone(),
+            trailing_comments: e.trailing_comments.clone(),
             name: e.name.clone(),
             variants: e
                 .variants
@@ -680,6 +686,8 @@ impl Resolver {
                     }
                     let discr = v.discr.unwrap_or(next_discr);
                     let e = Arc::from(EnumVariant {
+                        leading_comments: v.leading_comments.clone(),
+                        trailing_comments: v.trailing_comments.clone(),
                         id: v.id,
                         did,
                         name: v.name.clone(),
@@ -711,6 +719,8 @@ impl Resolver {
 
     fn lower_service(&mut self, s: &ir::Service) -> Service {
         Service {
+            leading_comments: s.leading_comments.clone(),
+            trailing_comments: s.trailing_comments.clone(),
             name: s.name.clone(),
             methods: s
                 .methods
@@ -721,6 +731,8 @@ impl Resolver {
                     self.tags.insert(tags_id, m.tags.clone());
                     let old_parent = self.parent_node.replace(def_id);
                     let method = Arc::from(Method {
+                        leading_comments: m.leading_comments.clone(),
+                        trailing_comments: m.trailing_comments.clone(),
                         def_id,
                         source: MethodSource::Own,
                         name: m.name.clone(),
@@ -777,6 +789,8 @@ impl Resolver {
 
     fn lower_type_alias(&mut self, t: &ir::NewType, tags: &Tags) -> NewType {
         NewType {
+            leading_comments: t.leading_comments.clone(),
+            trailing_comments: t.trailing_comments.clone(),
             name: t.name.clone(),
             ty: {
                 let ty = self.lower_type(&t.ty, false);
@@ -803,6 +817,8 @@ impl Resolver {
 
     fn lower_const(&mut self, c: &ir::Const, tags: &Tags) -> Const {
         Const {
+            leading_comments: c.leading_comments.clone(),
+            trailing_comments: c.trailing_comments.clone(),
             name: c.name.clone(),
             ty: {
                 let ty = self.lower_type(&c.ty, false);
@@ -913,6 +929,7 @@ impl Resolver {
             uses: file.uses.iter().map(|(_, f)| *f).collect(),
             descriptor: file.descriptor.clone(),
             extensions: self.lower_file_exts(&file.extensions),
+            comments: file.comments.clone(),
         };
 
         if should_pop {

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -1,8 +1,12 @@
 #![cfg(test)]
 
-use std::{fs, fs::File, path::Path, process::Command};
+use std::{
+    fs::{self, File},
+    path::{Path, PathBuf},
+    process::Command,
+};
 
-use tempfile::tempdir;
+use tempfile::{Builder, tempdir};
 
 use crate::{IdlService, plugin::SerdePlugin};
 
@@ -12,7 +16,6 @@ fn diff_file(old: impl AsRef<Path>, new: impl AsRef<Path>) {
 
     let new_content =
         unsafe { String::from_utf8_unchecked(std::fs::read(new).unwrap()) }.replace("\r", "");
-
     let patch = diffy::create_patch(&old_content, &new_content);
     if !patch.hunks().is_empty() {
         panic!("\n{}\n", patch)

--- a/pilota-build/test_data/thrift/apache.rs
+++ b/pilota-build/test_data/thrift/apache.rs
@@ -7,6 +7,40 @@ pub mod apache {
 
             pub mod test {
 
+                /*
+                 * Licensed to the Apache Software Foundation (ASF) under one
+                 * or more contributor license agreements. See the NOTICE file
+                 * distributed with this work for additional information
+                 * regarding copyright ownership. The ASF licenses this file
+                 * to you under the Apache License, Version 2.0 (the
+                 * "License"); you may not use this file except in compliance
+                 * with the License. You may obtain a copy of the License at
+                 *
+                 *   http://www.apache.org/licenses/LICENSE-2.0
+                 *
+                 * Unless required by applicable law or agreed to in writing,
+                 * software distributed under the License is distributed on an
+                 * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+                 * KIND, either express or implied. See the License for the
+                 * specific language governing permissions and limitations
+                 * under the License.
+                 *
+                 * Contains some contributions under the Thrift Software License.
+                 * Please see doc/old-thrift-license.txt in the Thrift distribution for
+                 * details.
+                 */
+
+                // Presence of namespaces and sub-namespaces for which there is
+
+                // no generator should compile with warnings only
+
+                // namespace noexist ThriftTest
+
+                // namespace cpp.noexist ThriftTest
+
+                /**
+                 * Docstring!
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
                 #[repr(transparent)]
                 pub struct Numberz(i32);
@@ -124,6 +158,7 @@ pub mod apache {
                         __protocol.i32_len(self.inner())
                     }
                 }
+
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct LargeDeltas {
                     pub b1: ::std::option::Option<Bools>,
@@ -570,6 +605,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI32ArgsSend {
                     pub thing: i32,
@@ -735,6 +775,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted
+                 * into a string of values  separated by
+                 * commas and new lines @param set<i32>
+                 * thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestSetArgsRecv {
                     pub thing: ::pilota::AHashSet<i32>,
@@ -927,6 +974,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and
+                 * arg1 as '%s' @param string arg - a string
+                 * indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode =
+                 * 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with
+                 * errorCode = 2002 and struct_thing.string_thing = "This is
+                 * an Xception2" else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionException {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionException::Err1(
@@ -1129,6 +1188,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestVoidArgsSend {}
                 impl ::pilota::thrift::Message for ThriftTestTestVoidArgsSend {
@@ -1260,6 +1322,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been
+                 * formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStructArgsRecv {
                     pub thing: Xtruct,
@@ -1430,6 +1498,19 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing =
+                 * "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMultiResultRecv::Ok(::std::default::Default::default())
@@ -1437,6 +1518,18 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiResultRecv {
+                    /**
+                     * Prints 'testMulti()'
+                     * @param i8 arg0 -
+                     * @param i32 arg1 -
+                     * @param i64 arg2 -
+                     * @param map<i16, string> arg3 -
+                     * @param Numberz arg4 -
+                     * @param UserId arg5 -
+                     * @return Xtruct - returns an Xtruct with string_thing
+                     * = "Hello2, byte_thing = arg0, i32_thing = arg1
+                     *    and i64_thing = arg2
+                     */
                     Ok(Xtruct),
                 }
 
@@ -1586,6 +1679,7 @@ pub mod apache {
                     }
                 }
                 pub const MY_NUMBERZ: Numberz = Numberz::ONE;
+
                 impl ::std::default::Default for BoolTest {
                     fn default() -> Self {
                         BoolTest {
@@ -1767,6 +1861,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI64ArgsRecv {
                     pub thing: i64,
@@ -1932,6 +2031,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted
+                 * into its numeric value @param Numberz
+                 * thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestEnumResultRecv {
                     fn default() -> Self {
                         ThriftTestTestEnumResultRecv::Ok(::std::default::Default::default())
@@ -1939,6 +2045,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestEnumResultRecv {
+                    /**
+                     * Prints 'testEnum("%d")' where thing has been
+                     * formatted into its numeric value
+                     * @param Numberz thing - the Numberz to print
+                     * @return Numberz - returns the Numberz 'thing'
+                     */
                     Ok(Numberz),
                 }
 
@@ -2082,6 +2194,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep
+                 * as '%d' sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with
+                 * secondsToSleep as '%d' @param i32
+                 * secondsToSleep - the number of seconds to sleep
+                 */
+
                 impl ::std::default::Default for ThriftTestTestOnewayResultSend {
                     fn default() -> Self {
                         ThriftTestTestOnewayResultSend::Ok(::std::default::Default::default())
@@ -2089,6 +2209,14 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestOnewayResultSend {
+                    /**
+                     * Print 'testOneway(%d): Sleeping...' with
+                     * secondsToSleep as '%d'
+                     * sleep 'secondsToSleep'
+                     * Print 'testOneway(%d): done sleeping!' with
+                     * secondsToSleep as '%d' @param i32
+                     * secondsToSleep - the number of seconds to sleep
+                     */
                     Ok(()),
                 }
 
@@ -2194,6 +2322,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringArgsRecv {
                     pub thing: ::pilota::FastStr,
@@ -2359,6 +2492,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted
+                 * into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMapResultRecv::Ok(::std::default::Default::default())
@@ -2366,6 +2507,14 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapResultRecv {
+                    /**
+                     * Prints 'testMap("{%s")' where thing has been
+                     * formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<i32,i32> thing - the map<i32,i32> to print
+                     * @return map<i32,i32> - returns the map<i32,i32>
+                     * 'thing'
+                     */
                     Ok(::pilota::AHashMap<i32, i32>),
                 }
 
@@ -2557,6 +2706,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct Xtruct3 {
                     pub string_thing: ::std::option::Option<::pilota::FastStr>,
@@ -2780,6 +2930,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted
+                 * string of thing's data @param binary
+                 * thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBinaryResultRecv {
                     fn default() -> Self {
                         ThriftTestTestBinaryResultRecv::Ok(::std::default::Default::default())
@@ -2787,6 +2944,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBinaryResultRecv {
+                    /**
+                     * Prints 'testBinary("%s")' where '%s' is a
+                     * hex-formatted string of thing's data
+                     * @param binary  thing - the binary data to print
+                     * @return binary  - returns the binary 'thing'
+                     */
                     Ok(::pilota::Bytes),
                 }
 
@@ -2930,6 +3093,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for SecondServiceSecondtestStringResultSend {
                     fn default() -> Self {
                         SecondServiceSecondtestStringResultSend::Ok(
@@ -2939,6 +3108,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum SecondServiceSecondtestStringResultSend {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -3085,6 +3259,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is
+                 * encouraged, byte still exists for the sake of
+                 * compatibility. @param byte thing - the
+                 * i8/byte to print @return i8 - returns the
+                 * i8/byte 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestByteResultRecv {
                     fn default() -> Self {
                         ThriftTestTestByteResultRecv::Ok(::std::default::Default::default())
@@ -3092,6 +3275,14 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestByteResultRecv {
+                    /**
+                     * Prints 'testByte("%d")' with thing as '%d'
+                     * The types i8 and byte are synonyms, use of i8 is
+                     * encouraged, byte still exists for the sake of
+                     * compatibility. @param byte thing
+                     * - the i8/byte to print @return i8
+                     * - returns the i8/byte 'thing'
+                     */
                     Ok(i8),
                 }
 
@@ -3234,6 +3425,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of
+                 * exception to throw if arg == "Xception"
+                 * throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestExceptionArgsSend {
                     pub arg: ::pilota::FastStr,
@@ -3399,6 +3598,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with
+                 * these values:   {-4 => {-4 => -4, -3 =>
+                 * -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3,
+                 * 4 => 4, }, }
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestMapMapResultSend::Ok(::std::default::Default::default())
@@ -3406,6 +3614,14 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapMapResultSend {
+                    /**
+                     * Prints 'testMapMap("%d")' with hello as '%d'
+                     * @param i32 hello - the i32 to print
+                     * @return map<i32,map<i32,i32>> - returns a dictionary
+                     * with these values:   {-4 => {-4
+                     * => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1,
+                     * 2 => 2, 3 => 3, 4 => 4, }, }
+                     */
                     Ok(::pilota::AHashMap<i32, ::pilota::AHashMap<i32, i32>>),
                 }
 
@@ -3648,6 +3864,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ListTypeVersioningV1 {
                     pub myints: ::std::option::Option<::std::vec::Vec<i32>>,
@@ -3857,6 +4074,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted
+                 * into a string of values  separated by
+                 * commas and new lines @param set<i32>
+                 * thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestSetResultSend {
                     fn default() -> Self {
                         ThriftTestTestSetResultSend::Ok(::std::default::Default::default())
@@ -3864,6 +4089,13 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestSetResultSend {
+                    /**
+                     * Prints 'testSet("{%s}")' where thing has been
+                     * formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param set<i32> thing - the set<i32> to print
+                     * @return set<i32> - returns the set<i32> 'thing'
+                     */
                     Ok(::pilota::AHashSet<i32>),
                 }
 
@@ -4041,6 +4273,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been
+                 * formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStructResultSend {
                     fn default() -> Self {
                         ThriftTestTestStructResultSend::Ok(::std::default::Default::default())
@@ -4048,6 +4287,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStructResultSend {
+                    /**
+                     * Prints 'testStruct("{%s}")' where thing has been
+                     * formatted into a string of comma separated values
+                     * @param Xtruct thing - the Xtruct to print
+                     * @return Xtruct - returns the Xtruct 'thing'
+                     */
                     Ok(Xtruct),
                 }
 
@@ -4196,6 +4441,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct NestedMixedx2 {
                     pub int_set_list:
@@ -4632,6 +4878,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI64ResultSend {
                     fn default() -> Self {
                         ThriftTestTestI64ResultSend::Ok(::std::default::Default::default())
@@ -4639,6 +4891,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI64ResultSend {
+                    /**
+                     * Prints 'testI64("%d")' with thing as '%d'
+                     * @param i64 thing - the i64 to print
+                     * @return i64 - returns the i64 'thing'
+                     */
                     Ok(i64),
                 }
 
@@ -4781,6 +5038,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and
+                 * arg1 as '%s' @param string arg - a string
+                 * indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode =
+                 * 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with
+                 * errorCode = 2002 and struct_thing.string_thing = "This is
+                 * an Xception2" else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiExceptionArgsRecv {
                     pub arg0: ::pilota::FastStr,
@@ -4983,6 +5251,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringResultSend {
                     fn default() -> Self {
                         ThriftTestTestStringResultSend::Ok(::std::default::Default::default())
@@ -4990,6 +5264,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringResultSend {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -5133,6 +5412,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing =
+                 * "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiArgsSend {
                     pub arg0: i8,
@@ -5513,6 +5804,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct Bools {
                     pub im_true: ::std::option::Option<bool>,
@@ -5692,6 +5984,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 impl ::std::default::Default for OptionalBinary {
                     fn default() -> Self {
                         OptionalBinary {
@@ -5705,6 +5998,7 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub struct OptionalBinary {
+                    //1: optional set<binary> bin_set = []
                     pub bin_map: ::std::option::Option<::pilota::AHashMap<::pilota::Bytes, i32>>,
                 }
                 impl ::pilota::thrift::Message for OptionalBinary {
@@ -5912,6 +6206,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted
+                 * into its numeric value @param Numberz
+                 * thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestEnumArgsSend {
                     pub thing: Numberz,
@@ -6079,6 +6379,14 @@ pub mod apache {
                     }
                 }
                 pub trait ThriftTest {}
+
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted
+                 * into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapArgsSend {
                     pub thing: ::pilota::AHashMap<i32, i32>,
@@ -6283,6 +6591,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted
+                 * string of thing's data @param binary
+                 * thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBinaryArgsSend {
                     pub thing: ::pilota::Bytes,
@@ -6448,6 +6762,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestTypedefArgsRecv {
                     pub thing: UserId,
@@ -6619,6 +6938,15 @@ pub mod apache {
                     }
                 }
                 pub trait SecondService {}
+
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is
+                 * encouraged, byte still exists for the sake of
+                 * compatibility. @param byte thing - the
+                 * i8/byte to print @return i8 - returns the
+                 * i8/byte 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestByteArgsSend {
                     pub thing: i8,
@@ -6784,6 +7112,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been
+                 * formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string>
+                 * to print @return map<string,string> -
+                 * returns the map<string,string> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringMapArgsRecv {
                     pub thing: ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
@@ -6988,6 +7324,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct EmptyStruct {}
                 impl ::pilota::thrift::Message for EmptyStruct {
@@ -7122,6 +7459,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given.
+                 * Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestUuidArgsRecv {
                     pub thing: [u8; 16],
@@ -7287,6 +7630,19 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with
+                 * the above values
+                 */
+
                 impl ::std::default::Default for ThriftTestTestInsanityResultRecv {
                     fn default() -> Self {
                         ThriftTestTestInsanityResultRecv::Ok(::std::default::Default::default())
@@ -7294,6 +7650,18 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestInsanityResultRecv {
+                    /**
+                     * So you think you've got this all worked out, eh?
+                     *
+                     * Creates a map with these values and prints it out:
+                     *   { 1 => { 2 => argument,
+                     *            3 => argument,
+                     *          },
+                     *     2 => { 6 => <empty Insanity struct>, },
+                     *   }
+                     * @return map<UserId, map<Numberz,Insanity>> - a map
+                     * with the above values
+                     */
                     Ok(::pilota::AHashMap<UserId, ::pilota::AHashMap<Numberz, Insanity>>),
                 }
 
@@ -7540,6 +7908,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct NestedListsI32x2 {
                     pub integerlist: ::std::option::Option<::std::vec::Vec<::std::vec::Vec<i32>>>,
@@ -7757,6 +8126,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI32ArgsRecv {
                     pub thing: i32,
@@ -7922,6 +8296,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted
+                 * into a string of values  separated by
+                 * commas and new lines @param list<i32>
+                 * thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestListResultRecv {
                     fn default() -> Self {
                         ThriftTestTestListResultRecv::Ok(::std::default::Default::default())
@@ -7929,6 +8311,13 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestListResultRecv {
+                    /**
+                     * Prints 'testList("{%s}")' where thing has been
+                     * formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param list<i32> thing - the list<i32> to print
+                     * @return list<i32> - returns the list<i32> 'thing'
+                     */
                     Ok(::std::vec::Vec<i32>),
                 }
 
@@ -8108,6 +8497,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestVoidArgsRecv {}
                 impl ::pilota::thrift::Message for ThriftTestTestVoidArgsRecv {
@@ -8239,6 +8631,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted
+                 * into a string of the nested struct @param
+                 * Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestNestResultRecv {
                     fn default() -> Self {
                         ThriftTestTestNestResultRecv::Ok(::std::default::Default::default())
@@ -8246,6 +8645,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestNestResultRecv {
+                    /**
+                     * Prints 'testNest("{%s}")' where thing has been
+                     * formatted into a string of the nested struct
+                     * @param Xtruct2 thing - the Xtruct2 to print
+                     * @return Xtruct2 - returns the Xtruct2 'thing'
+                     */
                     Ok(Xtruct2),
                 }
 
@@ -8393,6 +8798,9 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                // the following is expected to fail:
+
+                // const Numberz urNumberz = ONE;
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct UserId(pub i64);
 
@@ -8458,6 +8866,7 @@ pub mod apache {
                         __protocol.i64_len(*&**self)
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct StructA {
                     pub s: ::pilota::FastStr,
@@ -8624,6 +9033,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestDoubleResultRecv {
                     fn default() -> Self {
                         ThriftTestTestDoubleResultRecv::Ok(::std::default::Default::default())
@@ -8631,6 +9046,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestDoubleResultRecv {
+                    /**
+                     * Prints 'testDouble("%f")' with thing as '%f'
+                     * @param double thing - the double to print
+                     * @return double - returns the double 'thing'
+                     */
                     Ok(f64),
                 }
 
@@ -8774,6 +9194,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true'
+                 * or 'false' @param bool  thing - the bool
+                 * data to print @return bool  - returns the
+                 * bool 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBoolResultRecv {
                     fn default() -> Self {
                         ThriftTestTestBoolResultRecv::Ok(::std::default::Default::default())
@@ -8781,6 +9208,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBoolResultRecv {
+                    /**
+                     * Prints 'testBool("%s")' where '%s' with thing as
+                     * 'true' or 'false' @param bool
+                     * thing - the bool data to print
+                     * @return bool  - returns the bool 'thing'
+                     */
                     Ok(bool),
                 }
 
@@ -8923,6 +9356,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct Insanity {
                     pub user_map:
@@ -9171,6 +9605,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestTypedefResultSend {
                     fn default() -> Self {
                         ThriftTestTestTypedefResultSend::Ok(::std::default::Default::default())
@@ -9178,6 +9618,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestTypedefResultSend {
+                    /**
+                     * Prints 'testTypedef("%d")' with thing as '%d'
+                     * @param UserId thing - the UserId to print
+                     * @return UserId - returns the UserId 'thing'
+                     */
                     Ok(UserId),
                 }
 
@@ -9327,6 +9772,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been
+                 * formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string>
+                 * to print @return map<string,string> -
+                 * returns the map<string,string> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestStringMapResultSend::Ok(::std::default::Default::default())
@@ -9334,6 +9788,15 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringMapResultSend {
+                    /**
+                     * Prints 'testStringMap("{%s}")' where thing has been
+                     * formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<string,string> thing - the
+                     * map<string,string> to print
+                     * @return map<string,string> - returns the
+                     * map<string,string> 'thing'
+                     */
                     Ok(::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>),
                 }
 
@@ -9529,6 +9992,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of
+                 * exception to throw if arg == "Xception"
+                 * throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestExceptionArgsRecv {
                     pub arg: ::pilota::FastStr,
@@ -9694,6 +10165,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given.
+                 * Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestUuidResultSend {
                     fn default() -> Self {
                         ThriftTestTestUuidResultSend::Ok(::std::default::Default::default())
@@ -9701,6 +10179,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestUuidResultSend {
+                    /**
+                     * Prints 'testUuid("%s")' where '%s' is the uuid given.
+                     * Note that the uuid byte order should be correct.
+                     * @param uuid  thing - the uuid to print
+                     * @return uuid  - returns the uuid 'thing'
+                     */
                     Ok([u8; 16]),
                 }
 
@@ -9843,6 +10327,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ListTypeVersioningV2 {
                     pub strings: ::std::option::Option<::std::vec::Vec<::pilota::FastStr>>,
@@ -10052,6 +10537,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI32ResultSend {
                     fn default() -> Self {
                         ThriftTestTestI32ResultSend::Ok(::std::default::Default::default())
@@ -10059,6 +10550,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI32ResultSend {
+                    /**
+                     * Prints 'testI32("%d")' with thing as '%d'
+                     * @param i32 thing - the i32 to print
+                     * @return i32 - returns the i32 'thing'
+                     */
                     Ok(i32),
                 }
 
@@ -10201,6 +10697,10 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
+
                 impl ::std::default::Default for ThriftTestTestVoidResultSend {
                     fn default() -> Self {
                         ThriftTestTestVoidResultSend::Ok(::std::default::Default::default())
@@ -10208,6 +10708,9 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestVoidResultSend {
+                    /**
+                     * Prints "testVoid()" and returns nothing.
+                     */
                     Ok(()),
                 }
 
@@ -10313,6 +10816,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with
+                 * the above values
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestInsanityArgsSend {
                     pub argument: Insanity,
@@ -10483,6 +10998,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ListBonks {
                     pub bonk: ::std::option::Option<::std::vec::Vec<Bonk>>,
@@ -10668,6 +11184,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted
+                 * into a string of values  separated by
+                 * commas and new lines @param list<i32>
+                 * thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestListArgsSend {
                     pub thing: ::std::vec::Vec<i32>,
@@ -10865,6 +11388,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep
+                 * as '%d' sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with
+                 * secondsToSleep as '%d' @param i32
+                 * secondsToSleep - the number of seconds to sleep
+                 */
+
                 impl ::std::default::Default for ThriftTestTestOnewayResultRecv {
                     fn default() -> Self {
                         ThriftTestTestOnewayResultRecv::Ok(::std::default::Default::default())
@@ -10872,6 +11403,14 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestOnewayResultRecv {
+                    /**
+                     * Print 'testOneway(%d): Sleeping...' with
+                     * secondsToSleep as '%d'
+                     * sleep 'secondsToSleep'
+                     * Print 'testOneway(%d): done sleeping!' with
+                     * secondsToSleep as '%d' @param i32
+                     * secondsToSleep - the number of seconds to sleep
+                     */
                     Ok(()),
                 }
 
@@ -10977,6 +11516,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted
+                 * into a string of the nested struct @param
+                 * Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestNestArgsSend {
                     pub thing: Xtruct2,
@@ -11147,6 +11692,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing =
+                 * "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiArgsRecv {
                     pub arg0: i8,
@@ -11527,6 +12084,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct Xtruct {
                     pub string_thing: ::std::option::Option<::pilota::FastStr>,
@@ -11750,6 +12308,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
                 #[derive(PartialOrd, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestDoubleArgsSend {
                     pub thing: f64,
@@ -11915,6 +12478,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted
+                 * into its numeric value @param Numberz
+                 * thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestEnumArgsRecv {
                     pub thing: Numberz,
@@ -12081,6 +12650,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for SecondServiceSecondtestStringResultRecv {
                     fn default() -> Self {
                         SecondServiceSecondtestStringResultRecv::Ok(
@@ -12090,6 +12665,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum SecondServiceSecondtestStringResultRecv {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -12236,6 +12816,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true'
+                 * or 'false' @param bool  thing - the bool
+                 * data to print @return bool  - returns the
+                 * bool 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBoolArgsSend {
                     pub thing: bool,
@@ -12401,6 +12987,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted
+                 * into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapArgsRecv {
                     pub thing: ::pilota::AHashMap<i32, i32>,
@@ -12605,6 +13198,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of
+                 * exception to throw if arg == "Xception"
+                 * throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionException {
                     fn default() -> Self {
                         ThriftTestTestExceptionException::Err1(::std::default::Default::default())
@@ -12762,6 +13364,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted
+                 * string of thing's data @param binary
+                 * thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBinaryArgsRecv {
                     pub thing: ::pilota::Bytes,
@@ -12927,6 +13535,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with
+                 * these values:   {-4 => {-4 => -4, -3 =>
+                 * -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3,
+                 * 4 => 4, }, }
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMapMapResultRecv::Ok(::std::default::Default::default())
@@ -12934,6 +13551,14 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapMapResultRecv {
+                    /**
+                     * Prints 'testMapMap("%d")' with hello as '%d'
+                     * @param i32 hello - the i32 to print
+                     * @return map<i32,map<i32,i32>> - returns a dictionary
+                     * with these values:   {-4 => {-4
+                     * => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1,
+                     * 2 => 2, 3 => 3, 4 => 4, }, }
+                     */
                     Ok(::pilota::AHashMap<i32, ::pilota::AHashMap<i32, i32>>),
                 }
 
@@ -13176,6 +13801,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct VersioningTestV1 {
                     pub begin_in_both: ::std::option::Option<i32>,
@@ -13376,6 +14002,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is
+                 * encouraged, byte still exists for the sake of
+                 * compatibility. @param byte thing - the
+                 * i8/byte to print @return i8 - returns the
+                 * i8/byte 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestByteArgsRecv {
                     pub thing: i8,
@@ -13541,6 +14175,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted
+                 * into a string of values  separated by
+                 * commas and new lines @param set<i32>
+                 * thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestSetResultRecv {
                     fn default() -> Self {
                         ThriftTestTestSetResultRecv::Ok(::std::default::Default::default())
@@ -13548,6 +14190,13 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestSetResultRecv {
+                    /**
+                     * Prints 'testSet("{%s}")' where thing has been
+                     * formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param set<i32> thing - the set<i32> to print
+                     * @return set<i32> - returns the set<i32> 'thing'
+                     */
                     Ok(::pilota::AHashSet<i32>),
                 }
 
@@ -13725,6 +14374,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct OneField {
                     pub field: ::std::option::Option<EmptyStruct>,
@@ -13883,6 +14533,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been
+                 * formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStructResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStructResultRecv::Ok(::std::default::Default::default())
@@ -13890,6 +14547,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStructResultRecv {
+                    /**
+                     * Prints 'testStruct("{%s}")' where thing has been
+                     * formatted into a string of comma separated values
+                     * @param Xtruct thing - the Xtruct to print
+                     * @return Xtruct - returns the Xtruct 'thing'
+                     */
                     Ok(Xtruct),
                 }
 
@@ -14038,6 +14701,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct NestedListsI32x3 {
                     pub integerlist: ::std::option::Option<
@@ -14298,6 +14962,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI64ResultRecv {
                     fn default() -> Self {
                         ThriftTestTestI64ResultRecv::Ok(::std::default::Default::default())
@@ -14305,6 +14975,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI64ResultRecv {
+                    /**
+                     * Prints 'testI64("%d")' with thing as '%d'
+                     * @param i64 thing - the i64 to print
+                     * @return i64 - returns the i64 'thing'
+                     */
                     Ok(i64),
                 }
 
@@ -14447,6 +15122,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStringResultRecv::Ok(::std::default::Default::default())
@@ -14454,6 +15135,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringResultRecv {
+                    /**
+                     * Prints 'testString("%s")' with thing as '%s'
+                     * @param string thing - the string to print
+                     * @return string - returns the string 'thing'
+                     */
                     Ok(::pilota::FastStr),
                 }
 
@@ -14597,6 +15283,19 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMulti()'
+                 * @param i8 arg0 -
+                 * @param i32 arg1 -
+                 * @param i64 arg2 -
+                 * @param map<i16, string> arg3 -
+                 * @param Numberz arg4 -
+                 * @param UserId arg5 -
+                 * @return Xtruct - returns an Xtruct with string_thing =
+                 * "Hello2, byte_thing = arg0, i32_thing = arg1
+                 *    and i64_thing = arg2
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiResultSend {
                     fn default() -> Self {
                         ThriftTestTestMultiResultSend::Ok(::std::default::Default::default())
@@ -14604,6 +15303,18 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiResultSend {
+                    /**
+                     * Prints 'testMulti()'
+                     * @param i8 arg0 -
+                     * @param i32 arg1 -
+                     * @param i64 arg2 -
+                     * @param map<i16, string> arg3 -
+                     * @param Numberz arg4 -
+                     * @param UserId arg5 -
+                     * @return Xtruct - returns an Xtruct with string_thing
+                     * = "Hello2, byte_thing = arg0, i32_thing = arg1
+                     *    and i64_thing = arg2
+                     */
                     Ok(Xtruct),
                 }
 
@@ -14752,6 +15463,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct Bonk {
                     pub message: ::std::option::Option<::pilota::FastStr>,
@@ -14931,6 +15643,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct StructB {
                     pub aa: ::std::option::Option<StructA>,
@@ -15133,6 +15846,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testEnum("%d")' where thing has been formatted
+                 * into its numeric value @param Numberz
+                 * thing - the Numberz to print
+                 * @return Numberz - returns the Numberz 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestEnumResultSend {
                     fn default() -> Self {
                         ThriftTestTestEnumResultSend::Ok(::std::default::Default::default())
@@ -15140,6 +15860,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestEnumResultSend {
+                    /**
+                     * Prints 'testEnum("%d")' where thing has been
+                     * formatted into its numeric value
+                     * @param Numberz thing - the Numberz to print
+                     * @return Numberz - returns the Numberz 'thing'
+                     */
                     Ok(Numberz),
                 }
 
@@ -15283,6 +16009,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep
+                 * as '%d' sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with
+                 * secondsToSleep as '%d' @param i32
+                 * secondsToSleep - the number of seconds to sleep
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestOnewayArgsSend {
                     pub seconds_to_sleep: i32,
@@ -15452,6 +16185,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMap("{%s")' where thing has been formatted
+                 * into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<i32,i32> thing - the map<i32,i32> to print
+                 * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMapResultSend {
                     fn default() -> Self {
                         ThriftTestTestMapResultSend::Ok(::std::default::Default::default())
@@ -15459,6 +16200,14 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMapResultSend {
+                    /**
+                     * Prints 'testMap("{%s")' where thing has been
+                     * formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<i32,i32> thing - the map<i32,i32> to print
+                     * @return map<i32,i32> - returns the map<i32,i32>
+                     * 'thing'
+                     */
                     Ok(::pilota::AHashMap<i32, i32>),
                 }
 
@@ -15650,6 +16399,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of
+                 * exception to throw if arg == "Xception"
+                 * throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionResultSend {
                     fn default() -> Self {
                         ThriftTestTestExceptionResultSend::Ok(::std::default::Default::default())
@@ -15657,6 +16415,15 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestExceptionResultSend {
+                    /**
+                     * Print 'testException(%s)' with arg as '%s'
+                     * @param string arg - a string indication what type of
+                     * exception to throw if arg == "
+                     * Xception" throw Xception with errorCode = 1001 and
+                     * message = arg else if arg ==
+                     * "TException" throw TException
+                     * else do not throw anything
+                     */
                     Ok(()),
 
                     Err1(Xception),
@@ -15803,12 +16570,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct CrazyNesting {
                     pub string_field: ::std::option::Option<::pilota::FastStr>,
 
                     pub set_field: ::std::option::Option<::pilota::AHashSet<Insanity>>,
 
+                    // Do not insert line break as test/go/Makefile.am is removing this line with
+                    // pattern match
                     pub list_field: ::std::vec::Vec<
                         ::std::collections::BTreeMap<
                             ::std::collections::BTreeSet<i32>,
@@ -16255,6 +17025,13 @@ pub mod apache {
                     }) +self.binary_field.as_ref().map_or(0, |value| __protocol.bytes_field_len(Some(4), value)) +self.uuid_field.as_ref().map_or(0, |value| __protocol.uuid_field_len(Some(5), *value) ) + __protocol.field_stop_len() + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBinary("%s")' where '%s' is a hex-formatted
+                 * string of thing's data @param binary
+                 * thing - the binary data to print
+                 * @return binary  - returns the binary 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBinaryResultSend {
                     fn default() -> Self {
                         ThriftTestTestBinaryResultSend::Ok(::std::default::Default::default())
@@ -16262,6 +17039,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBinaryResultSend {
+                    /**
+                     * Prints 'testBinary("%s")' where '%s' is a
+                     * hex-formatted string of thing's data
+                     * @param binary  thing - the binary data to print
+                     * @return binary  - returns the binary 'thing'
+                     */
                     Ok(::pilota::Bytes),
                 }
 
@@ -16405,6 +17188,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct SecondServiceSecondtestStringArgsSend {
                     pub thing: ::pilota::FastStr,
@@ -16570,6 +17358,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testByte("%d")' with thing as '%d'
+                 * The types i8 and byte are synonyms, use of i8 is
+                 * encouraged, byte still exists for the sake of
+                 * compatibility. @param byte thing - the
+                 * i8/byte to print @return i8 - returns the
+                 * i8/byte 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestByteResultSend {
                     fn default() -> Self {
                         ThriftTestTestByteResultSend::Ok(::std::default::Default::default())
@@ -16577,6 +17374,14 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestByteResultSend {
+                    /**
+                     * Prints 'testByte("%d")' with thing as '%d'
+                     * The types i8 and byte are synonyms, use of i8 is
+                     * encouraged, byte still exists for the sake of
+                     * compatibility. @param byte thing
+                     * - the i8/byte to print @return i8
+                     * - returns the i8/byte 'thing'
+                     */
                     Ok(i8),
                 }
 
@@ -16719,6 +17524,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and
+                 * arg1 as '%s' @param string arg - a string
+                 * indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode =
+                 * 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with
+                 * errorCode = 2002 and struct_thing.string_thing = "This is
+                 * an Xception2" else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionResultRecv {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionResultRecv::Ok(
@@ -16728,6 +17545,18 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiExceptionResultRecv {
+                    /**
+                     * Print 'testMultiException(%s, %s)' with arg0 as '%s'
+                     * and arg1 as '%s' @param string
+                     * arg - a string indicating what type of exception to
+                     * throw if arg0 == "Xception" throw
+                     * Xception with errorCode = 1001 and message = "This is
+                     * an Xception" else if arg0 ==
+                     * "Xception2" throw Xception2 with errorCode = 2002 and
+                     * struct_thing.string_thing = "This is an Xception2"
+                     * else do not throw anything
+                     * @return Xtruct - an Xtruct with string_thing = arg1
+                     */
                     Ok(Xtruct),
 
                     Err1(Xception),
@@ -17141,6 +17970,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with
+                 * these values:   {-4 => {-4 => -4, -3 =>
+                 * -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3,
+                 * 4 => 4, }, }
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapMapArgsSend {
                     pub hello: i32,
@@ -17306,6 +18143,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct GuessProtocolStruct {
                     pub map_field: ::std::option::Option<
@@ -17498,6 +18336,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testSet("{%s}")' where thing has been formatted
+                 * into a string of values  separated by
+                 * commas and new lines @param set<i32>
+                 * thing - the set<i32> to print
+                 * @return set<i32> - returns the set<i32> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestSetArgsSend {
                     pub thing: ::pilota::AHashSet<i32>,
@@ -17690,6 +18535,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStruct("{%s}")' where thing has been
+                 * formatted into a string of comma separated values
+                 * @param Xtruct thing - the Xtruct to print
+                 * @return Xtruct - returns the Xtruct 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStructArgsSend {
                     pub thing: Xtruct,
@@ -17860,6 +18711,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with
+                 * the above values
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestInsanityArgsRecv {
                     pub argument: Insanity,
@@ -18030,6 +18893,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct NestedListsBonk {
                     pub bonk: ::std::option::Option<
@@ -18274,6 +19138,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI64("%d")' with thing as '%d'
+                 * @param i64 thing - the i64 to print
+                 * @return i64 - returns the i64 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestI64ArgsSend {
                     pub thing: i64,
@@ -18439,6 +19308,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted
+                 * into a string of values  separated by
+                 * commas and new lines @param list<i32>
+                 * thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestListArgsRecv {
                     pub thing: ::std::vec::Vec<i32>,
@@ -18636,6 +19512,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringArgsSend {
                     pub thing: ::pilota::FastStr,
@@ -18801,6 +19682,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted
+                 * into a string of the nested struct @param
+                 * Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestNestArgsRecv {
                     pub thing: Xtruct2,
@@ -18971,6 +19858,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testException(%s)' with arg as '%s'
+                 * @param string arg - a string indication what type of
+                 * exception to throw if arg == "Xception"
+                 * throw Xception with errorCode = 1001 and message = arg
+                 * else if arg == "TException" throw TException
+                 * else do not throw anything
+                 */
+
                 impl ::std::default::Default for ThriftTestTestExceptionResultRecv {
                     fn default() -> Self {
                         ThriftTestTestExceptionResultRecv::Ok(::std::default::Default::default())
@@ -18978,6 +19874,15 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestExceptionResultRecv {
+                    /**
+                     * Print 'testException(%s)' with arg as '%s'
+                     * @param string arg - a string indication what type of
+                     * exception to throw if arg == "
+                     * Xception" throw Xception with errorCode = 1001 and
+                     * message = arg else if arg ==
+                     * "TException" throw TException
+                     * else do not throw anything
+                     */
                     Ok(()),
 
                     Err1(Xception),
@@ -19124,9 +20029,10 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct Xtruct2 {
-                    pub byte_thing: ::std::option::Option<i8>,
+                    pub byte_thing: ::std::option::Option<i8>, // used to be byte, hence the name
 
                     pub struct_thing: ::std::option::Option<Xtruct>,
 
@@ -19330,6 +20236,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
                 #[derive(PartialOrd, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestDoubleArgsRecv {
                     pub thing: f64,
@@ -19495,6 +20406,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestTypedefResultRecv {
                     fn default() -> Self {
                         ThriftTestTestTypedefResultRecv::Ok(::std::default::Default::default())
@@ -19502,6 +20419,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestTypedefResultRecv {
+                    /**
+                     * Prints 'testTypedef("%d")' with thing as '%d'
+                     * @param UserId thing - the UserId to print
+                     * @return UserId - returns the UserId 'thing'
+                     */
                     Ok(UserId),
                 }
 
@@ -19651,6 +20573,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true'
+                 * or 'false' @param bool  thing - the bool
+                 * data to print @return bool  - returns the
+                 * bool 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestBoolArgsRecv {
                     pub thing: bool,
@@ -19816,6 +20744,15 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been
+                 * formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string>
+                 * to print @return map<string,string> -
+                 * returns the map<string,string> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestStringMapResultRecv {
                     fn default() -> Self {
                         ThriftTestTestStringMapResultRecv::Ok(::std::default::Default::default())
@@ -19823,6 +20760,15 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestStringMapResultRecv {
+                    /**
+                     * Prints 'testStringMap("{%s}")' where thing has been
+                     * formatted into a string of 'key => value' pairs
+                     *  separated by commas and new lines
+                     * @param map<string,string> thing - the
+                     * map<string,string> to print
+                     * @return map<string,string> - returns the
+                     * map<string,string> 'thing'
+                     */
                     Ok(::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>),
                 }
 
@@ -20018,6 +20964,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given.
+                 * Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestUuidResultRecv {
                     fn default() -> Self {
                         ThriftTestTestUuidResultRecv::Ok(::std::default::Default::default())
@@ -20025,6 +20978,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestUuidResultRecv {
+                    /**
+                     * Prints 'testUuid("%s")' where '%s' is the uuid given.
+                     * Note that the uuid byte order should be correct.
+                     * @param uuid  thing - the uuid to print
+                     * @return uuid  - returns the uuid 'thing'
+                     */
                     Ok([u8; 16]),
                 }
 
@@ -20167,6 +21126,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct VersioningTestV2 {
                     pub begin_in_both: ::std::option::Option<i32>,
@@ -20668,6 +21628,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testI32("%d")' with thing as '%d'
+                 * @param i32 thing - the i32 to print
+                 * @return i32 - returns the i32 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestI32ResultRecv {
                     fn default() -> Self {
                         ThriftTestTestI32ResultRecv::Ok(::std::default::Default::default())
@@ -20675,6 +21641,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestI32ResultRecv {
+                    /**
+                     * Prints 'testI32("%d")' with thing as '%d'
+                     * @param i32 thing - the i32 to print
+                     * @return i32 - returns the i32 'thing'
+                     */
                     Ok(i32),
                 }
 
@@ -20817,6 +21788,18 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and
+                 * arg1 as '%s' @param string arg - a string
+                 * indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode =
+                 * 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with
+                 * errorCode = 2002 and struct_thing.string_thing = "This is
+                 * an Xception2" else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
+
                 impl ::std::default::Default for ThriftTestTestMultiExceptionResultSend {
                     fn default() -> Self {
                         ThriftTestTestMultiExceptionResultSend::Ok(
@@ -20826,6 +21809,18 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestMultiExceptionResultSend {
+                    /**
+                     * Print 'testMultiException(%s, %s)' with arg0 as '%s'
+                     * and arg1 as '%s' @param string
+                     * arg - a string indicating what type of exception to
+                     * throw if arg0 == "Xception" throw
+                     * Xception with errorCode = 1001 and message = "This is
+                     * an Xception" else if arg0 ==
+                     * "Xception2" throw Xception2 with errorCode = 2002 and
+                     * struct_thing.string_thing = "This is an Xception2"
+                     * else do not throw anything
+                     * @return Xtruct - an Xtruct with string_thing = arg1
+                     */
                     Ok(Xtruct),
 
                     Err1(Xception),
@@ -21060,6 +22055,10 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints "testVoid()" and returns nothing.
+                 */
+
                 impl ::std::default::Default for ThriftTestTestVoidResultRecv {
                     fn default() -> Self {
                         ThriftTestTestVoidResultRecv::Ok(::std::default::Default::default())
@@ -21067,6 +22066,9 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestVoidResultRecv {
+                    /**
+                     * Prints "testVoid()" and returns nothing.
+                     */
                     Ok(()),
                 }
 
@@ -21172,6 +22174,19 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * So you think you've got this all worked out, eh?
+                 *
+                 * Creates a map with these values and prints it out:
+                 *   { 1 => { 2 => argument,
+                 *            3 => argument,
+                 *          },
+                 *     2 => { 6 => <empty Insanity struct>, },
+                 *   }
+                 * @return map<UserId, map<Numberz,Insanity>> - a map with
+                 * the above values
+                 */
+
                 impl ::std::default::Default for ThriftTestTestInsanityResultSend {
                     fn default() -> Self {
                         ThriftTestTestInsanityResultSend::Ok(::std::default::Default::default())
@@ -21179,6 +22194,18 @@ pub mod apache {
                 }
                 #[derive(Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestInsanityResultSend {
+                    /**
+                     * So you think you've got this all worked out, eh?
+                     *
+                     * Creates a map with these values and prints it out:
+                     *   { 1 => { 2 => argument,
+                     *            3 => argument,
+                     *          },
+                     *     2 => { 6 => <empty Insanity struct>, },
+                     *   }
+                     * @return map<UserId, map<Numberz,Insanity>> - a map
+                     * with the above values
+                     */
                     Ok(::pilota::AHashMap<UserId, ::pilota::AHashMap<Numberz, Insanity>>),
                 }
 
@@ -21425,6 +22452,7 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+
                 #[derive(PartialOrd, Debug, Default, Clone, PartialEq)]
                 pub struct NestedListsDoublex2 {
                     pub doublelist: ::std::option::Option<::std::vec::Vec<::std::vec::Vec<f64>>>,
@@ -21642,6 +22670,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testList("{%s}")' where thing has been formatted
+                 * into a string of values  separated by
+                 * commas and new lines @param list<i32>
+                 * thing - the list<i32> to print
+                 * @return list<i32> - returns the list<i32> 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestListResultSend {
                     fn default() -> Self {
                         ThriftTestTestListResultSend::Ok(::std::default::Default::default())
@@ -21649,6 +22685,13 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestListResultSend {
+                    /**
+                     * Prints 'testList("{%s}")' where thing has been
+                     * formatted into a string of values
+                     *  separated by commas and new lines
+                     * @param list<i32> thing - the list<i32> to print
+                     * @return list<i32> - returns the list<i32> 'thing'
+                     */
                     Ok(::std::vec::Vec<i32>),
                 }
 
@@ -21828,6 +22871,17 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testMultiException(%s, %s)' with arg0 as '%s' and
+                 * arg1 as '%s' @param string arg - a string
+                 * indicating what type of exception to throw
+                 * if arg0 == "Xception" throw Xception with errorCode =
+                 * 1001 and message = "This is an Xception"
+                 * else if arg0 == "Xception2" throw Xception2 with
+                 * errorCode = 2002 and struct_thing.string_thing = "This is
+                 * an Xception2" else do not throw anything
+                 * @return Xtruct - an Xtruct with string_thing = arg1
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMultiExceptionArgsSend {
                     pub arg0: ::pilota::FastStr,
@@ -22030,6 +23084,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testNest("{%s}")' where thing has been formatted
+                 * into a string of the nested struct @param
+                 * Xtruct2 thing - the Xtruct2 to print
+                 * @return Xtruct2 - returns the Xtruct2 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestNestResultSend {
                     fn default() -> Self {
                         ThriftTestTestNestResultSend::Ok(::std::default::Default::default())
@@ -22037,6 +23098,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestNestResultSend {
+                    /**
+                     * Prints 'testNest("{%s}")' where thing has been
+                     * formatted into a string of the nested struct
+                     * @param Xtruct2 thing - the Xtruct2 to print
+                     * @return Xtruct2 - returns the Xtruct2 'thing'
+                     */
                     Ok(Xtruct2),
                 }
 
@@ -22292,6 +23359,7 @@ pub mod apache {
                         )
                     }
                 }
+
                 impl ::std::default::Default for OptionalSetDefaultTest {
                     fn default() -> Self {
                         OptionalSetDefaultTest {
@@ -22495,6 +23563,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testDouble("%f")' with thing as '%f'
+                 * @param double thing - the double to print
+                 * @return double - returns the double 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestDoubleResultSend {
                     fn default() -> Self {
                         ThriftTestTestDoubleResultSend::Ok(::std::default::Default::default())
@@ -22502,6 +23576,11 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestDoubleResultSend {
+                    /**
+                     * Prints 'testDouble("%f")' with thing as '%f'
+                     * @param double thing - the double to print
+                     * @return double - returns the double 'thing'
+                     */
                     Ok(f64),
                 }
 
@@ -22645,6 +23724,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Print 'testOneway(%d): Sleeping...' with secondsToSleep
+                 * as '%d' sleep 'secondsToSleep'
+                 * Print 'testOneway(%d): done sleeping!' with
+                 * secondsToSleep as '%d' @param i32
+                 * secondsToSleep - the number of seconds to sleep
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestOnewayArgsRecv {
                     pub seconds_to_sleep: i32,
@@ -22814,6 +23900,13 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testBool("%s")' where '%s' with thing as 'true'
+                 * or 'false' @param bool  thing - the bool
+                 * data to print @return bool  - returns the
+                 * bool 'thing'
+                 */
+
                 impl ::std::default::Default for ThriftTestTestBoolResultSend {
                     fn default() -> Self {
                         ThriftTestTestBoolResultSend::Ok(::std::default::Default::default())
@@ -22821,6 +23914,12 @@ pub mod apache {
                 }
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
                 pub enum ThriftTestTestBoolResultSend {
+                    /**
+                     * Prints 'testBool("%s")' where '%s' with thing as
+                     * 'true' or 'false' @param bool
+                     * thing - the bool data to print
+                     * @return bool  - returns the bool 'thing'
+                     */
                     Ok(bool),
                 }
 
@@ -23293,6 +24392,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testTypedef("%d")' with thing as '%d'
+                 * @param UserId thing - the UserId to print
+                 * @return UserId - returns the UserId 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestTypedefArgsSend {
                     pub thing: UserId,
@@ -23463,6 +24567,11 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testString("%s")' with thing as '%s'
+                 * @param string thing - the string to print
+                 * @return string - returns the string 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct SecondServiceSecondtestStringArgsRecv {
                     pub thing: ::pilota::FastStr,
@@ -23628,6 +24737,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testStringMap("{%s}")' where thing has been
+                 * formatted into a string of 'key => value' pairs
+                 *  separated by commas and new lines
+                 * @param map<string,string> thing - the map<string,string>
+                 * to print @return map<string,string> -
+                 * returns the map<string,string> 'thing'
+                 */
                 #[derive(Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestStringMapArgsSend {
                     pub thing: ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
@@ -24017,6 +25134,12 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testUuid("%s")' where '%s' is the uuid given.
+                 * Note that the uuid byte order should be correct.
+                 * @param uuid  thing - the uuid to print
+                 * @return uuid  - returns the uuid 'thing'
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestUuidArgsSend {
                     pub thing: [u8; 16],
@@ -24182,6 +25305,14 @@ pub mod apache {
                             + __protocol.struct_end_len()
                     }
                 }
+                /**
+                 * Prints 'testMapMap("%d")' with hello as '%d'
+                 * @param i32 hello - the i32 to print
+                 * @return map<i32,map<i32,i32>> - returns a dictionary with
+                 * these values:   {-4 => {-4 => -4, -3 =>
+                 * -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3,
+                 * 4 => 4, }, }
+                 */
                 #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
                 pub struct ThriftTestTestMapMapArgsRecv {
                     pub hello: i32,

--- a/pilota-build/test_data/thrift/auto_name.rs
+++ b/pilota-build/test_data/thrift/auto_name.rs
@@ -462,6 +462,7 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct TestException {}
         impl ::pilota::thrift::Message for TestException {
@@ -2552,6 +2553,7 @@ pub mod auto_name {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Test {
             pub ID: ::pilota::FastStr,

--- a/pilota-build/test_data/thrift/btree.rs
+++ b/pilota-build/test_data/thrift/btree.rs
@@ -259,6 +259,7 @@ pub mod btree {
                 )
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct B {
             pub m: ::std::collections::BTreeMap<i32, ::std::vec::Vec<::std::sync::Arc<A>>>,
@@ -737,6 +738,7 @@ pub mod btree {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Vec {}
         impl ::pilota::thrift::Message for Vec {

--- a/pilota-build/test_data/thrift/comments.rs
+++ b/pilota-build/test_data/thrift/comments.rs
@@ -1,0 +1,1478 @@
+pub mod comments {
+    #![allow(warnings, clippy::all)]
+
+    pub mod volo {
+
+        pub mod rpc {
+
+            pub mod example {
+
+                // namespace declaration
+
+                // File comments test
+
+                // Another file comment line
+
+                /*
+                 * Item struct represents an item with id, title, content, and extra metadata
+                 */
+
+                // This is a comment for the Item struct
+
+                #[derive(Debug, Default, Clone, PartialEq)]
+                pub struct Item {
+                    // id of the item
+                    pub id: i64, // id of the item
+
+                    /*
+                     * title of the item
+                     */
+                    pub title: ::pilota::FastStr, // trailing comment test
+
+                    // content of the item
+                    pub content: ::pilota::FastStr, // trailing comment
+
+                    // extra metadata of the item
+                    pub extra: ::std::option::Option<
+                        ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
+                    >, // trailing comment
+                }
+                impl ::pilota::thrift::Message for Item {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Item" };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_i64_field(1, *&self.id)?;
+                        __protocol.write_faststr_field(2, (&self.title).clone())?;
+                        __protocol.write_faststr_field(3, (&self.content).clone())?;
+                        if let Some(value) = self.extra.as_ref() {
+                            __protocol.write_map_field(
+                                10,
+                                ::pilota::thrift::TType::Binary,
+                                ::pilota::thrift::TType::Binary,
+                                &value,
+                                |__protocol, key| {
+                                    __protocol.write_faststr((key).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_faststr((val).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+                        let mut var_2 = None;
+                        let mut var_3 = None;
+                        let mut var_10 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I64 =>
+                                    {
+                                        var_1 = Some(__protocol.read_i64()?);
+                                    }
+                                    Some(2)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Binary =>
+                                    {
+                                        var_2 = Some(__protocol.read_faststr()?);
+                                    }
+                                    Some(3)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Binary =>
+                                    {
+                                        var_3 = Some(__protocol.read_faststr()?);
+                                    }
+                                    Some(10)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Map =>
+                                    {
+                                        var_10 = Some({
+                                            let map_ident = __protocol.read_map_begin()?;
+                                            let mut val =
+                                                ::pilota::AHashMap::with_capacity(map_ident.size);
+                                            for _ in 0..map_ident.size {
+                                                val.insert(
+                                                    __protocol.read_faststr()?,
+                                                    __protocol.read_faststr()?,
+                                                );
+                                            }
+                                            __protocol.read_map_end()?;
+                                            val
+                                        });
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!(
+                                    "decode struct `Item` field(#{}) failed, caused by: ",
+                                    field_id
+                                ));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field id is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_2) = var_2 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field title is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_3) = var_3 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field content is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self {
+                            id: var_1,
+                            title: var_2,
+                            content: var_3,
+                            extra: var_10,
+                        };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+                            let mut var_2 = None;
+                            let mut var_3 = None;
+                            let mut var_10 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64  => {
+                    var_1 = Some(__protocol.read_i64().await?);
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::Binary  => {
+                    var_2 = Some(__protocol.read_faststr().await?);
+
+                },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Binary  => {
+                    var_3 = Some(__protocol.read_faststr().await?);
+
+                },Some(10) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_10 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(__protocol.read_faststr().await?, __protocol.read_faststr().await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `Item` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field id is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_2) = var_2 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field title is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_3) = var_3 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field content is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self {
+                                id: var_1,
+                                title: var_2,
+                                content: var_3,
+                                extra: var_10,
+                            };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol
+                            .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
+                            + __protocol.i64_field_len(Some(1), *&self.id)
+                            + __protocol.faststr_field_len(Some(2), &self.title)
+                            + __protocol.faststr_field_len(Some(3), &self.content)
+                            + self.extra.as_ref().map_or(0, |value| {
+                                __protocol.map_field_len(
+                                    Some(10),
+                                    ::pilota::thrift::TType::Binary,
+                                    ::pilota::thrift::TType::Binary,
+                                    value,
+                                    |__protocol, key| __protocol.faststr_len(key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
+                            })
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct TestServiceGetItemArgsRecv {
+                    pub req: GetItemRequest,
+                }
+                impl ::pilota::thrift::Message for TestServiceGetItemArgsRecv {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsRecv",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.req,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsRecv` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field req is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { req: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetItemRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsRecv` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field req is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { req: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsRecv",
+                        }) + __protocol.struct_field_len(Some(1), &self.req)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+
+                impl ::std::default::Default for TestServiceGetItemResultSend {
+                    fn default() -> Self {
+                        TestServiceGetItemResultSend::Ok(::std::default::Default::default())
+                    }
+                }
+                #[derive(Debug, Clone, PartialEq)]
+                pub enum TestServiceGetItemResultSend {
+                    // method to get an item
+                    Ok(GetItemResponse),
+                }
+
+                impl ::pilota::thrift::Message for TestServiceGetItemResultSend {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultSend",
+                        })?;
+                        match self {
+                            TestServiceGetItemResultSend::Ok(value) => {
+                                __protocol.write_struct_field(
+                                    0,
+                                    value,
+                                    ::pilota::thrift::TType::Struct,
+                                )?;
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let mut ret = None;
+                        __protocol.read_struct_begin()?;
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            match field_ident.id {
+                                Some(0) => {
+                                    if ret.is_none() {
+                                        let field_ident =
+                                            ::pilota::thrift::Message::decode(__protocol)?;
+                                        __protocol.struct_len(&field_ident);
+                                        ret = Some(TestServiceGetItemResultSend::Ok(field_ident));
+                                    } else {
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                    }
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+                        }
+                        __protocol.read_field_end()?;
+                        __protocol.read_struct_end()?;
+                        if let Some(ret) = ret {
+                            ::std::result::Result::Ok(ret)
+                        } else {
+                            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received empty union from remote Message",
+                            ))
+                        }
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut ret = None;
+                            __protocol.read_struct_begin().await?;
+                            loop {
+                                let field_ident = __protocol.read_field_begin().await?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    break;
+                                } else {
+                                }
+                                match field_ident.id {
+                                    Some(0) => {
+                                        if ret.is_none() {
+                                            let field_ident = <GetItemResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                            ret =
+                                                Some(TestServiceGetItemResultSend::Ok(field_ident));
+                                        } else {
+                                            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                        }
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type).await?;
+                                    }
+                                }
+                            }
+                            __protocol.read_field_end().await?;
+                            __protocol.read_struct_end().await?;
+                            if let Some(ret) = ret {
+                                ::std::result::Result::Ok(ret)
+                            } else {
+                                ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received empty union from remote Message",
+                                    ),
+                                )
+                            }
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultSend",
+                        }) + match self {
+                            TestServiceGetItemResultSend::Ok(value) => {
+                                __protocol.struct_field_len(Some(0), value)
+                            }
+                        } + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // GetItemResponse struct represents the response for getting an item
+
+                #[derive(Debug, Default, Clone, PartialEq)]
+                pub struct GetItemResponse {
+                    pub item: Item,
+
+                    pub status: Status,
+                }
+                impl ::pilota::thrift::Message for GetItemResponse {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "GetItemResponse",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.item,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_i32_field(2, (&self.status).inner())?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+                        let mut var_2 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    Some(2)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I32 =>
+                                    {
+                                        var_2 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `GetItemResponse` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field item is required".to_string(),
+                                ),
+                            );
+                        };
+                        let Some(var_2) = var_2 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field status is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self {
+                            item: var_1,
+                            status: var_2,
+                        };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+                            let mut var_2 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<Item as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::I32  => {
+                    var_2 = Some(<Status as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetItemResponse` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field item is required".to_string(),
+                                    ),
+                                );
+                            };
+                            let Some(var_2) = var_2 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field status is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self {
+                                item: var_1,
+                                status: var_2,
+                            };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "GetItemResponse",
+                        }) + __protocol.struct_field_len(Some(1), &self.item)
+                            + __protocol.i32_field_len(Some(2), (&self.status).inner())
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // method to get an item
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct TestServiceGetItemArgsSend {
+                    pub req: GetItemRequest,
+                }
+                impl ::pilota::thrift::Message for TestServiceGetItemArgsSend {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsSend",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_struct_field(
+                            1,
+                            &self.req,
+                            ::pilota::thrift::TType::Struct,
+                        )?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::Struct =>
+                                    {
+                                        var_1 =
+                                            Some(::pilota::thrift::Message::decode(__protocol)?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsSend` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field req is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { req: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetItemRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `TestServiceGetItemArgsSend` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field req is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { req: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemArgsSend",
+                        }) + __protocol.struct_field_len(Some(1), &self.req)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // GetItemRequest struct represents the request for getting an item
+
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+                pub struct GetItemRequest {
+                    pub id: i64,
+                }
+                impl ::pilota::thrift::Message for GetItemRequest {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "GetItemRequest",
+                        };
+
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        __protocol.write_i64_field(1, *&self.id)?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin()?;
+                        if let ::std::result::Result::Err(mut err) = (|| {
+                            loop {
+                                let field_ident = __protocol.read_field_begin()?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    __protocol.field_stop_len();
+                                    break;
+                                } else {
+                                    __protocol
+                                        .field_begin_len(field_ident.field_type, field_ident.id);
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I64 =>
+                                    {
+                                        var_1 = Some(__protocol.read_i64()?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type)?;
+                                    }
+                                }
+
+                                __protocol.read_field_end()?;
+                                __protocol.field_end_len();
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        })() {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!(
+                                    "decode struct `GetItemRequest` field(#{}) failed, caused by: ",
+                                    field_id
+                                ));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end()?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field id is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { id: var_1 };
+                        ::std::result::Result::Ok(data)
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut var_1 = None;
+
+                            let mut __pilota_decoding_field_id = None;
+
+                            __protocol.read_struct_begin().await?;
+                            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64  => {
+                    var_1 = Some(__protocol.read_i64().await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetItemRequest` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                            __protocol.read_struct_end().await?;
+
+                            let Some(var_1) = var_1 else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "field id is required".to_string(),
+                                    ),
+                                );
+                            };
+
+                            let data = Self { id: var_1 };
+                            ::std::result::Result::Ok(data)
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "GetItemRequest",
+                        }) + __protocol.i64_field_len(Some(1), *&self.id)
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+                // Status enum represents the status of an operation
+                #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
+                #[repr(transparent)]
+                pub struct Status(i32);
+
+                impl Status {
+                    pub const SUCCESS: Self = Self(0);
+                    pub const ERROR: Self = Self(1);
+
+                    pub fn inner(&self) -> i32 {
+                        self.0
+                    }
+
+                    pub fn to_string(&self) -> ::std::string::String {
+                        match self {
+                            Self(0) => ::std::string::String::from("SUCCESS"),
+                            Self(1) => ::std::string::String::from("ERROR"),
+                            Self(val) => val.to_string(),
+                        }
+                    }
+
+                    pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
+                        match value {
+                            0 => Some(Self::SUCCESS),
+                            1 => Some(Self::ERROR),
+                            _ => None,
+                        }
+                    }
+                }
+
+                impl ::std::convert::From<i32> for Status {
+                    fn from(value: i32) -> Self {
+                        Self(value)
+                    }
+                }
+
+                impl ::std::convert::From<Status> for i32 {
+                    fn from(value: Status) -> i32 {
+                        value.0
+                    }
+                }
+
+                impl ::pilota::thrift::Message for Status {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_i32(self.inner())?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let value = __protocol.read_i32()?;
+                        ::std::result::Result::Ok(
+                            ::std::convert::TryFrom::try_from(value).map_err(|err| {
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    format!("invalid enum value for Status, value: {}", value),
+                                )
+                            })?,
+                        )
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let value = __protocol.read_i32().await?;
+                            ::std::result::Result::Ok(
+                                ::std::convert::TryFrom::try_from(value).map_err(|err| {
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        format!("invalid enum value for Status, value: {}", value),
+                                    )
+                                })?,
+                            )
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.i32_len(self.inner())
+                    }
+                }
+                // Test Service
+
+                // This is a comment for the TestService
+
+                pub trait TestService {}
+
+                // method to get an item
+
+                impl ::std::default::Default for TestServiceGetItemResultRecv {
+                    fn default() -> Self {
+                        TestServiceGetItemResultRecv::Ok(::std::default::Default::default())
+                    }
+                }
+                #[derive(Debug, Clone, PartialEq)]
+                pub enum TestServiceGetItemResultRecv {
+                    // method to get an item
+                    Ok(GetItemResponse),
+                }
+
+                impl ::pilota::thrift::Message for TestServiceGetItemResultRecv {
+                    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TOutputProtocolExt;
+                        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultRecv",
+                        })?;
+                        match self {
+                            TestServiceGetItemResultRecv::Ok(value) => {
+                                __protocol.write_struct_field(
+                                    0,
+                                    value,
+                                    ::pilota::thrift::TType::Struct,
+                                )?;
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+
+                    fn decode<T: ::pilota::thrift::TInputProtocol>(
+                        __protocol: &mut T,
+                    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                    {
+                        #[allow(unused_imports)]
+                        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                        let mut ret = None;
+                        __protocol.read_struct_begin()?;
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            match field_ident.id {
+                                Some(0) => {
+                                    if ret.is_none() {
+                                        let field_ident =
+                                            ::pilota::thrift::Message::decode(__protocol)?;
+                                        __protocol.struct_len(&field_ident);
+                                        ret = Some(TestServiceGetItemResultRecv::Ok(field_ident));
+                                    } else {
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                    }
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+                        }
+                        __protocol.read_field_end()?;
+                        __protocol.read_struct_end()?;
+                        if let Some(ret) = ret {
+                            ::std::result::Result::Ok(ret)
+                        } else {
+                            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received empty union from remote Message",
+                            ))
+                        }
+                    }
+
+                    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                        __protocol: &'a mut T,
+                    ) -> ::std::pin::Pin<
+                        ::std::boxed::Box<
+                            dyn ::std::future::Future<
+                                    Output = ::std::result::Result<
+                                        Self,
+                                        ::pilota::thrift::ThriftException,
+                                    >,
+                                > + Send
+                                + 'a,
+                        >,
+                    > {
+                        ::std::boxed::Box::pin(async move {
+                            let mut ret = None;
+                            __protocol.read_struct_begin().await?;
+                            loop {
+                                let field_ident = __protocol.read_field_begin().await?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    break;
+                                } else {
+                                }
+                                match field_ident.id {
+                                    Some(0) => {
+                                        if ret.is_none() {
+                                            let field_ident = <GetItemResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                            ret =
+                                                Some(TestServiceGetItemResultRecv::Ok(field_ident));
+                                        } else {
+                                            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                        }
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type).await?;
+                                    }
+                                }
+                            }
+                            __protocol.read_field_end().await?;
+                            __protocol.read_struct_end().await?;
+                            if let Some(ret) = ret {
+                                ::std::result::Result::Ok(ret)
+                            } else {
+                                ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received empty union from remote Message",
+                                    ),
+                                )
+                            }
+                        })
+                    }
+
+                    fn size<T: ::pilota::thrift::TLengthProtocol>(
+                        &self,
+                        __protocol: &mut T,
+                    ) -> usize {
+                        #[allow(unused_imports)]
+                        use ::pilota::thrift::TLengthProtocolExt;
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "TestServiceGetItemResultRecv",
+                        }) + match self {
+                            TestServiceGetItemResultRecv::Ok(value) => {
+                                __protocol.struct_field_len(Some(0), value)
+                            }
+                        } + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift/comments.thrift
+++ b/pilota-build/test_data/thrift/comments.thrift
@@ -1,0 +1,50 @@
+// namespace declaration
+namespace rs volo.rpc.example
+
+/*
+ * Item struct represents an item with id, title, content, and extra metadata
+ */
+
+// This is a comment for the Item struct
+struct Item {
+    // id of the item
+    1: required i64 id,                     // id of the item
+
+    /*
+     * title of the item
+     */
+    2: required string title,               // trailing comment test
+    // content of the item
+    3: required string content,             # trailing comment
+    // extra metadata of the item
+    10: optional map<string, string> extra, // trailing comment
+}
+
+// Status enum represents the status of an operation
+enum Status {
+    // Success status
+    SUCCESS = 0,
+    // Error status
+    ERROR = 1,
+}
+
+// GetItemRequest struct represents the request for getting an item
+struct GetItemRequest {
+    1: required i64 id,
+}
+
+// GetItemResponse struct represents the response for getting an item
+struct GetItemResponse {
+    1: required Item item,
+    2: required Status status,
+}
+
+// Test Service
+// This is a comment for the TestService
+service TestService {
+    // method to get an item
+    GetItemResponse getItem(1: GetItemRequest req),
+}
+
+// File comments test
+// Another file comment line

--- a/pilota-build/test_data/thrift/const_val.rs
+++ b/pilota-build/test_data/thrift/const_val.rs
@@ -116,6 +116,7 @@ pub mod const_val {
             map.insert(1i32, ::std::vec!["hello"]);
             map
         });
+
         #[derive(Debug, Default, Clone, PartialEq)]
         pub struct Test {
             pub name:

--- a/pilota-build/test_data/thrift/decode_error.rs
+++ b/pilota-build/test_data/thrift/decode_error.rs
@@ -159,6 +159,7 @@ pub mod decode_error {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct C {
             pub a: ::pilota::FastStr,
@@ -312,6 +313,7 @@ pub mod decode_error {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct B {
             pub c: C,

--- a/pilota-build/test_data/thrift/default_value.rs
+++ b/pilota-build/test_data/thrift/default_value.rs
@@ -100,6 +100,7 @@ pub mod default_value {
                 __protocol.i32_len(self.inner())
             }
         }
+
         impl ::std::default::Default for C {
             fn default() -> Self {
                 C {
@@ -275,6 +276,7 @@ pub mod default_value {
                     + __protocol.struct_end_len()
             }
         }
+
         impl ::std::default::Default for A {
             fn default() -> Self {
                 A {

--- a/pilota-build/test_data/thrift/enum_test.rs
+++ b/pilota-build/test_data/thrift/enum_test.rs
@@ -1102,6 +1102,7 @@ pub mod enum_test {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Request {
             pub Index: Index,

--- a/pilota-build/test_data/thrift/multi.rs
+++ b/pilota-build/test_data/thrift/multi.rs
@@ -276,6 +276,7 @@ pub mod multi {
                 __protocol.i32_len(self.inner())
             }
         }
+
         impl ::std::default::Default for A {
             fn default() -> Self {
                 A {
@@ -1115,6 +1116,7 @@ pub mod multi {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(Debug, Default, Clone, PartialEq)]
         pub struct B {
             pub a: ::std::option::Option<super::recursive_type::A>,
@@ -1449,6 +1451,7 @@ pub mod multi {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
             pub a: ::std::option::Option<::std::boxed::Box<A>>,
@@ -1629,6 +1632,7 @@ pub mod multi {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct B {
             pub b_a: ::std::option::Option<::std::boxed::Box<A>>,

--- a/pilota-build/test_data/thrift/normal.rs
+++ b/pilota-build/test_data/thrift/normal.rs
@@ -262,6 +262,7 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(Debug, Default, Clone, PartialEq)]
         pub struct ObjReq {
             pub msg: Message,
@@ -644,6 +645,7 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct B {
             pub a: ::std::option::Option<A>,
@@ -1312,6 +1314,7 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct SubMessage {
             pub value: ::std::option::Option<::pilota::FastStr>,
@@ -2235,6 +2238,7 @@ pub mod normal {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Message {
             pub uid: ::std::option::Option<[u8; 16]>,

--- a/pilota-build/test_data/thrift/pilota_name.rs
+++ b/pilota-build/test_data/thrift/pilota_name.rs
@@ -457,6 +457,7 @@ pub mod pilota_name {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Test1 {
             pub id: ::pilota::FastStr,

--- a/pilota-build/test_data/thrift/recursive_type.rs
+++ b/pilota-build/test_data/thrift/recursive_type.rs
@@ -183,6 +183,7 @@ pub mod recursive_type {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(Debug, Default, Clone, PartialEq)]
         pub struct C {
             pub c: ::std::option::Option<::pilota::AHashSet<::pilota::FastStr>>,
@@ -352,6 +353,7 @@ pub mod recursive_type {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct B {
             pub b_a: ::std::option::Option<::std::boxed::Box<A>>,

--- a/pilota-build/test_data/thrift/self_kw.rs
+++ b/pilota-build/test_data/thrift/self_kw.rs
@@ -100,6 +100,7 @@ pub mod self_kw {
                 __protocol.i32_len(self.inner())
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
             pub r#type: ::pilota::FastStr,

--- a/pilota-build/test_data/thrift/union.rs
+++ b/pilota-build/test_data/thrift/union.rs
@@ -176,6 +176,7 @@ pub mod union {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Default {}
         impl ::pilota::thrift::Message for Default {
@@ -398,6 +399,7 @@ pub mod union {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct A {
             pub u: ::std::option::Option<Union>,

--- a/pilota-build/test_data/thrift/wrapper_arc.rs
+++ b/pilota-build/test_data/thrift/wrapper_arc.rs
@@ -1034,6 +1034,7 @@ pub mod wrapper_arc {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(Debug, Default, Clone, PartialEq)]
         pub struct Test {
             pub id: ::pilota::FastStr,

--- a/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/article/src/gen.rs
@@ -395,6 +395,7 @@ pub mod r#gen {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct GetArticleResponse {
             pub article: Article,
@@ -709,6 +710,7 @@ pub mod r#gen {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct GetArticleRequest {
             pub id: i64,
@@ -1006,6 +1008,7 @@ pub mod r#gen {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
         pub struct Article {
             pub id: i64,

--- a/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/common/src/gen.rs
@@ -529,6 +529,7 @@ pub mod r#gen {
 
             pub email: ::pilota::FastStr,
 
+            //4: required image.Image avatar,
             pub common_data: super::common::CommonData,
         }
         impl ::pilota::thrift::Message for Author {

--- a/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/message_Article.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/article/src/article/loop/message_Article.rs
@@ -10,6 +10,7 @@ pub struct Article {
 
     pub status: Status,
 
+    //6: required list<image.Image> images,
     pub common_data: ::common::common::CommonData,
 }
 impl ::pilota::thrift::Message for Article {

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -172,6 +172,7 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(
             PartialOrd,
             Hash,
@@ -567,6 +568,7 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(
             PartialOrd,
             Hash,
@@ -882,6 +884,7 @@ pub mod unknown_fields {
             }
         }
         pub const TEST_LIST: [&'static str; 2] = ["hello", "world"];
+
         #[derive(
             PartialOrd,
             Hash,
@@ -1196,6 +1199,7 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(
             PartialOrd,
             Hash,
@@ -1655,6 +1659,7 @@ pub mod unknown_fields {
             map.insert(1i32, ::std::vec!["hello"]);
             map
         });
+
         #[derive(
             PartialOrd,
             Hash,
@@ -1838,6 +1843,7 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
+
         #[derive(
             PartialOrd,
             Hash,
@@ -2777,6 +2783,7 @@ pub mod unknown_fields {
                 __protocol.i32_len(self.inner())
             }
         }
+
         #[derive(
             PartialOrd,
             Hash,

--- a/pilota-thrift-fieldmask/Cargo.toml
+++ b/pilota-thrift-fieldmask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-fieldmask"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-fieldmask/Cargo.toml
+++ b/pilota-thrift-fieldmask/Cargo.toml
@@ -28,3 +28,4 @@ ahash.workspace = true
 faststr.workspace = true
 thiserror.workspace = true
 serde.workspace = true
+chumsky.workspace = true

--- a/pilota-thrift-fieldmask/src/fieldmask.rs
+++ b/pilota-thrift-fieldmask/src/fieldmask.rs
@@ -1508,7 +1508,7 @@ impl FieldMask {
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
-    use pilota_thrift_parser::parser::Parser as _;
+    use chumsky::prelude::*;
 
     use super::*;
 
@@ -1644,7 +1644,9 @@ mod tests {
     #[test]
     fn test_get_path() {
         let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::File::parse(&content).unwrap().1;
+        let mut ast = pilota_thrift_parser::descriptor::File::parse()
+            .parse(&content)
+            .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/fieldmask.thrift")
                 .canonicalize()
@@ -1655,7 +1657,9 @@ mod tests {
         pilota_thrift_reflect::service::Register::register(key, desc.clone());
 
         let content = std::fs::read_to_string("../examples/idl/base.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::File::parse(&content).unwrap().1;
+        let mut ast = pilota_thrift_parser::descriptor::File::parse()
+            .parse(&content)
+            .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/base.thrift")
                 .canonicalize()

--- a/pilota-thrift-fieldmask/src/fieldmask.rs
+++ b/pilota-thrift-fieldmask/src/fieldmask.rs
@@ -1644,9 +1644,15 @@ mod tests {
     #[test]
     fn test_get_path() {
         let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::descriptor::File::parse()
-            .parse(&content)
-            .unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/fieldmask.thrift")
                 .canonicalize()
@@ -1657,9 +1663,15 @@ mod tests {
         pilota_thrift_reflect::service::Register::register(key, desc.clone());
 
         let content = std::fs::read_to_string("../examples/idl/base.thrift").unwrap();
-        let mut ast = pilota_thrift_parser::descriptor::File::parse()
-            .parse(&content)
-            .unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/base.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
         ast.path = Arc::from(
             PathBuf::from("../examples/idl/base.thrift")
                 .canonicalize()

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true
@@ -21,3 +21,5 @@ maintenance = { status = "actively-developed" }
 nom.workspace = true
 bytes.workspace = true
 faststr.workspace = true
+chumsky.workspace = true
+ariadne.workspace = true

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -18,8 +18,10 @@ keywords = ["serialization", "thrift", "parser"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-nom.workspace = true
-bytes.workspace = true
-faststr.workspace = true
-chumsky.workspace = true
+anyhow.workspace = true
 ariadne.workspace = true
+bytes.workspace = true
+chumsky.workspace = true
+faststr.workspace = true
+nom.workspace = true
+thiserror.workspace = true

--- a/pilota-thrift-parser/src/descriptor/constant.rs
+++ b/pilota-thrift-parser/src/descriptor/constant.rs
@@ -1,5 +1,7 @@
 use std::{ops::Deref, sync::Arc};
 
+use faststr::FastStr;
+
 use super::{Annotations, Ident, Literal, Path, Type};
 
 #[derive(Debug, Clone)]
@@ -19,6 +21,8 @@ pub struct Constant {
     pub r#type: Type,
     pub value: ConstValue,
     pub annotations: Annotations,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/pilota-thrift-parser/src/descriptor/enum_.rs
+++ b/pilota-thrift-parser/src/descriptor/enum_.rs
@@ -1,3 +1,5 @@
+use faststr::FastStr;
+
 pub use super::{Annotations, Ident, IntConstant};
 
 #[derive(Debug)]
@@ -5,6 +7,8 @@ pub struct EnumValue {
     pub name: Ident,
     pub value: Option<IntConstant>,
     pub annotations: Annotations,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 #[derive(Debug)]
@@ -12,4 +16,6 @@ pub struct Enum {
     pub name: Ident,
     pub values: Vec<EnumValue>,
     pub annotations: Annotations,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }

--- a/pilota-thrift-parser/src/descriptor/field.rs
+++ b/pilota-thrift-parser/src/descriptor/field.rs
@@ -1,3 +1,5 @@
+use faststr::FastStr;
+
 use super::{Annotations, ConstValue, Ident, Type};
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -16,4 +18,6 @@ pub struct Field {
     pub ty: Type,
     pub default: Option<ConstValue>,
     pub annotations: Annotations,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }

--- a/pilota-thrift-parser/src/descriptor/function.rs
+++ b/pilota-thrift-parser/src/descriptor/function.rs
@@ -1,3 +1,5 @@
+use faststr::FastStr;
+
 use super::{Annotations, Field, Ident, Type};
 
 #[derive(Debug)]
@@ -8,4 +10,6 @@ pub struct Function {
     pub arguments: Vec<Field>,
     pub throws: Vec<Field>, // throws as an exception
     pub annotations: Annotations,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }

--- a/pilota-thrift-parser/src/descriptor/include.rs
+++ b/pilota-thrift-parser/src/descriptor/include.rs
@@ -1,9 +1,17 @@
+use faststr::FastStr;
+
 use super::Literal;
 
 #[derive(Debug)]
 pub struct Include {
     pub path: Literal,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }
 
 #[derive(Debug)]
-pub struct CppInclude(pub Literal);
+pub struct CppInclude {
+    pub path: Literal,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
+}

--- a/pilota-thrift-parser/src/descriptor/mod.rs
+++ b/pilota-thrift-parser/src/descriptor/mod.rs
@@ -30,6 +30,8 @@ pub use struct_::{Exception, Struct, StructLike, Union};
 pub use ty::{CppType, Ty, Type};
 pub use typedef::Typedef;
 
+pub struct Components {}
+
 #[derive(Debug, Clone)]
 pub struct Path {
     pub segments: Arc<[Ident]>,
@@ -85,6 +87,7 @@ pub struct File {
     pub package: Option<Path>,
     pub items: Vec<Item>,
     pub descriptor: Bytes,
+    pub comments: FastStr,
 }
 
 impl PartialEq for File {

--- a/pilota-thrift-parser/src/descriptor/namespace.rs
+++ b/pilota-thrift-parser/src/descriptor/namespace.rs
@@ -1,3 +1,5 @@
+use faststr::FastStr;
+
 use crate::{Annotations, Path};
 
 #[derive(Debug, Clone)]
@@ -8,4 +10,6 @@ pub struct Namespace {
     pub scope: Scope,
     pub name: Path,
     pub annotations: Option<Annotations>,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }

--- a/pilota-thrift-parser/src/descriptor/service.rs
+++ b/pilota-thrift-parser/src/descriptor/service.rs
@@ -1,3 +1,5 @@
+use faststr::FastStr;
+
 use super::{Annotations, Function, Ident, Path};
 
 #[derive(Debug)]
@@ -6,4 +8,6 @@ pub struct Service {
     pub extends: Option<Path>,
     pub functions: Vec<Function>,
     pub annotations: Annotations,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }

--- a/pilota-thrift-parser/src/descriptor/struct_.rs
+++ b/pilota-thrift-parser/src/descriptor/struct_.rs
@@ -1,22 +1,28 @@
 use std::ops::{Deref, DerefMut};
 
+use faststr::FastStr;
+
 use super::{Annotations, Field, Ident};
 
 #[derive(Debug)]
-pub struct Struct(pub StructLike);
+pub struct Struct {
+    pub struct_like: StructLike,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
+}
 
 macro_rules! struct_like {
     ($name: ty) => {
         impl Deref for $name {
             type Target = StructLike;
             fn deref(&self) -> &StructLike {
-                &self.0
+                &self.struct_like
             }
         }
 
         impl DerefMut for $name {
             fn deref_mut(&mut self) -> &mut Self::Target {
-                &mut self.0
+                &mut self.struct_like
             }
         }
     };
@@ -25,12 +31,20 @@ macro_rules! struct_like {
 struct_like!(Struct);
 
 #[derive(Debug)]
-pub struct Union(pub StructLike);
+pub struct Union {
+    pub struct_like: StructLike,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
+}
 
 struct_like!(Union);
 
 #[derive(Debug)]
-pub struct Exception(pub StructLike);
+pub struct Exception {
+    pub struct_like: StructLike,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
+}
 
 struct_like!(Exception);
 
@@ -39,4 +53,5 @@ pub struct StructLike {
     pub name: Ident,
     pub fields: Vec<Field>,
     pub annotations: Annotations,
+    pub comments: FastStr,
 }

--- a/pilota-thrift-parser/src/descriptor/typedef.rs
+++ b/pilota-thrift-parser/src/descriptor/typedef.rs
@@ -1,3 +1,5 @@
+use faststr::FastStr;
+
 use super::{Annotations, Ident, Type};
 
 #[derive(Debug)]
@@ -5,4 +7,6 @@ pub struct Typedef {
     pub r#type: Type,
     pub alias: Ident,
     pub annotations: Annotations,
+    pub leading_comments: FastStr,
+    pub trailing_comments: FastStr,
 }

--- a/pilota-thrift-parser/src/lib.rs
+++ b/pilota-thrift-parser/src/lib.rs
@@ -7,3 +7,7 @@ pub mod descriptor;
 pub mod parser;
 
 pub use descriptor::*;
+pub use parser::{
+    error::Error,
+    thrift::{FileParser, FileSource},
+};

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 impl Annotation {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
         let key = Ident::ident_with_dot();
 
         let value = Literal::parse();
@@ -33,7 +33,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_annotations() {
-        let _a = Annotation::parse()
+        let _a = Annotation::get_parser()
             .parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#)
             .unwrap();
 
@@ -42,7 +42,7 @@ mod tests {
             python.type ="DenseFoo",
             java.final="",
             )"#;
-        let res = Annotation::parse().parse(input).unwrap();
+        let res = Annotation::get_parser().parse(input).unwrap();
         assert_eq!(res.len(), 3);
     }
 }

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -12,12 +12,18 @@ impl Annotation {
 
         let value = Literal::parse();
 
-        just("(")
+        Components::blank()
+            .or_not()
+            .ignore_then(just("("))
             .ignore_then(
-                key.padded_by(blank().or_not())
-                    .then_ignore(just("=").padded_by(blank().or_not()))
+                key.padded_by(Components::blank().or_not())
+                    .then_ignore(just("=").padded_by(Components::blank().or_not()))
                     .then(value)
-                    .then_ignore(list_separator().padded_by(blank().or_not()).or_not())
+                    .then_ignore(
+                        Components::list_separator()
+                            .padded_by(Components::blank().or_not())
+                            .or_not(),
+                    )
                     .map(|(key, value)| Annotation { key, value })
                     .repeated()
                     .at_least(1)

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -1,64 +1,48 @@
-use nom::{
-    IResult,
-    bytes::complete::{tag, take_while},
-    character::complete::satisfy,
-    combinator::{map, opt, recognize},
-    multi::many1,
-    sequence::tuple,
-};
+use chumsky::prelude::*;
 
 use crate::{
-    descriptor::{Annotation, Annotations, Literal},
+    Literal,
+    descriptor::{Annotation, Annotations},
     parser::*,
 };
 
-impl Parser for Annotations {
-    // (foo = 'bar', x = "1")
-    fn parse(input: &str) -> IResult<&str, Annotations> {
-        map(
-            tuple((
-                tag("("),
-                many1(map(
-                    tuple((
-                        opt(blank),
-                        recognize(tuple((
-                            satisfy(|c| c.is_ascii_alphabetic() || c == '_'),
-                            take_while(|c: char| c.is_ascii_alphanumeric() || c == '_' || c == '.'),
-                        ))),
-                        opt(blank),
-                        tag("="),
-                        opt(blank),
-                        Literal::parse,
-                        opt(blank),
-                        opt(list_separator),
-                    )),
-                    |(_, p, _, _, _, lit, _, _)| Annotation {
-                        key: p.to_owned(),
-                        value: lit,
-                    },
-                )),
-                tag(")"),
-            )),
-            |(_, annotations, _)| Annotations(annotations),
-        )(input)
+impl Annotation {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
+        let key = Ident::ident_with_dot();
+
+        let value = Literal::parse();
+
+        just("(")
+            .ignore_then(
+                key.padded_by(blank().or_not())
+                    .then_ignore(just("=").padded_by(blank().or_not()))
+                    .then(value)
+                    .then_ignore(list_separator().padded_by(blank().or_not()).or_not())
+                    .map(|(key, value)| Annotation { key, value })
+                    .repeated()
+                    .at_least(1)
+                    .collect::<Vec<Annotation>>(),
+            )
+            .then_ignore(just(")"))
+            .map(Annotations)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{super::super::parser::Parser, Annotations};
-
+    use super::*;
     #[test]
     fn test_annotations() {
-        let _a = Annotations::parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#).unwrap();
+        let _a = Annotation::parse()
+            .parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#)
+            .unwrap();
 
         let input = r#"(
             cpp.type = "DenseFoo",
-            python.type = "DenseFoo",
-            java.final = "",
+            python.type ="DenseFoo",
+            java.final="",
             )"#;
-        let (remain, a) = Annotations::parse(input).unwrap();
-        assert!(remain.is_empty());
-        assert_eq!(a.len(), 3);
+        let res = Annotation::parse().parse(input).unwrap();
+        assert_eq!(res.len(), 3);
     }
 }

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -1,4 +1,5 @@
 use chumsky::prelude::*;
+use faststr::FastStr;
 
 use super::super::{
     descriptor::{Enum, EnumValue},
@@ -8,42 +9,61 @@ use crate::{Annotation, IntConstant};
 
 impl EnumValue {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
-        Ident::get_parser()
-            .padded_by(blank().or_not())
+        Components::comment()
+            .repeated()
+            .collect::<Vec<_>>()
+            .then_ignore(Components::blank().or_not())
+            .then(Ident::get_parser())
             .then(
-                just("=")
-                    .ignore_then(blank().or_not())
+                Components::blank()
+                    .or_not()
+                    .ignore_then(just("="))
+                    .ignore_then(Components::blank().or_not())
                     .ignore_then(IntConstant::parse())
                     .or_not(),
             )
-            .then_ignore(blank().or_not())
             .then(Annotation::get_parser().or_not())
-            .then_ignore(list_separator().or_not())
-            .map(|((name, value), annotations)| EnumValue {
-                name: Ident(name.into()),
-                value,
-                annotations: annotations.unwrap_or_default(),
-            })
+            .then_ignore(Components::list_separator().or_not())
+            .then(Components::trailing_comment().or_not())
+            .then_ignore(Components::blank().or_not())
+            .map(
+                |((((comments, name), value), annotations), trailing_comments)| EnumValue {
+                    leading_comments: FastStr::from(comments.join("\n\n")),
+                    name: Ident(name.into()),
+                    value,
+                    annotations: annotations.unwrap_or_default(),
+                    trailing_comments: FastStr::from(trailing_comments.unwrap_or_default()),
+                },
+            )
     }
 }
 
 impl Enum {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
-        just("enum")
-            .ignore_then(blank())
-            .ignore_then(Ident::get_parser())
-            .then_ignore(blank().or_not())
+        Components::comment()
+            .repeated()
+            .collect::<Vec<_>>()
+            .then_ignore(Components::blank().or_not())
+            .then_ignore(just("enum"))
+            .then_ignore(Components::blank())
+            .then(Ident::get_parser())
+            .then_ignore(Components::blank().or_not())
             .then_ignore(just("{"))
             .then(EnumValue::get_parser().repeated().collect())
-            .then_ignore(blank().or_not())
+            .then_ignore(Components::blank().or_not())
             .then_ignore(just("}"))
-            .then_ignore(blank().or_not())
             .then(Annotation::get_parser().or_not())
-            .map(|((name, values), annotations)| Enum {
-                name: Ident(name.into()),
-                values,
-                annotations: annotations.unwrap_or_default(),
-            })
+            .then(Components::trailing_comment().or_not())
+            .then_ignore(Components::blank().or_not())
+            .map(
+                |((((comments, name), values), annotations), trailing_comments)| Enum {
+                    leading_comments: FastStr::from(comments.join("\n\n")),
+                    name: Ident(name.into()),
+                    values,
+                    annotations: annotations.unwrap_or_default(),
+                    trailing_comments: FastStr::from(trailing_comments.unwrap_or_default()),
+                },
+            )
     }
 }
 
@@ -70,6 +90,17 @@ mod tests {
                 r#"enum Index {
                             A = 0x01,
                             B = 0x10,
+                        }"#,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_enum3() {
+        let _ = Enum::get_parser()
+            .parse(
+                r#"enum Index {
+
                         }"#,
             )
             .unwrap();

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -1,61 +1,49 @@
-use nom::{
-    IResult,
-    bytes::complete::tag,
-    combinator::{map, opt},
-    sequence::tuple,
-};
+use chumsky::prelude::*;
 
 use super::super::{
-    descriptor::{Annotations, Enum, EnumValue, Ident, IntConstant},
+    descriptor::{Enum, EnumValue},
     parser::*,
 };
+use crate::{Annotation, IntConstant};
 
-impl Parser for EnumValue {
-    fn parse(input: &str) -> IResult<&str, EnumValue> {
-        map(
-            tuple((
-                Ident::parse,
-                opt(blank),
-                opt(map(
-                    tuple((tag("="), opt(blank), IntConstant::parse)),
-                    |(_, _, value)| value,
-                )),
-                opt(blank),
-                opt(Annotations::parse),
-                opt(list_separator),
-                opt(blank),
-            )),
-            |(name, _, value, _, annotations, _, _)| EnumValue {
-                name,
+impl EnumValue {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
+        Ident::parse()
+            .padded_by(blank().or_not())
+            .then(
+                just("=")
+                    .ignore_then(blank().or_not())
+                    .ignore_then(IntConstant::parse())
+                    .or_not(),
+            )
+            .then_ignore(blank().or_not())
+            .then(Annotation::parse().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(|((name, value), annotations)| EnumValue {
+                name: Ident(name.into()),
                 value,
                 annotations: annotations.unwrap_or_default(),
-            },
-        )(input)
+            })
     }
 }
 
-impl Parser for Enum {
-    fn parse(input: &str) -> IResult<&str, Enum> {
-        map(
-            tuple((
-                tag("enum"),
-                blank,
-                Ident::parse,
-                opt(blank),
-                tag("{"),
-                opt(blank),
-                many0(EnumValue::parse),
-                opt(blank),
-                tag("}"),
-                opt(blank),
-                opt(Annotations::parse),
-            )),
-            |(_, _, name, _, _, _, values, _, _, _, annotations)| Enum {
-                name,
+impl Enum {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
+        just("enum")
+            .ignore_then(blank())
+            .ignore_then(Ident::parse())
+            .then_ignore(blank().or_not())
+            .then_ignore(just("{"))
+            .then(EnumValue::parse().repeated().collect())
+            .then_ignore(blank().or_not())
+            .then_ignore(just("}"))
+            .then_ignore(blank().or_not())
+            .then(Annotation::parse().or_not())
+            .map(|((name, values), annotations)| Enum {
+                name: Ident(name.into()),
                 values,
                 annotations: annotations.unwrap_or_default(),
-            },
-        )(input)
+            })
     }
 }
 
@@ -64,13 +52,26 @@ mod tests {
     use super::*;
     #[test]
     fn test_enum() {
-        let (_remain, _e) = Enum::parse(
-            r#"enum Sex {
-                UNKNOWN = 0,
-                MALE = 1 (pilota.key="male") // male
-                FEMALE = 2,
-            }"#,
-        )
-        .unwrap();
+        let _ = Enum::parse()
+            .parse(
+                r#"enum Sex {
+                            UNKNOWN = 0,
+                            MALE = 1 (pilota.key="male") // male
+                            FEMALE = 2,
+                        }"#,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_enum2() {
+        let _ = Enum::parse()
+            .parse(
+                r#"enum Index {
+                            A = 0x01,
+                            B = 0x10,
+                        }"#,
+            )
+            .unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -7,8 +7,8 @@ use super::super::{
 use crate::{Annotation, IntConstant};
 
 impl EnumValue {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, EnumValue, extra::Err<Rich<'a, char>>> {
+        Ident::get_parser()
             .padded_by(blank().or_not())
             .then(
                 just("=")
@@ -17,7 +17,7 @@ impl EnumValue {
                     .or_not(),
             )
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|((name, value), annotations)| EnumValue {
                 name: Ident(name.into()),
@@ -28,17 +28,17 @@ impl EnumValue {
 }
 
 impl Enum {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Enum, extra::Err<Rich<'a, char>>> {
         just("enum")
             .ignore_then(blank())
-            .ignore_then(Ident::parse())
+            .ignore_then(Ident::get_parser())
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
-            .then(EnumValue::parse().repeated().collect())
+            .then(EnumValue::get_parser().repeated().collect())
             .then_ignore(blank().or_not())
             .then_ignore(just("}"))
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .map(|((name, values), annotations)| Enum {
                 name: Ident(name.into()),
                 values,
@@ -52,7 +52,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_enum() {
-        let _ = Enum::parse()
+        let _ = Enum::get_parser()
             .parse(
                 r#"enum Sex {
                             UNKNOWN = 0,
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn test_enum2() {
-        let _ = Enum::parse()
+        let _ = Enum::get_parser()
             .parse(
                 r#"enum Index {
                             A = 0x01,

--- a/pilota-thrift-parser/src/parser/error.rs
+++ b/pilota-thrift-parser/src/parser/error.rs
@@ -1,0 +1,28 @@
+use faststr::FastStr;
+
+#[derive(thiserror::Error)]
+pub enum Error {
+    #[error("IO error: {0}")]
+    IO(std::io::Error),
+    #[error("File not found: {0}")]
+    FileNotFound(std::path::PathBuf),
+    #[error("Syntax error: {source}")]
+    Syntax {
+        summary: FastStr,
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+// for unwrap
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Syntax { summary, .. } => {
+                write!(f, "{}", summary)
+            }
+            Error::IO(error) => write!(f, "{}", error),
+            Error::FileNotFound(path_buf) => write!(f, "{}", path_buf.display()),
+        }
+    }
+}

--- a/pilota-thrift-parser/src/parser/field.rs
+++ b/pilota-thrift-parser/src/parser/field.rs
@@ -1,59 +1,46 @@
-use nom::{
-    IResult,
-    branch::alt,
-    bytes::complete::tag,
-    character::complete::digit1,
-    combinator::{map, opt},
-    sequence::tuple,
-};
+use chumsky::prelude::*;
 
 use super::super::{
-    descriptor::{Annotations, Attribute, ConstValue, Field, Ident, Type},
+    descriptor::{Attribute, Field},
     parser::*,
 };
+use crate::{Annotation, ConstValue, Type};
 
-impl Parser for Attribute {
-    fn parse(input: &str) -> IResult<&str, Attribute> {
-        alt((
-            map(tag("required"), |_| Attribute::Required),
-            map(tag("optional"), |_| Attribute::Optional),
-        ))(input)
+impl Attribute {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Attribute, extra::Err<Rich<'a, char>>> {
+        choice((
+            just("required").to(Attribute::Required),
+            just("optional").to(Attribute::Optional),
+        ))
     }
 }
 
-impl Parser for Field {
-    fn parse(input: &str) -> IResult<&str, Field> {
+impl Field {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Field, extra::Err<Rich<'a, char>>> {
         // 1: required i32 name = 123;
-        map(
-            tuple((
-                map(tuple((digit1, opt(blank), tag(":"))), |(id, _, _)| {
-                    id.parse::<i32>().unwrap()
-                }),
-                opt(blank),
-                opt(Attribute::parse),
-                opt(blank),
-                Type::parse,
-                opt(blank),
-                Ident::parse,
-                opt(blank),
-                opt(map(
-                    tuple((tag("="), opt(blank), ConstValue::parse)),
-                    |(_, _, default)| default,
-                )),
-                opt(blank),
-                opt(Annotations::parse),
-                opt(blank),
-                opt(list_separator),
-            )),
-            |(id, _, attribute, _, r#type, _, name, _, default, _, annotations, _, _)| Field {
-                id,
-                attribute: attribute.unwrap_or_default(),
-                ty: r#type,
-                name,
-                default,
-                annotations: annotations.unwrap_or_default(),
-            },
-        )(input)
+        text::int(10)
+            .then_ignore(just(":").padded_by(blank().or_not()))
+            .then(Attribute::parse().or_not())
+            .then(Type::parse().padded_by(blank().or_not()))
+            .then(Ident::parse())
+            .then(
+                just("=")
+                    .padded_by(blank().or_not())
+                    .ignore_then(ConstValue::parse())
+                    .or_not(),
+            )
+            .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+            .then_ignore(list_separator().or_not())
+            .map(
+                |(((((id, attribute), r#type), name), value), annotations)| Field {
+                    id: id.parse().unwrap(),
+                    attribute: attribute.unwrap_or_default(),
+                    ty: r#type,
+                    name: Ident(name.into()),
+                    default: value,
+                    annotations: annotations.unwrap_or_default(),
+                },
+            )
     }
 }
 
@@ -64,17 +51,22 @@ mod tests {
 
     #[test]
     fn test_field() {
-        let _f = Field::parse(
-            r#"1: required string(foo="1", bar='2') LogID = "xxx" (foo = '1', bar="2"),"#,
-        )
-        .unwrap()
-        .1;
+        let _f = Field::parse()
+            .parse(r#"1: required string(foo="1", bar='2') LogID = "xxx" (foo = '1', bar="2"),"#)
+            .unwrap();
     }
 
     #[test]
     fn test_field2() {
-        let _f =
-            Field::parse(r#"1: set<i64> Ids (go.tag = "json:\"Ids\" split:\"type=tenant\""),"#)
-                .unwrap();
+        let _f = Field::parse()
+            .parse(r#"1: set<i64> Ids (go.tag = "json:\"Ids\" split:\"type=tenant\""),"#)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_field3() {
+        let _f = Field::parse()
+            .parse(r#"2: required bytet_i.Injection Injection,"#)
+            .unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -8,8 +8,8 @@ use super::super::{
 use crate::{Annotation, Field, Type, parser::*};
 
 impl Function {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
-        let fields = Field::parse()
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Function, extra::Err<Rich<'a, char>>> {
+        let fields = Field::get_parser()
             .padded_by(blank().or_not())
             .repeated()
             .at_least(1)
@@ -26,16 +26,16 @@ impl Function {
         just("oneway")
             .then_ignore(blank())
             .or_not()
-            .then(Type::parse())
+            .then(Type::get_parser())
             .then_ignore(blank())
-            .then(Ident::parse())
+            .then(Ident::get_parser())
             .then_ignore(just("(").padded_by(blank().or_not()))
             .then(fields.clone().or_not())
             .then_ignore(just(")"))
             .padded_by(blank().or_not())
             .then(throws.or_not())
             .then_ignore(blank().or_not())
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(
                 |(((((oneway, r#type), name), arguments), throws), annotations)| {
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_func() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(
                 r#"map<i64, shared.ProcessingStatus> processUserData(
                             1: required list<UserProfile> profiles,
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_func2() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(
                 r#"oneway void pingServer(
                             1: required string(go.tag = 'json:"source_service"') source,
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_func3() {
-        let _f = Function::parse()
+        let _f = Function::get_parser()
             .parse(r#"Err test_enum_var_type_name_conflict (1: Request req);"#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/identifier.rs
+++ b/pilota-thrift-parser/src/parser/identifier.rs
@@ -3,7 +3,7 @@ use chumsky::prelude::*;
 use crate::Ident;
 
 impl Ident {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
         text::ascii::ident().map(|ident: &str| ident.to_string())
     }
 
@@ -27,12 +27,12 @@ mod test {
 
     #[test]
     fn test_identifier() {
-        assert_eq!(Ident::parse().parse("abc").unwrap(), "abc");
-        assert_eq!(Ident::parse().parse("a1d").unwrap(), "a1d");
-        assert_eq!(Ident::parse().parse("foo_bar").unwrap(), "foo_bar");
+        assert_eq!(Ident::get_parser().parse("abc").unwrap(), "abc");
+        assert_eq!(Ident::get_parser().parse("a1d").unwrap(), "a1d");
+        assert_eq!(Ident::get_parser().parse("foo_bar").unwrap(), "foo_bar");
 
-        assert_eq!(Ident::parse().parse("_123").unwrap(), "_123");
-        assert_eq!(Ident::parse().parse("_").unwrap(), "_");
+        assert_eq!(Ident::get_parser().parse("_123").unwrap(), "_123");
+        assert_eq!(Ident::get_parser().parse("_").unwrap(), "_");
     }
 
     #[test]

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -7,7 +7,7 @@ use super::super::{
 use crate::Literal;
 
 impl Include {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Include, extra::Err<Rich<'a, char>>> {
         just("include")
             .ignore_then(blank())
             .ignore_then(Literal::parse())
@@ -24,7 +24,7 @@ impl CppInclude {
             .ignore_then(Literal::parse())
             .then_ignore(blank().or_not())
             .then_ignore(list_separator().or_not())
-            .map(|path| CppInclude(path))
+            .map(CppInclude)
     }
 }
 
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn test_include() {
-        let _f = Include::parse()
+        let _f = Include::get_parser()
             .parse(r#"include "shared.thrift""#)
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/literal.rs
+++ b/pilota-thrift-parser/src/parser/literal.rs
@@ -1,34 +1,49 @@
-use nom::{
-    IResult,
-    branch::alt,
-    bytes::complete::{escaped, tag},
-    character::complete::none_of,
-    combinator::map,
-    sequence::delimited,
-};
+use chumsky::prelude::*;
 
-use super::super::{descriptor::Literal, parser::*};
+use super::super::descriptor::Literal;
 
-macro_rules! gen_parse_quote {
-    ($func_name: ident, $char: tt) => {
-        fn $func_name(input: &str) -> IResult<&str, &str> {
-            let esc = escaped(none_of(concat!("\\", $char)), '\\', one_of(r#"'"n\"#));
-            let esc_or_empty = alt((esc, tag("")));
-            let res = delimited(tag($char), esc_or_empty, tag($char))(input)?;
+fn quoted_string<'a>(quote: char) -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+    let normal_char = none_of([quote, '\\']);
 
-            Ok(res)
-        }
-    };
+    let escape_char = just('\\').ignore_then(one_of(['\'', '"', 'n', '\\']));
+
+    let content_char = escape_char
+        .map(|c| match c {
+            'n' => '\n',
+            other => other,
+        })
+        .or(normal_char);
+
+    just(quote)
+        .ignore_then(content_char.repeated().collect::<String>())
+        .then_ignore(just(quote))
 }
 
-gen_parse_quote!(single_quote, "\'");
-gen_parse_quote!(double_quote, "\"");
+fn single_quote<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+    quoted_string('\'')
+}
 
-impl Parser for Literal {
-    fn parse(input: &str) -> IResult<&str, Literal> {
-        alt((
-            map(single_quote, |x| Literal(x.into())),
-            map(double_quote, |x| Literal(x.into())),
-        ))(input)
+fn double_quote<'a>() -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
+    quoted_string('"')
+}
+
+impl Literal {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Literal, extra::Err<Rich<'a, char>>> {
+        single_quote().map(Literal).or(double_quote().map(Literal))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_literal() {
+        let _ = Literal::parse().parse(r#""hello""#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\'world'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\nworld'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\\world'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\"world'"#).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -13,57 +13,79 @@ mod literal;
 mod namespace;
 mod service;
 mod struct_;
-mod thrift;
+pub mod thrift;
 mod ty;
 mod typedef;
 
-use std::sync::Arc;
+use chumsky::prelude::*;
 
-use nom::{
-    IResult,
-    branch::alt,
-    bytes::complete::{tag, take_till, take_until},
-    character::complete::{multispace1, one_of, satisfy},
-    combinator::{map, opt},
-    multi::{many0, many1, separated_list1},
-    sequence::{preceded, terminated, tuple},
-};
+use super::descriptor::Path;
+use crate::Ident;
 
-use super::descriptor::{Ident, Path};
-
-/// combinator for parsing thrift idl
-pub trait Parser: Sized {
-    /// parse from input idl
-    fn parse(input: &str) -> IResult<&str, Self>;
-}
-
-impl Parser for Path {
-    fn parse(input: &str) -> IResult<&str, Self> {
-        map(
-            separated_list1(tuple((opt(blank), tag("."), opt(blank))), Ident::parse),
-            |idents| Path {
-                segments: Arc::from(idents),
-            },
-        )(input)
+impl Path {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
+        Ident::parse()
+            .separated_by(just('.').padded_by(blank()))
+            .at_least(1)
+            .collect()
+            .map(|s: Vec<String>| {
+                let idents: Vec<Ident> = s.into_iter().map(Ident::from).collect();
+                Path {
+                    segments: idents.into(),
+                }
+            })
+            .padded_by(blank())
     }
 }
 
-pub(crate) fn list_separator(input: &str) -> IResult<&str, char> {
-    map(tuple((one_of(",;"), opt(blank))), |(sep, _)| sep)(input)
+pub fn list_separator<'a>() -> impl Parser<'a, &'a str, char, extra::Err<Rich<'a, char>>> {
+    one_of(",;").then(blank().or_not()).map(|(sep, _)| sep)
 }
 
-fn comment(input: &str) -> IResult<&str, &str> {
-    alt((
-        preceded(tag("//"), take_till(|c| c == '\n')),
-        preceded(tag("/*"), terminated(take_until("*/"), tag("*/"))),
-        preceded(tag("#"), take_till(|c| c == '\n')),
-    ))(input)
+pub fn blank<'a>() -> impl Parser<'a, &'a str, (), extra::Err<Rich<'a, char>>> {
+    choice((
+        just("//")
+            .then(any().and_is(just('\n').not()).repeated())
+            .ignored(),
+        just("#")
+            .then(any().and_is(just('\n').not()).repeated())
+            .ignored(),
+        just("/*")
+            .then(any().and_is(just("*/").not()).repeated())
+            .then(just("*/"))
+            .ignored(),
+        one_of(" \t\r\n").ignored(),
+    ))
+    .repeated()
+    .ignored()
 }
 
-pub(crate) fn blank(input: &str) -> IResult<&str, ()> {
-    map(many1(alt((comment, multispace1))), |_| ())(input)
+pub fn not_alphanumeric_or_underscore<'a>()
+-> impl Parser<'a, &'a str, char, extra::Err<Rich<'a, char>>> {
+    any()
+        .rewind()
+        .filter(|c: &char| !c.is_alphanumeric() && *c != '_')
 }
 
-pub(crate) fn alphanumeric_or_underscore(input: &str) -> IResult<&str, char> {
-    satisfy(|c: char| c.is_alphanumeric() || c == '_')(input)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blank() {
+        let _ = blank().parse(" \t\r\n").unwrap();
+    }
+
+    #[test]
+    fn test_path() {
+        let p = Path::parse().parse("foo.bar.baz").unwrap();
+        assert_eq!(p.segments.len(), 3);
+        assert_eq!(p.segments[0].as_str(), "foo");
+        assert_eq!(p.segments[1].as_str(), "bar");
+        assert_eq!(p.segments[2].as_str(), "baz");
+
+        let p = Path::parse().parse("foo").unwrap();
+        assert_eq!(p.segments.len(), 1);
+        assert_eq!(p.segments[0].as_str(), "foo");
+    }
 }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -5,6 +5,7 @@
 mod annotation;
 mod constant;
 mod enum_;
+pub mod error;
 mod field;
 mod function;
 mod identifier;
@@ -24,7 +25,7 @@ use crate::Ident;
 
 impl Path {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+        Ident::get_parser()
             .separated_by(just('.').padded_by(blank()))
             .at_least(1)
             .collect()

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -1,40 +1,35 @@
-use nom::{
-    IResult,
-    bytes::complete::tag,
-    combinator::{map, opt},
-    sequence::{preceded, tuple},
-};
+use chumsky::prelude::*;
 
-use super::super::{descriptor::Annotations, parser::*};
-use crate::{Namespace, Scope};
+use super::super::parser::*;
+use crate::{Annotation, Namespace, Scope};
 
-impl Parser for Namespace {
-    fn parse(input: &str) -> IResult<&str, Namespace> {
-        map(
-            tuple((
-                tag("namespace"),
-                preceded(blank, Scope::parse),
-                preceded(blank, Path::parse),
-                opt(blank),
-                opt(Annotations::parse),
-                opt(blank),
-                opt(list_separator),
-            )),
-            |(_, scope, name, _, annotations, _, _)| Namespace {
+impl Namespace {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
+        just("namespace")
+            .ignore_then(Scope::parse().padded_by(blank()))
+            .then(Path::parse())
+            .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+            .then_ignore(list_separator().or_not())
+            .map(|((scope, name), annotations)| Namespace {
                 scope,
                 name,
                 annotations,
-            },
-        )(input)
+            })
     }
 }
 
-impl Parser for Scope {
-    fn parse(input: &str) -> IResult<&str, Scope> {
-        map(
-            nom::bytes::complete::take_while1(|c: char| !c.is_whitespace()),
-            |s: &str| Scope(s.into()),
-        )(input)
+fn is_white_space(c: &char) -> bool {
+    *c == ' ' || *c == '\t' || *c == '\n' || *c == '\r'
+}
+
+impl Scope {
+    fn parse<'a>() -> impl Parser<'a, &'a str, Scope, extra::Err<Rich<'a, char>>> {
+        any()
+            .filter(|c: &char| !is_white_space(c))
+            .repeated()
+            .at_least(1)
+            .collect::<String>()
+            .map(|s: String| Scope(s))
     }
 }
 
@@ -43,38 +38,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_scope() {
-        let input = "cocoa ";
-        let (remaining, scope) = Scope::parse(input).unwrap();
-        assert_eq!(scope.0, "cocoa");
-        assert_eq!(remaining, " ");
-
-        let input = "*";
-        let (_, scope) = Scope::parse(input).unwrap();
-        assert_eq!(scope.0, "*");
-
-        let input = "py.twisted";
-        let (_, scope) = Scope::parse(input).unwrap();
-        assert_eq!(scope.0, "py.twisted");
-
-        let input = "  ";
-        let res = Scope::parse(input);
-        assert!(res.is_err());
-    }
-
-    #[test]
     fn test_namespace() {
-        let input = "namespace cocoa java.lang.Object";
-        let (_, namespace) = Namespace::parse(input).unwrap();
-        assert_eq!(namespace.scope.0, "cocoa");
-        assert_eq!(
-            namespace
-                .name
-                .segments
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>(),
-            vec!["java", "lang", "Object"]
-        );
+        let _ = Namespace::parse().parse("namespace * foo.bar").unwrap();
+        let _ = Namespace::parse()
+            .parse("namespace py.twisted ThriftTest")
+            .unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -4,11 +4,15 @@ use super::super::parser::*;
 use crate::{Annotation, Namespace, Scope};
 
 impl Namespace {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Namespace, extra::Err<Rich<'a, char>>> {
         just("namespace")
             .ignore_then(Scope::parse().padded_by(blank()))
             .then(Path::parse())
-            .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+            .then(
+                Annotation::get_parser()
+                    .or_not()
+                    .padded_by(blank().or_not()),
+            )
             .then_ignore(list_separator().or_not())
             .map(|((scope, name), annotations)| Namespace {
                 scope,
@@ -39,8 +43,10 @@ mod tests {
 
     #[test]
     fn test_namespace() {
-        let _ = Namespace::parse().parse("namespace * foo.bar").unwrap();
-        let _ = Namespace::parse()
+        let _ = Namespace::get_parser()
+            .parse("namespace * foo.bar")
+            .unwrap();
+        let _ = Namespace::get_parser()
             .parse("namespace py.twisted ThriftTest")
             .unwrap();
     }

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -1,44 +1,82 @@
-use nom::{
-    IResult,
-    bytes::complete::tag,
-    combinator::{map, opt},
-    sequence::tuple,
-};
+use chumsky::prelude::*;
 
-use super::super::{
-    descriptor::{Annotations, Function, Ident, Service},
-    parser::*,
-};
+use super::super::{descriptor::Service, parser::*};
+use crate::{Annotation, Function, Ident};
 
-impl Parser for Service {
-    fn parse(input: &str) -> IResult<&str, Service> {
-        map(
-            tuple((
-                tag("service"),
-                blank,
-                Ident::parse,
-                opt(map(
-                    tuple((blank, tag("extends"), blank, Path::parse)),
-                    |(_, _, _, p)| p,
-                )),
-                opt(blank),
-                tag("{"),
-                many0(map(tuple((opt(blank), Function::parse)), |(_, f)| f)),
-                opt(blank),
-                tag("}"),
-                opt(blank),
-                opt(Annotations::parse),
-                opt(list_separator),
-            )),
-            |(_, _, name, extends, _, _, functions, _, _, _, annotations, _)| Service {
-                name,
+impl Service {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
+        let extends = just("extends")
+            .padded_by(blank())
+            .ignore_then(Path::parse());
+        let functions = blank()
+            .or_not()
+            .ignore_then(Function::parse())
+            .repeated()
+            .collect::<Vec<_>>();
+
+        just("service")
+            .ignore_then(blank())
+            .ignore_then(Ident::parse())
+            .then(extends.or_not())
+            .then_ignore(blank().or_not())
+            .then_ignore(just("{"))
+            .then(functions)
+            .then_ignore(just("}").padded_by(blank().or_not()))
+            .then(Annotation::parse().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(|(((name, extends), functions), annotations)| Service {
+                name: Ident(name.into()),
                 extends,
                 functions,
                 annotations: annotations.unwrap_or_default(),
-            },
-        )(input)
+            })
     }
 }
 
-#[test]
-fn test_gen() {}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_service() {
+        let _ = Service::parse().parse(
+            r#"service ComplexService {
+
+                        /**
+                         * 函数1: processUserData
+                         * 这是一个复杂的 RPC 调用，用于处理用户数据。
+                         * 它接收一个用户 Profile 列表，返回一个处理结果的映射。
+                         * 可能会抛出自定义异常。
+                         */
+                        map<i64, shared.ProcessingStatus> processUserData(
+                            1: required list<UserProfile> profiles,
+                            2: optional map<string, string(go.tag='json:"config_value"')> config = {"timeout": "10s", "retries": "3"},
+                            3: i32(some.annotation = "for_i32_type") executionPriority = 1
+                        ) throws (1: ServiceException ex),
+
+                        /**
+                         * 函数2: pingServer
+                         * 这是一个 oneway 函数，客户端发送后不等待服务器响应。
+                         * 用于发送心跳或日志，参数中包含了复杂的嵌套结构和注解。
+                         * Oneway 函数不能有返回值（除了 void），也不能抛出异常。
+                         */
+                        oneway void pingServer(
+                            1: required string(go.tag = 'json:"source_service"') source,
+                            2: optional list<map<i64, set<double>>> nestedDataPoints
+                        ) (api.version = "2.5", deprecated = "false")
+
+                        }"#,
+        );
+    }
+
+    #[test]
+    fn test_service2() {
+        let _ = Service::parse()
+            .parse(
+                r#"service Test {
+                            Err test_enum(1: Ok req);
+                            Err test_enum_var_type_name_conflict (1: Request req);
+                        }"#,
+            )
+            .unwrap();
+    }
+}

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -4,25 +4,25 @@ use super::super::{descriptor::Service, parser::*};
 use crate::{Annotation, Function, Ident};
 
 impl Service {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
         let extends = just("extends")
             .padded_by(blank())
             .ignore_then(Path::parse());
         let functions = blank()
             .or_not()
-            .ignore_then(Function::parse())
+            .ignore_then(Function::get_parser())
             .repeated()
             .collect::<Vec<_>>();
 
         just("service")
             .ignore_then(blank())
-            .ignore_then(Ident::parse())
+            .ignore_then(Ident::get_parser())
             .then(extends.or_not())
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
             .then(functions)
             .then_ignore(just("}").padded_by(blank().or_not()))
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|(((name, extends), functions), annotations)| Service {
                 name: Ident(name.into()),
@@ -38,7 +38,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_service() {
-        let _ = Service::parse().parse(
+        let _ = Service::get_parser().parse(
             r#"service ComplexService {
 
                         /**
@@ -70,7 +70,7 @@ mod tests {
 
     #[test]
     fn test_service2() {
-        let _ = Service::parse()
+        let _ = Service::get_parser()
             .parse(
                 r#"service Test {
                             Err test_enum(1: Ok req);

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -7,7 +7,7 @@ use super::super::{
 use crate::{Annotation, Field, Ident};
 
 impl Struct {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Struct, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Struct, extra::Err<Rich<'a, char>>> {
         just("struct")
             .ignore_then(blank())
             .ignore_then(StructLike::parse())
@@ -35,17 +35,17 @@ impl Exception {
 
 impl StructLike {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, StructLike, extra::Err<Rich<'a, char>>> {
-        Ident::parse()
+        Ident::get_parser()
             .then_ignore(blank().or_not())
             .then_ignore(just("{"))
             .then(
                 blank()
-                    .ignore_then(Field::parse())
+                    .ignore_then(Field::get_parser())
                     .repeated()
                     .collect::<Vec<_>>(),
             )
             .then_ignore(just("}").padded_by(blank().or_not()))
-            .then(Annotation::parse().or_not())
+            .then(Annotation::get_parser().or_not())
             .then_ignore(list_separator().or_not())
             .map(|((name, fields), annotations)| StructLike {
                 name: Ident(name.into()),
@@ -72,7 +72,7 @@ mod tests {
         }
         "#;
 
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -81,7 +81,7 @@ mod tests {
             // 1
         }
         "#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -90,7 +90,7 @@ mod tests {
             1: string user_id (go.tag = 'json:\"user_id,omitempty\"'),
             2: string __files (go.tag = 'json:\"__files,omitempty\"'),
         }"#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 
     #[test]
@@ -99,6 +99,6 @@ mod tests {
             1: required string(pilota.annotation="test") Service,      // required service
             2: required bytet_i.Injection Injection,
         }"#;
-        Struct::parse().parse(str).unwrap();
+        Struct::get_parser().parse(str).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/thrift.rs
+++ b/pilota-thrift-parser/src/parser/thrift.rs
@@ -1,100 +1,77 @@
-use nom::{
-    IResult,
-    bytes::complete::take_while,
-    character::complete::satisfy,
-    combinator::{eof, map, opt, peek, recognize},
-    multi::many_till,
-    sequence::tuple,
+use chumsky::prelude::*;
+
+use super::super::{descriptor::File, parser::*};
+use crate::{
+    Constant, CppInclude, Enum, Exception, Include, Item, Namespace, Service, Struct, Union,
 };
 
-use super::super::{
-    descriptor::{
-        Constant, CppInclude, Enum, Exception, File, Include, Service, Struct, Typedef, Union,
-    },
-    parser::*,
-};
-use crate::{Item, Namespace};
-
-impl Parser for Item {
-    fn parse(input: &str) -> IResult<&str, Self> {
-        let (input, keyword) = peek(recognize(tuple((
-            satisfy(|c| c.is_ascii_alphabetic()),
-            take_while(|c: char| c.is_ascii_alphanumeric() || c == '_'),
-        ))))(input)?;
-        macro_rules! unpack {
-            ($variant: ident) => {{
-                let (rest, item) = $variant::parse(input)?;
-                Ok((rest, Self::$variant(item)))
-            }};
-        }
-        match keyword {
-            "include" => unpack!(Include),
-            "cpp_include" => unpack!(CppInclude),
-            "namespace" => unpack!(Namespace),
-            "typedef" => unpack!(Typedef),
-            "const" => unpack!(Constant),
-            "enum" => unpack!(Enum),
-            "struct" => unpack!(Struct),
-            "union" => unpack!(Union),
-            "exception" => unpack!(Exception),
-            "service" => unpack!(Service),
-            _ => Err(nom::Err::Failure(nom::error::Error::new(
-                input,
-                nom::error::ErrorKind::Fail,
-            ))),
-        }
+impl Item {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Item, extra::Err<Rich<'a, char>>> {
+        choice((
+            Include::parse().map(Item::Include),
+            CppInclude::parse().map(Item::CppInclude),
+            Namespace::parse().map(Item::Namespace),
+            typedef::type_def().map(Item::Typedef),
+            Constant::parse().map(Item::Constant),
+            Enum::parse().map(Item::Enum),
+            Struct::parse().map(Item::Struct),
+            Union::parse().map(Item::Union),
+            Exception::parse().map(Item::Exception),
+            Service::parse().map(Item::Service),
+        ))
     }
 }
 
-impl Parser for File {
-    fn parse(input: &str) -> IResult<&str, File> {
-        let mut t: File = Default::default();
+impl File {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, File, extra::Err<Rich<'a, char>>> {
+        let item_or_none = blank()
+            .or_not()
+            .ignore_then(Item::parse())
+            .then_ignore(blank().or_not());
 
-        // support empty file/only comment: skip leading and trailing blank, collect 0
-        // or more items, and verify EOF
-        let (remain, items) = many_till(
-            map(
-                tuple((opt(blank), opt(Item::parse), opt(blank))),
-                |(_, item, _)| item,
-            ),
-            eof,
-        )(input)?;
+        item_or_none
+            .repeated()
+            .collect()
+            .then_ignore(blank().or_not())
+            .then_ignore(end())
+            .map(|items: Vec<Item>| {
+                let mut file = File::default();
 
-        t.items = items.0.into_iter().flatten().collect::<Vec<_>>();
+                file.items = items;
 
-        let mut namespaces = t.items.iter().filter_map(|item| {
-            if let Item::Namespace(ns) = item {
-                Some(ns)
-            } else {
-                None
-            }
-        });
+                let mut namespaces = file.items.iter().filter_map(|i| match i {
+                    Item::Namespace(ns) => Some(ns),
+                    _ => None,
+                });
 
-        t.package = namespaces
-            .clone()
-            .find_map(|n| {
-                if n.scope.0 == "rs" {
-                    Some(n.name.clone())
-                } else {
-                    None
-                }
+                file.package = namespaces
+                    .clone()
+                    .find_map(|n| {
+                        if n.scope.0 == "rs" {
+                            Some(n.name.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .or_else(|| {
+                        namespaces.find_map(|n| {
+                            if n.scope.0 == "*" {
+                                Some(n.name.clone())
+                            } else {
+                                None
+                            }
+                        })
+                    });
+
+                file
             })
-            .or_else(|| {
-                namespaces.find_map(|n| {
-                    if n.scope.0 == "*" {
-                        Some(n.name.clone())
-                    } else {
-                        None
-                    }
-                })
-            });
-
-        Ok((remain, t))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use ariadne::{Color, Label, Report, ReportKind, Source};
+
     use super::*;
 
     #[test]
@@ -161,7 +138,21 @@ mod tests {
             BizResponse BizMethod3(1: BizRequest req)(api.post = '/life/client/:action/:biz/other', api.baseurl = 'ib.snssdk.com', api.param = 'true', api.serializer = 'json')
         }
         "#;
-        let (_remain, _res) = File::parse(body).unwrap();
+        let (file, errs) = File::parse().parse(body).into_output_errors();
+        println!("{file:#?}");
+        errs.into_iter().for_each(|e| {
+            Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
+                .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
+                .with_message(e.to_string())
+                .with_label(
+                    Label::new(("test.thrift", e.span().into_range()))
+                        .with_message(e.reason().to_string())
+                        .with_color(Color::Red),
+                )
+                .finish()
+                .print(("test.thrift", Source::from(body)))
+                .unwrap()
+        });
     }
 
     #[test]
@@ -186,9 +177,21 @@ const list<string> TEST_LIST = [
 service Service {
   MyStruct testEpisode(1:MyStruct arg)
 },"#;
-        let (remain, res) = File::parse(body).unwrap();
-        assert!(remain.is_empty());
-        assert_eq!(res.items.len(), 6);
+        let (file, errs) = File::parse().parse(body).into_output_errors();
+        println!("{file:#?}");
+        errs.into_iter().for_each(|e| {
+            Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
+                .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
+                .with_message(e.to_string())
+                .with_label(
+                    Label::new(("test.thrift", e.span().into_range()))
+                        .with_message(e.reason().to_string())
+                        .with_color(Color::Red),
+                )
+                .finish()
+                .print(("test.thrift", Source::from(body)))
+                .unwrap()
+        });
     }
 
     #[test]
@@ -199,8 +202,20 @@ service Service {
 
         # comment 2
         "#;
-        let (remain, res) = File::parse(body).unwrap();
-        assert!(remain.is_empty());
-        assert_eq!(res.items.len(), 0);
+        let (file, errs) = File::parse().parse(body).into_output_errors();
+        println!("{file:#?}");
+        errs.into_iter().for_each(|e| {
+            Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
+                .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
+                .with_message(e.to_string())
+                .with_label(
+                    Label::new(("test.thrift", e.span().into_range()))
+                        .with_message(e.reason().to_string())
+                        .with_color(Color::Red),
+                )
+                .finish()
+                .print(("test.thrift", Source::from(body)))
+                .unwrap()
+        });
     }
 }

--- a/pilota-thrift-parser/src/parser/thrift.rs
+++ b/pilota-thrift-parser/src/parser/thrift.rs
@@ -1,29 +1,193 @@
+use std::path::PathBuf;
+
+use ariadne::{Color, Label, Report, ReportKind, Source};
 use chumsky::prelude::*;
+use faststr::FastStr;
 
 use super::super::{descriptor::File, parser::*};
 use crate::{
-    Constant, CppInclude, Enum, Exception, Include, Item, Namespace, Service, Struct, Union,
+    Constant, CppInclude, Enum, Exception, Include, Item, Namespace, Service, Struct, Typedef,
+    Union,
 };
 
 impl Item {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, Item, extra::Err<Rich<'a, char>>> {
         choice((
-            Include::parse().map(Item::Include),
+            Include::get_parser().map(Item::Include),
             CppInclude::parse().map(Item::CppInclude),
-            Namespace::parse().map(Item::Namespace),
-            typedef::type_def().map(Item::Typedef),
-            Constant::parse().map(Item::Constant),
-            Enum::parse().map(Item::Enum),
-            Struct::parse().map(Item::Struct),
+            Namespace::get_parser().map(Item::Namespace),
+            Typedef::get_parser().map(Item::Typedef),
+            Constant::get_parser().map(Item::Constant),
+            Enum::get_parser().map(Item::Enum),
+            Struct::get_parser().map(Item::Struct),
             Union::parse().map(Item::Union),
             Exception::parse().map(Item::Exception),
-            Service::parse().map(Item::Service),
+            Service::get_parser().map(Item::Service),
         ))
     }
 }
 
+pub struct FileSource<'a> {
+    path: Option<PathBuf>,
+    content: &'a str,
+}
+
+impl<'a> FileSource<'a> {
+    pub fn new(inline: &'a str) -> Self {
+        Self {
+            path: None,
+            content: inline,
+        }
+    }
+
+    pub fn new_with_path(path: PathBuf, content: &'a str) -> Result<Self, error::Error> {
+        if !path.exists() {
+            return Err(error::Error::FileNotFound(path));
+        }
+
+        Ok(Self {
+            path: Some(path),
+            content,
+        })
+    }
+}
+
+pub struct FileParser<'a> {
+    pub source: FileSource<'a>,
+}
+
+impl<'a> FileParser<'a> {
+    pub fn new(source: FileSource<'a>) -> Self {
+        Self { source }
+    }
+
+    pub fn parse(&self) -> Result<File, error::Error> {
+        let (ast, errs) = File::get_parser()
+            .parse(self.source.content)
+            .into_output_errors();
+
+        let path_str = match &self.source.path {
+            Some(path) => &path.display().to_string(),
+            None => "inline",
+        };
+
+        if !errs.is_empty() {
+            let mut report_strings = Vec::with_capacity(errs.len() + 1);
+
+            let title = if errs.len() == 1 {
+                format!("Failed to parse thrift file: {}", path_str)
+            } else {
+                format!(
+                    "Failed to parse thrift file: {} ({} errors found)",
+                    path_str,
+                    errs.len()
+                )
+            };
+            report_strings.push(title);
+            report_strings.push(String::new());
+
+            for (i, e) in errs.iter().enumerate() {
+                if errs.len() > 1 {
+                    let error_header = format!("Error {}:", i + 1);
+                    report_strings.push(error_header.clone());
+                }
+
+                let mut buffer = Vec::new();
+                Report::build(ReportKind::Error, (path_str, e.span().into_range()))
+                    .with_config(ariadne::Config::new().with_index_type(ariadne::IndexType::Byte))
+                    .with_message(e.to_string())
+                    .with_label(
+                        Label::new((path_str, e.span().into_range()))
+                            .with_message(e.reason().to_string())
+                            .with_color(Color::Red),
+                    )
+                    .finish()
+                    .write((path_str, Source::from(self.source.content)), &mut buffer)
+                    .unwrap();
+                report_strings.push(String::from_utf8_lossy(&buffer).to_string());
+
+                if i < errs.len() - 1 {
+                    report_strings.push(String::new());
+                }
+            }
+
+            let report = report_strings.join("\n").into();
+            let summary = create_error_summary(&errs, path_str, self.source.content).into();
+            let custom_error = CustomSyntaxError { report };
+
+            return Err(error::Error::Syntax {
+                summary,
+                source: anyhow::anyhow!(custom_error),
+            });
+        }
+
+        Ok(ast.unwrap())
+    }
+}
+
+fn create_error_summary(errs: &[chumsky::error::Rich<char>], path_str: &str, text: &str) -> String {
+    if errs.is_empty() {
+        return String::new();
+    }
+
+    let mut summary = format!("Failed to parse thrift file: {}", path_str);
+
+    if errs.len() == 1 {
+        let err = &errs[0];
+        // 计算行号和列号
+        let (line, col) = calculate_line_col(err.span().start, text);
+        summary.push_str(&format!(" at line {}:{} - {}", line, col, err.reason()));
+    } else {
+        summary.push_str(&format!(" ({} errors found):", errs.len()));
+        for (i, err) in errs.iter().enumerate() {
+            let (line, col) = calculate_line_col(err.span().start, text);
+            summary.push_str(&format!(
+                "\n  {}. Line {}:{} - {}",
+                i + 1,
+                line,
+                col,
+                err.reason()
+            ));
+        }
+    }
+
+    summary
+}
+
+fn calculate_line_col(pos: usize, text: &str) -> (usize, usize) {
+    let mut line = 1;
+    let mut col = 1;
+
+    for (i, ch) in text.char_indices() {
+        if i >= pos {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 1;
+        } else {
+            col += 1;
+        }
+    }
+
+    (line, col)
+}
+
+#[derive(Debug)]
+pub struct CustomSyntaxError {
+    pub report: FastStr,
+}
+
+impl std::fmt::Display for CustomSyntaxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.report)
+    }
+}
+
+impl std::error::Error for CustomSyntaxError {}
+
 impl File {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, File, extra::Err<Rich<'a, char>>> {
+    pub(crate) fn get_parser<'a>() -> impl Parser<'a, &'a str, File, extra::Err<Rich<'a, char>>> {
         let item_or_none = blank()
             .or_not()
             .ignore_then(Item::parse())
@@ -35,9 +199,10 @@ impl File {
             .then_ignore(blank().or_not())
             .then_ignore(end())
             .map(|items: Vec<Item>| {
-                let mut file = File::default();
-
-                file.items = items;
+                let mut file = File {
+                    items,
+                    ..Default::default()
+                };
 
                 let mut namespaces = file.items.iter().filter_map(|i| match i {
                     Item::Namespace(ns) => Some(ns),
@@ -138,7 +303,7 @@ mod tests {
             BizResponse BizMethod3(1: BizRequest req)(api.post = '/life/client/:action/:biz/other', api.baseurl = 'ib.snssdk.com', api.param = 'true', api.serializer = 'json')
         }
         "#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
@@ -177,7 +342,7 @@ const list<string> TEST_LIST = [
 service Service {
   MyStruct testEpisode(1:MyStruct arg)
 },"#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))
@@ -202,7 +367,7 @@ service Service {
 
         # comment 2
         "#;
-        let (file, errs) = File::parse().parse(body).into_output_errors();
+        let (file, errs) = File::get_parser().parse(body).into_output_errors();
         println!("{file:#?}");
         errs.into_iter().for_each(|e| {
             Report::build(ReportKind::Error, ("test.thrift", e.span().into_range()))

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -1,143 +1,108 @@
 use std::sync::Arc;
 
-use nom::{
-    self, IResult,
-    branch::{alt, permutation},
-    bytes::complete::tag,
-    combinator::{map, not, opt, peek},
-    sequence::{preceded, tuple},
-};
+use chumsky::prelude::*;
 
 use super::super::{
-    descriptor::{Annotations, CppType, Literal, Path, Ty, Type},
+    descriptor::{CppType, Ty, Type},
     parser::*,
 };
+use crate::{Annotation, Literal};
 
-impl Parser for Type {
-    fn parse(input: &str) -> IResult<&str, Type> {
-        map(
-            tuple((
-                Ty::parse,
-                opt(map(
-                    permutation((opt(blank), Annotations::parse)),
-                    |(_, an)| an,
-                )),
-            )),
-            |(ty, an)| Type(ty, an.unwrap_or_default()),
-        )(input)
+impl CppType {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, CppType, extra::Err<Rich<'a, char>>> {
+        just("cpp_type")
+            .ignore_then(blank())
+            .ignore_then(Literal::parse())
+            .map(CppType)
     }
 }
 
-impl Parser for CppType {
-    fn parse(input: &str) -> IResult<&str, CppType> {
-        map(
-            tuple((tag("cpp_type"), blank, Literal::parse)),
-            |(_, _, cpp_type)| CppType(cpp_type),
-        )(input)
-    }
-}
+impl Type {
+    pub fn parse<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
+        recursive(|self_parser| {
+            let base_ty = choice((
+                just("string").to(Ty::String),
+                just("void").to(Ty::Void),
+                just("byte").to(Ty::Byte),
+                just("bool").to(Ty::Bool),
+                just("binary").to(Ty::Binary),
+                just("i8").to(Ty::I8),
+                just("i16").to(Ty::I16),
+                just("i32").to(Ty::I32),
+                just("i64").to(Ty::I64),
+                just("double").to(Ty::Double),
+                just("uuid").to(Ty::Uuid),
+            ))
+            .then_ignore(not_alphanumeric_or_underscore());
 
-impl Parser for Ty {
-    fn parse(input: &str) -> IResult<&str, Ty> {
-        alt((
-            map(
-                tuple((tag("string"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::String,
-            ),
-            map(
-                tuple((tag("void"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::Void,
-            ),
-            map(
-                tuple((tag("byte"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::Byte,
-            ),
-            map(
-                tuple((tag("bool"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::Bool,
-            ),
-            map(
-                tuple((tag("binary"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::Binary,
-            ),
-            map(
-                tuple((tag("i8"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::I8,
-            ),
-            map(
-                tuple((tag("i16"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::I16,
-            ),
-            map(
-                tuple((tag("i32"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::I32,
-            ),
-            map(
-                tuple((tag("i64"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::I64,
-            ),
-            map(
-                tuple((tag("double"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::Double,
-            ),
-            map(
-                tuple((tag("uuid"), peek(not(alphanumeric_or_underscore)))),
-                |_| Ty::Uuid,
-            ),
-            map(
-                tuple((
-                    tag("list"),
-                    opt(blank),
-                    tag("<"),
-                    opt(blank),
-                    Type::parse,
-                    opt(blank),
-                    tag(">"),
-                    opt(preceded(blank, CppType::parse)),
-                )),
-                |(_, _, _, _, inner_type, _, _, cpp_type)| Ty::List {
+            let list = just("list")
+                .ignore_then(just("<").padded_by(blank().or_not()))
+                .ignore_then(self_parser.clone())
+                .then_ignore(blank().or_not())
+                .then_ignore(just(">"))
+                .then(blank().ignore_then(CppType::parse()).or_not())
+                .map(|(inner_type, cpp_type)| Ty::List {
                     value: Arc::new(inner_type),
                     cpp_type,
-                },
-            ),
-            map(
-                tuple((
-                    tag("set"),
-                    opt(preceded(blank, CppType::parse)),
-                    opt(blank),
-                    tag("<"),
-                    opt(blank),
-                    Type::parse,
-                    opt(blank),
-                    tag(">"),
-                )),
-                |(_, cpp_type, _, _, _, inner_type, _, _)| Ty::Set {
+                })
+                .boxed();
+
+            let set = just("set")
+                .ignore_then(blank().ignore_then(CppType::parse()).or_not())
+                .then_ignore(just("<"))
+                .padded_by(blank().or_not())
+                .then(self_parser.clone())
+                .then_ignore(blank().or_not())
+                .then_ignore(just(">"))
+                .map(|(cpp_type, inner_type)| Ty::Set {
                     value: Arc::new(inner_type),
                     cpp_type,
-                },
-            ),
-            map(
-                tuple((
-                    tag("map"),
-                    opt(preceded(blank, CppType::parse)),
-                    opt(blank),
-                    tag("<"),
-                    opt(blank),
-                    Type::parse,
-                    opt(blank),
-                    list_separator,
-                    opt(blank),
-                    Type::parse,
-                    opt(blank),
-                    tag(">"),
-                )),
-                |(_, cpp_type, _, _, _, key_type, _, _, _, value_type, _, _)| Ty::Map {
+                })
+                .boxed();
+
+            let map_parser = just("map")
+                .ignore_then(blank().ignore_then(CppType::parse()).or_not())
+                .then_ignore(just("<").padded_by(blank().or_not()))
+                .then(self_parser.clone())
+                .then_ignore(list_separator().padded_by(blank().or_not()))
+                .then(self_parser.clone())
+                .then_ignore(blank().or_not())
+                .then_ignore(just(">"))
+                .map(|((cpp_type, key_type), value_type)| Ty::Map {
                     key: Arc::new(key_type),
                     value: Arc::new(value_type),
                     cpp_type,
-                },
-            ),
-            map(Path::parse, Ty::Path),
-        ))(input)
+                })
+                .boxed();
+
+            let ty_parser = choice((base_ty, list, set, map_parser, Path::parse().map(Ty::Path)));
+
+            ty_parser
+                .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+                .map(|(ty, an)| Type(ty, an.unwrap_or_default()))
+                .boxed()
+        })
+        .boxed()
+    }
+}
+
+//test
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_type() {
+        let parser = Type::parse();
+        let input = "map<i32, string>";
+        let _res = parser.parse(input).unwrap();
+    }
+
+    #[test]
+    fn test_type_path() {
+        let parser = Type::parse();
+        let input = "bytet_i.Injection";
+        let _res = parser.parse(input).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -18,7 +18,7 @@ impl CppType {
 }
 
 impl Type {
-    pub fn parse<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Type, extra::Err<Rich<'a, char>>> {
         recursive(|self_parser| {
             let base_ty = choice((
                 just("string").to(Ty::String),
@@ -78,7 +78,11 @@ impl Type {
             let ty_parser = choice((base_ty, list, set, map_parser, Path::parse().map(Ty::Path)));
 
             ty_parser
-                .then(Annotation::parse().or_not().padded_by(blank().or_not()))
+                .then(
+                    Annotation::get_parser()
+                        .or_not()
+                        .padded_by(blank().or_not()),
+                )
                 .map(|(ty, an)| Type(ty, an.unwrap_or_default()))
                 .boxed()
         })
@@ -94,14 +98,14 @@ mod tests {
 
     #[test]
     fn test_type() {
-        let parser = Type::parse();
+        let parser = Type::get_parser();
         let input = "map<i32, string>";
         let _res = parser.parse(input).unwrap();
     }
 
     #[test]
     fn test_type_path() {
-        let parser = Type::parse();
+        let parser = Type::get_parser();
         let input = "bytet_i.Injection";
         let _res = parser.parse(input).unwrap();
     }

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -3,18 +3,20 @@ use chumsky::prelude::*;
 use super::super::{descriptor::Typedef, parser::*};
 use crate::{Annotation, Type, descriptor::Ident};
 
-pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
-    just("typedef")
-        .ignore_then(Type::parse().padded_by(blank()))
-        .then(Ident::parse())
-        .then_ignore(blank().or_not())
-        .then(Annotation::parse().or_not())
-        .then_ignore(list_separator().or_not())
-        .map(|((r#type, alias), annotations)| Typedef {
-            r#type,
-            alias: Ident(alias.into()),
-            annotations: annotations.unwrap_or_default(),
-        })
+impl Typedef {
+    pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
+        just("typedef")
+            .ignore_then(Type::get_parser().padded_by(blank()))
+            .then(Ident::get_parser())
+            .then_ignore(blank().or_not())
+            .then(Annotation::get_parser().or_not())
+            .then_ignore(list_separator().or_not())
+            .map(|((r#type, alias), annotations)| Typedef {
+                r#type,
+                alias: Ident(alias.into()),
+                annotations: annotations.unwrap_or_default(),
+            })
+    }
 }
 
 #[cfg(test)]
@@ -23,6 +25,6 @@ mod tests {
 
     #[test]
     fn test_type_def() {
-        let _td = type_def().parse("typedef i32 Int32,").unwrap();
+        let _td = Typedef::get_parser().parse("typedef i32 Int32,").unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -1,33 +1,28 @@
-use nom::{
-    IResult,
-    bytes::complete::tag,
-    combinator::{map, opt},
-    sequence::tuple,
-};
+use chumsky::prelude::*;
 
-use super::super::{
-    descriptor::{Annotations, Ident, Type, Typedef},
-    parser::*,
-};
+use super::super::{descriptor::Typedef, parser::*};
+use crate::{Annotation, Type, descriptor::Ident};
 
-impl Parser for Typedef {
-    fn parse(input: &str) -> IResult<&str, Typedef> {
-        map(
-            tuple((
-                tag("typedef"),
-                blank,
-                Type::parse,
-                blank,
-                Ident::parse,
-                opt(blank),
-                opt(Annotations::parse),
-                opt(list_separator),
-            )),
-            |(_, _, r#type, _, alias, _, annotations, _)| Typedef {
-                r#type,
-                alias,
-                annotations: annotations.unwrap_or_default(),
-            },
-        )(input)
+pub fn type_def<'a>() -> impl Parser<'a, &'a str, Typedef, extra::Err<Rich<'a, char>>> {
+    just("typedef")
+        .ignore_then(Type::parse().padded_by(blank()))
+        .then(Ident::parse())
+        .then_ignore(blank().or_not())
+        .then(Annotation::parse().or_not())
+        .then_ignore(list_separator().or_not())
+        .map(|((r#type, alias), annotations)| Typedef {
+            r#type,
+            alias: Ident(alias.into()),
+            annotations: annotations.unwrap_or_default(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_type_def() {
+        let _td = type_def().parse("typedef i32 Int32,").unwrap();
     }
 }

--- a/pilota-thrift-reflect/Cargo.toml
+++ b/pilota-thrift-reflect/Cargo.toml
@@ -27,6 +27,7 @@ bytes.workspace = true
 dashmap.workspace = true
 faststr.workspace = true
 thiserror.workspace = true
+chumsky.workspace = true
 
 [build-dependencies]
 # pilota-build = { path = "../pilota-build" }

--- a/pilota-thrift-reflect/examples/idl/apache.thrift
+++ b/pilota-thrift-reflect/examples/idl/apache.thrift
@@ -63,8 +63,7 @@ const Numberz myNumberz = Numberz.ONE;
 
 typedef i64 UserId
 
-struct Bonk
-{
+struct Bonk {
   1: string message,
   2: i32 type
 }

--- a/pilota-thrift-reflect/examples/main.rs
+++ b/pilota-thrift-reflect/examples/main.rs
@@ -9,9 +9,22 @@ fn main() {
     println!("{}", idl_path.display());
 
     let content = std::fs::read_to_string(&idl_path).unwrap();
-    let mut parsed_file = pilota_thrift_parser::descriptor::File::parse()
-        .parse(&content)
-        .unwrap();
+    let ret = pilota_thrift_parser::parser::thrift::FileParser::new(
+        pilota_thrift_parser::FileSource::new_with_path(idl_path.clone(), &content).unwrap(),
+    )
+    .parse();
+    let mut parsed_file = match ret {
+        Ok(parsed_file) => parsed_file,
+        Err(e) => {
+            eprintln!("{}", e);
+            return;
+        }
+    };
+    // let mut parsed_file =
+    // pilota_thrift_parser::parser::thrift::FileParser::new(idl_path.clone())
+    //     .parse()
+    //     .unwrap();
+
     parsed_file.path = idl_path.into();
 
     let descriptor: pilota_thrift_reflect::thrift_reflection::FileDescriptor =

--- a/pilota-thrift-reflect/examples/main.rs
+++ b/pilota-thrift-reflect/examples/main.rs
@@ -1,15 +1,17 @@
 use std::path::PathBuf;
 
 use bytes::BytesMut;
+use chumsky::prelude::*;
 use pilota::thrift::Message as _;
-use pilota_thrift_parser::parser::Parser as _;
 
 fn main() {
     let idl_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/idl/apache.thrift");
     println!("{}", idl_path.display());
 
     let content = std::fs::read_to_string(&idl_path).unwrap();
-    let mut parsed_file = pilota_thrift_parser::File::parse(&content).unwrap().1;
+    let mut parsed_file = pilota_thrift_parser::descriptor::File::parse()
+        .parse(&content)
+        .unwrap();
     parsed_file.path = idl_path.into();
 
     let descriptor: pilota_thrift_reflect::thrift_reflection::FileDescriptor =

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2021"
+edition = "2024"
 wrap_comments = true
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

Better parser errors with chumsky:

The existing thrift-parser has difficulty generating user-friendly error messages. Therefore, it is necessary to rewrite the parser to provide friendly syntax error prompts and offer code-level scalability for more detailed error handling in the future.

Codegen with comments:

Currently, the Pilota build completely ignores comments in the user's IDL, which makes it harder for users to understand the meaning and usage of each field.
It is necessary to preserve all comments from the IDL in the generated code, including those for structs, enums, fields, services, methods, and types.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

The entire thrift-parser has been rewritten using chumsky, and in pilota-build, ariadne is used to display clearer error messages, including the complete path of the source IDL file as well as line and column number information. The original AST structure definition has not been modified, so it does not affect other components.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
