### PR TITLE
feat(pilota): add encode_to_vec and generalize buffer usage in pb

### DIFF
--- a/pilota-build/src/codegen/pb/mod.rs
+++ b/pilota-build/src/codegen/pb/mod.rs
@@ -506,7 +506,7 @@ impl CodegenBackend for ProtobufBackend {
                 }}
 
                 #[allow(unused_variables)]
-                fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {{
+                fn encode_raw<B>(&self, buf: &mut B) where B: ::pilota::prost::bytes::BufMut {{
                     {encode}
                 }}
 
@@ -601,7 +601,7 @@ impl CodegenBackend for ProtobufBackend {
 
         stream.push_str(&format! {
             r#"impl {name} {{
-                pub fn encode(&self, buf: &mut ::pilota::LinkedBytes) {{
+                pub fn encode<B>(&self, buf: &mut B) where B: ::pilota::prost::bytes::BufMut {{
                     match self {{
                         {encode}
                     }}

--- a/pilota/src/pb/mod.rs
+++ b/pilota/src/pb/mod.rs
@@ -28,7 +28,10 @@ const RECURSION_LIMIT: u32 = 100;
 ///
 /// An error will be returned if the buffer does not have sufficient capacity to
 /// encode the delimiter.
-pub fn encode_length_delimiter(length: usize, buf: &mut LinkedBytes) -> Result<(), EncodeError> {
+pub fn encode_length_delimiter<B>(length: usize, buf: &mut B) -> Result<(), EncodeError>
+where
+    B: BufMut,
+{
     let length = length as u64;
     let required = encoded_len_varint(length);
     let remaining = buf.remaining_mut();

--- a/pilota/src/pb/types.rs
+++ b/pilota/src/pb/types.rs
@@ -8,8 +8,7 @@ extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
 
-use ::bytes::Bytes;
-use linkedbytes::LinkedBytes;
+use ::bytes::{BufMut, Bytes};
 
 use super::{
     DecodeError, Message,
@@ -21,7 +20,10 @@ use super::{
 
 /// `google.protobuf.BoolValue`
 impl Message for bool {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self {
             bool::encode(1, self, buf)
         }
@@ -46,7 +48,10 @@ impl Message for bool {
 
 /// `google.protobuf.UInt32Value`
 impl Message for u32 {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             uint32::encode(1, self, buf)
         }
@@ -75,7 +80,10 @@ impl Message for u32 {
 
 /// `google.protobuf.UInt64Value`
 impl Message for u64 {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             uint64::encode(1, self, buf)
         }
@@ -104,7 +112,10 @@ impl Message for u64 {
 
 /// `google.protobuf.Int32Value`
 impl Message for i32 {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             int32::encode(1, self, buf)
         }
@@ -133,7 +144,10 @@ impl Message for i32 {
 
 /// `google.protobuf.Int64Value`
 impl Message for i64 {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0 {
             int64::encode(1, self, buf)
         }
@@ -162,7 +176,10 @@ impl Message for i64 {
 
 /// `google.protobuf.FloatValue`
 impl Message for f32 {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0.0 {
             float::encode(1, self, buf)
         }
@@ -191,7 +208,10 @@ impl Message for f32 {
 
 /// `google.protobuf.DoubleValue`
 impl Message for f64 {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if *self != 0.0 {
             double::encode(1, self, buf)
         }
@@ -220,7 +240,10 @@ impl Message for f64 {
 
 /// `google.protobuf.StringValue`
 impl Message for String {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if !self.is_empty() {
             string::encode(1, self, buf)
         }
@@ -249,7 +272,10 @@ impl Message for String {
 
 /// `google.protobuf.BytesValue`
 impl Message for Vec<u8> {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if !self.is_empty() {
             bytes::encode(1, self, buf)
         }
@@ -278,7 +304,10 @@ impl Message for Vec<u8> {
 
 /// `google.protobuf.BytesValue`
 impl Message for Bytes {
-    fn encode_raw(&self, buf: &mut LinkedBytes) {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
         if !self.is_empty() {
             bytes::encode(1, self, buf)
         }
@@ -307,7 +336,10 @@ impl Message for Bytes {
 
 /// `google.protobuf.Empty`
 impl Message for () {
-    fn encode_raw(&self, _buf: &mut LinkedBytes) {}
+    fn encode_raw<B>(&self, _buf: &mut B)
+    where
+        B: BufMut,
+    {}
     fn merge_field(
         &mut self,
         tag: u32,


### PR DESCRIPTION
[English](#en) / [中文](#cn)

<a id="en"></a>
## Description

This pull request introduces two main improvements to the `pilota`'s `pb` (protobuf) module:

1.  **Added `encode_to_vec` and `encode_length_delimited_to_vec` methods:** The `pb::Message` trait now includes `encode_to_vec` and `encode_length_delimited_to_vec` methods. This allows for direct encoding of messages into a `Vec<u8>`, which is more convenient and aligns the `pb` module's API with the `prost` module.

2.  **Generalized Buffer Usage:** Many encoding functions within the `pb` module have been updated to use a generic `B: BufMut` trait bound instead of the concrete `LinkedBytes` type. This makes the encoding logic more flexible and allows it to work with any buffer that implements `BufMut`.

These changes enhance the usability and flexibility of the `pb` encoding functionality.

<a id="cn"></a>
## 描述

这个 pull request 对 `pilota` 的 `pb` (protobuf) 模块进行了两项主要改进：

1.  **添加 `encode_to_vec` 和 `encode_length_delimited_to_vec` 方法：** `pb::Message` trait 现在包含了 `encode_to_vec` 和 `encode_length_delimited_to_vec` 方法。这允许将消息直接编码到 `Vec<u8>` 中，使用起来更方便，并使 `pb` 模块的 API 与 `prost` 模块保持一致。

2.  **通用化缓冲区使用：** `pb` 模块中的许多编码函数已更新为使用通用的 `B: BufMut` trait 约束，而不是具体的 `LinkedBytes` 类型。这使得编码逻辑更加灵活，可以与任何实现 `BufMut` 的缓冲区一起使用。

这些更改增强了 `pb` 编码功能的可用性和灵活性。
