### PR TITLE
fix(pilota-build): extend the re_pub_use items for direct items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.13.1"
+version = "0.13.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -277,23 +277,17 @@ where
 
         let mut gen_rs_stream = String::default();
 
-        let mod_items = self
-            .cg
-            .collect_direct_codegen_items(&info.mod_items)
-            .into_iter()
-            .chain(info.re_pubs.into_iter().map(|(mod_path, def_ids)| {
-                (
-                    mod_path,
-                    def_ids
-                        .iter()
-                        .map(|&def_id| CodegenItem {
-                            def_id,
-                            kind: super::CodegenKind::RePub,
-                        })
-                        .collect_vec(),
-                )
-            }))
-            .collect::<AHashMap<_, _>>();
+        let mut mod_items = self.cg.collect_direct_codegen_items(&info.mod_items);
+
+        for (mod_path, def_ids) in info.re_pubs.iter() {
+            mod_items
+                .entry(mod_path.clone())
+                .or_default()
+                .extend(def_ids.iter().map(|&def_id| CodegenItem {
+                    def_id,
+                    kind: super::CodegenKind::RePub,
+                }));
+        }
 
         self.cg.write_items(
             &mut gen_rs_stream,

--- a/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/author/src/gen.rs
@@ -3,6 +3,909 @@ pub mod r#gen {
 
     pub mod author {
 
+        pub trait AuthorService {}
+
+        impl ::std::default::Default for AuthorServiceGetAuthorResultRecv {
+            fn default() -> Self {
+                AuthorServiceGetAuthorResultRecv::Ok(::std::default::Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+        pub enum AuthorServiceGetAuthorResultRecv {
+            Ok(GetAuthorResponse),
+        }
+
+        impl ::pilota::thrift::Message for AuthorServiceGetAuthorResultRecv {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "AuthorServiceGetAuthorResultRecv",
+                })?;
+                match self {
+                    AuthorServiceGetAuthorResultRecv::Ok(value) => {
+                        __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
+                    }
+                }
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                let mut ret = None;
+                __protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = __protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        __protocol.field_stop_len();
+                        break;
+                    } else {
+                        __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                    }
+                    match field_ident.id {
+                        Some(0) => {
+                            if ret.is_none() {
+                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                __protocol.struct_len(&field_ident);
+                                ret = Some(AuthorServiceGetAuthorResultRecv::Ok(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                __protocol.read_field_end()?;
+                __protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    ::std::result::Result::Ok(ret)
+                } else {
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut ret = None;
+                    __protocol.read_struct_begin().await?;
+                    loop {
+                        let field_ident = __protocol.read_field_begin().await?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            break;
+                        } else {
+                        }
+                        match field_ident.id {
+                            Some(0) => {
+                                if ret.is_none() {
+                                    let field_ident = <GetAuthorResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                    ret = Some(AuthorServiceGetAuthorResultRecv::Ok(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type).await?;
+                            }
+                        }
+                    }
+                    __protocol.read_field_end().await?;
+                    __protocol.read_struct_end().await?;
+                    if let Some(ret) = ret {
+                        ::std::result::Result::Ok(ret)
+                    } else {
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            "received empty union from remote Message",
+                        ))
+                    }
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "AuthorServiceGetAuthorResultRecv",
+                }) + match self {
+                    AuthorServiceGetAuthorResultRecv::Ok(value) => {
+                        __protocol.struct_field_len(Some(0), value)
+                    }
+                } + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct AuthorServiceGetAuthorArgsRecv {
+            pub req: GetAuthorRequest,
+        }
+        impl ::pilota::thrift::Message for AuthorServiceGetAuthorArgsRecv {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier {
+                    name: "AuthorServiceGetAuthorArgsRecv",
+                };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+                __protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1)
+                                if field_ident.field_type == ::pilota::thrift::TType::Struct =>
+                            {
+                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!("decode struct `AuthorServiceGetAuthorArgsRecv` field(#{}) failed, caused by: ", field_id));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field req is required".to_string(),
+                    ));
+                };
+
+                let data = Self { req: var_1 };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetAuthorRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `AuthorServiceGetAuthorArgsRecv` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self { req: var_1 };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "AuthorServiceGetAuthorArgsRecv",
+                }) + __protocol.struct_field_len(Some(1), &self.req)
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        impl ::std::default::Default for AuthorServiceGetAuthorResultSend {
+            fn default() -> Self {
+                AuthorServiceGetAuthorResultSend::Ok(::std::default::Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+        pub enum AuthorServiceGetAuthorResultSend {
+            Ok(GetAuthorResponse),
+        }
+
+        impl ::pilota::thrift::Message for AuthorServiceGetAuthorResultSend {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "AuthorServiceGetAuthorResultSend",
+                })?;
+                match self {
+                    AuthorServiceGetAuthorResultSend::Ok(value) => {
+                        __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
+                    }
+                }
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                let mut ret = None;
+                __protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = __protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        __protocol.field_stop_len();
+                        break;
+                    } else {
+                        __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                    }
+                    match field_ident.id {
+                        Some(0) => {
+                            if ret.is_none() {
+                                let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                                __protocol.struct_len(&field_ident);
+                                ret = Some(AuthorServiceGetAuthorResultSend::Ok(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                __protocol.read_field_end()?;
+                __protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    ::std::result::Result::Ok(ret)
+                } else {
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut ret = None;
+                    __protocol.read_struct_begin().await?;
+                    loop {
+                        let field_ident = __protocol.read_field_begin().await?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            break;
+                        } else {
+                        }
+                        match field_ident.id {
+                            Some(0) => {
+                                if ret.is_none() {
+                                    let field_ident = <GetAuthorResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                    ret = Some(AuthorServiceGetAuthorResultSend::Ok(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type).await?;
+                            }
+                        }
+                    }
+                    __protocol.read_field_end().await?;
+                    __protocol.read_struct_end().await?;
+                    if let Some(ret) = ret {
+                        ::std::result::Result::Ok(ret)
+                    } else {
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            "received empty union from remote Message",
+                        ))
+                    }
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "AuthorServiceGetAuthorResultSend",
+                }) + match self {
+                    AuthorServiceGetAuthorResultSend::Ok(value) => {
+                        __protocol.struct_field_len(Some(0), value)
+                    }
+                } + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct GetAuthorResponse {
+            pub author: ::common::author::Author,
+        }
+        impl ::pilota::thrift::Message for GetAuthorResponse {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier {
+                    name: "GetAuthorResponse",
+                };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+                __protocol.write_struct_field(1, &self.author, ::pilota::thrift::TType::Struct)?;
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1)
+                                if field_ident.field_type == ::pilota::thrift::TType::Struct =>
+                            {
+                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `GetAuthorResponse` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field author is required".to_string(),
+                    ));
+                };
+
+                let data = Self { author: var_1 };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<::common::author::Author as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetAuthorResponse` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field author is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self { author: var_1 };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "GetAuthorResponse",
+                }) + __protocol.struct_field_len(Some(1), &self.author)
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct AuthorServiceGetAuthorArgsSend {
+            pub req: GetAuthorRequest,
+        }
+        impl ::pilota::thrift::Message for AuthorServiceGetAuthorArgsSend {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier {
+                    name: "AuthorServiceGetAuthorArgsSend",
+                };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+                __protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1)
+                                if field_ident.field_type == ::pilota::thrift::TType::Struct =>
+                            {
+                                var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!("decode struct `AuthorServiceGetAuthorArgsSend` field(#{}) failed, caused by: ", field_id));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field req is required".to_string(),
+                    ));
+                };
+
+                let data = Self { req: var_1 };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetAuthorRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `AuthorServiceGetAuthorArgsSend` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self { req: var_1 };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "AuthorServiceGetAuthorArgsSend",
+                }) + __protocol.struct_field_len(Some(1), &self.req)
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct GetAuthorRequest {
+            pub id: i64,
+        }
+        impl ::pilota::thrift::Message for GetAuthorRequest {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier {
+                    name: "GetAuthorRequest",
+                };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+                __protocol.write_i64_field(1, *&self.id)?;
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64 => {
+                                var_1 = Some(__protocol.read_i64()?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `GetAuthorRequest` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field id is required".to_string(),
+                    ));
+                };
+
+                let data = Self { id: var_1 };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type == ::pilota::thrift::TType::I64 =>
+                                {
+                                    var_1 = Some(__protocol.read_i64().await?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `GetAuthorRequest` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field id is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self { id: var_1 };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                    name: "GetAuthorRequest",
+                }) + __protocol.i64_field_len(Some(1), *&self.id)
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
         pub use ::common::author::Author;
     }
 

--- a/pilota-build/test_data/thrift_workspace/output/image/src/gen.rs
+++ b/pilota-build/test_data/thrift_workspace/output/image/src/gen.rs
@@ -5,6 +5,955 @@ pub mod r#gen {
 
         pub mod image {
 
+            #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+            pub struct ImageServiceGetImageArgsRecv {
+                pub req: GetImageRequest,
+            }
+            impl ::pilota::thrift::Message for ImageServiceGetImageArgsRecv {
+                fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                    &self,
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TOutputProtocolExt;
+                    let struct_ident = ::pilota::thrift::TStructIdentifier {
+                        name: "ImageServiceGetImageArgsRecv",
+                    };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+
+                fn decode<T: ::pilota::thrift::TInputProtocol>(
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                {
+                    #[allow(unused_imports)]
+                    use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                    let mut var_1 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin()?;
+                    if let ::std::result::Result::Err(mut err) = (|| {
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Struct =>
+                                {
+                                    var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+
+                            __protocol.read_field_end()?;
+                            __protocol.field_end_len();
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    })() {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!("decode struct `ImageServiceGetImageArgsRecv` field(#{}) failed, caused by: ", field_id));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end()?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self { req: var_1 };
+                    ::std::result::Result::Ok(data)
+                }
+
+                fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                    __protocol: &'a mut T,
+                ) -> ::std::pin::Pin<
+                    ::std::boxed::Box<
+                        dyn ::std::future::Future<
+                                Output = ::std::result::Result<
+                                    Self,
+                                    ::pilota::thrift::ThriftException,
+                                >,
+                            > + Send
+                            + 'a,
+                    >,
+                > {
+                    ::std::boxed::Box::pin(async move {
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin().await?;
+                        if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetImageRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `ImageServiceGetImageArgsRecv` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                        __protocol.read_struct_end().await?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field req is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { req: var_1 };
+                        ::std::result::Result::Ok(data)
+                    })
+                }
+
+                fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TLengthProtocolExt;
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "ImageServiceGetImageArgsRecv",
+                    }) + __protocol.struct_field_len(Some(1), &self.req)
+                        + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+            impl ::std::default::Default for ImageServiceGetImageResultSend {
+                fn default() -> Self {
+                    ImageServiceGetImageResultSend::Ok(::std::default::Default::default())
+                }
+            }
+            #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+            pub enum ImageServiceGetImageResultSend {
+                Ok(GetImageResponse),
+            }
+
+            impl ::pilota::thrift::Message for ImageServiceGetImageResultSend {
+                fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                    &self,
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TOutputProtocolExt;
+                    __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                        name: "ImageServiceGetImageResultSend",
+                    })?;
+                    match self {
+                        ImageServiceGetImageResultSend::Ok(value) => {
+                            __protocol.write_struct_field(
+                                0,
+                                value,
+                                ::pilota::thrift::TType::Struct,
+                            )?;
+                        }
+                    }
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+
+                fn decode<T: ::pilota::thrift::TInputProtocol>(
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                {
+                    #[allow(unused_imports)]
+                    use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                    let mut ret = None;
+                    __protocol.read_struct_begin()?;
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        match field_ident.id {
+                            Some(0) => {
+                                if ret.is_none() {
+                                    let field_ident =
+                                        ::pilota::thrift::Message::decode(__protocol)?;
+                                    __protocol.struct_len(&field_ident);
+                                    ret = Some(ImageServiceGetImageResultSend::Ok(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+                    }
+                    __protocol.read_field_end()?;
+                    __protocol.read_struct_end()?;
+                    if let Some(ret) = ret {
+                        ::std::result::Result::Ok(ret)
+                    } else {
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            "received empty union from remote Message",
+                        ))
+                    }
+                }
+
+                fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                    __protocol: &'a mut T,
+                ) -> ::std::pin::Pin<
+                    ::std::boxed::Box<
+                        dyn ::std::future::Future<
+                                Output = ::std::result::Result<
+                                    Self,
+                                    ::pilota::thrift::ThriftException,
+                                >,
+                            > + Send
+                            + 'a,
+                    >,
+                > {
+                    ::std::boxed::Box::pin(async move {
+                        let mut ret = None;
+                        __protocol.read_struct_begin().await?;
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            match field_ident.id {
+                                Some(0) => {
+                                    if ret.is_none() {
+                                        let field_ident = <GetImageResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                        ret = Some(ImageServiceGetImageResultSend::Ok(field_ident));
+                                    } else {
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                    }
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+                        }
+                        __protocol.read_field_end().await?;
+                        __protocol.read_struct_end().await?;
+                        if let Some(ret) = ret {
+                            ::std::result::Result::Ok(ret)
+                        } else {
+                            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received empty union from remote Message",
+                            ))
+                        }
+                    })
+                }
+
+                fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TLengthProtocolExt;
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "ImageServiceGetImageResultSend",
+                    }) + match self {
+                        ImageServiceGetImageResultSend::Ok(value) => {
+                            __protocol.struct_field_len(Some(0), value)
+                        }
+                    } + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+
+            #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+            pub struct GetImageResponse {
+                pub image: ::common::article::image::Image,
+            }
+            impl ::pilota::thrift::Message for GetImageResponse {
+                fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                    &self,
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TOutputProtocolExt;
+                    let struct_ident = ::pilota::thrift::TStructIdentifier {
+                        name: "GetImageResponse",
+                    };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_struct_field(
+                        1,
+                        &self.image,
+                        ::pilota::thrift::TType::Struct,
+                    )?;
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+
+                fn decode<T: ::pilota::thrift::TInputProtocol>(
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                {
+                    #[allow(unused_imports)]
+                    use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                    let mut var_1 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin()?;
+                    if let ::std::result::Result::Err(mut err) = (|| {
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Struct =>
+                                {
+                                    var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+
+                            __protocol.read_field_end()?;
+                            __protocol.field_end_len();
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    })() {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `GetImageResponse` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end()?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field image is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self { image: var_1 };
+                    ::std::result::Result::Ok(data)
+                }
+
+                fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                    __protocol: &'a mut T,
+                ) -> ::std::pin::Pin<
+                    ::std::boxed::Box<
+                        dyn ::std::future::Future<
+                                Output = ::std::result::Result<
+                                    Self,
+                                    ::pilota::thrift::ThriftException,
+                                >,
+                            > + Send
+                            + 'a,
+                    >,
+                > {
+                    ::std::boxed::Box::pin(async move {
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin().await?;
+                        if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<::common::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetImageResponse` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                        __protocol.read_struct_end().await?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field image is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { image: var_1 };
+                        ::std::result::Result::Ok(data)
+                    })
+                }
+
+                fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TLengthProtocolExt;
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "GetImageResponse",
+                    }) + __protocol.struct_field_len(Some(1), &self.image)
+                        + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+            #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+            pub struct ImageServiceGetImageArgsSend {
+                pub req: GetImageRequest,
+            }
+            impl ::pilota::thrift::Message for ImageServiceGetImageArgsSend {
+                fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                    &self,
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TOutputProtocolExt;
+                    let struct_ident = ::pilota::thrift::TStructIdentifier {
+                        name: "ImageServiceGetImageArgsSend",
+                    };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+
+                fn decode<T: ::pilota::thrift::TInputProtocol>(
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                {
+                    #[allow(unused_imports)]
+                    use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                    let mut var_1 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin()?;
+                    if let ::std::result::Result::Err(mut err) = (|| {
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Struct =>
+                                {
+                                    var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+
+                            __protocol.read_field_end()?;
+                            __protocol.field_end_len();
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    })() {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!("decode struct `ImageServiceGetImageArgsSend` field(#{}) failed, caused by: ", field_id));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end()?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field req is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self { req: var_1 };
+                    ::std::result::Result::Ok(data)
+                }
+
+                fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                    __protocol: &'a mut T,
+                ) -> ::std::pin::Pin<
+                    ::std::boxed::Box<
+                        dyn ::std::future::Future<
+                                Output = ::std::result::Result<
+                                    Self,
+                                    ::pilota::thrift::ThriftException,
+                                >,
+                            > + Send
+                            + 'a,
+                    >,
+                > {
+                    ::std::boxed::Box::pin(async move {
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin().await?;
+                        if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<GetImageRequest as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `ImageServiceGetImageArgsSend` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                        __protocol.read_struct_end().await?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field req is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { req: var_1 };
+                        ::std::result::Result::Ok(data)
+                    })
+                }
+
+                fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TLengthProtocolExt;
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "ImageServiceGetImageArgsSend",
+                    }) + __protocol.struct_field_len(Some(1), &self.req)
+                        + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+
+            #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+            pub struct GetImageRequest {
+                pub id: i64,
+            }
+            impl ::pilota::thrift::Message for GetImageRequest {
+                fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                    &self,
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TOutputProtocolExt;
+                    let struct_ident = ::pilota::thrift::TStructIdentifier {
+                        name: "GetImageRequest",
+                    };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_i64_field(1, *&self.id)?;
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+
+                fn decode<T: ::pilota::thrift::TInputProtocol>(
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                {
+                    #[allow(unused_imports)]
+                    use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                    let mut var_1 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin()?;
+                    if let ::std::result::Result::Err(mut err) = (|| {
+                        loop {
+                            let field_ident = __protocol.read_field_begin()?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                __protocol.field_stop_len();
+                                break;
+                            } else {
+                                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type == ::pilota::thrift::TType::I64 =>
+                                {
+                                    var_1 = Some(__protocol.read_i64()?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type)?;
+                                }
+                            }
+
+                            __protocol.read_field_end()?;
+                            __protocol.field_end_len();
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    })() {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `GetImageRequest` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end()?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field id is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self { id: var_1 };
+                    ::std::result::Result::Ok(data)
+                }
+
+                fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                    __protocol: &'a mut T,
+                ) -> ::std::pin::Pin<
+                    ::std::boxed::Box<
+                        dyn ::std::future::Future<
+                                Output = ::std::result::Result<
+                                    Self,
+                                    ::pilota::thrift::ThriftException,
+                                >,
+                            > + Send
+                            + 'a,
+                    >,
+                > {
+                    ::std::boxed::Box::pin(async move {
+                        let mut var_1 = None;
+
+                        let mut __pilota_decoding_field_id = None;
+
+                        __protocol.read_struct_begin().await?;
+                        if let ::std::result::Result::Err(mut err) = async {
+                            loop {
+                                let field_ident = __protocol.read_field_begin().await?;
+                                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                    break;
+                                } else {
+                                }
+                                __pilota_decoding_field_id = field_ident.id;
+                                match field_ident.id {
+                                    Some(1)
+                                        if field_ident.field_type
+                                            == ::pilota::thrift::TType::I64 =>
+                                    {
+                                        var_1 = Some(__protocol.read_i64().await?);
+                                    }
+                                    _ => {
+                                        __protocol.skip(field_ident.field_type).await?;
+                                    }
+                                }
+
+                                __protocol.read_field_end().await?;
+                            }
+                            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                        }
+                        .await
+                        {
+                            if let Some(field_id) = __pilota_decoding_field_id {
+                                err.prepend_msg(&format!("decode struct `GetImageRequest` field(#{}) failed, caused by: ", field_id));
+                            }
+                            return ::std::result::Result::Err(err);
+                        };
+                        __protocol.read_struct_end().await?;
+
+                        let Some(var_1) = var_1 else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "field id is required".to_string(),
+                                ),
+                            );
+                        };
+
+                        let data = Self { id: var_1 };
+                        ::std::result::Result::Ok(data)
+                    })
+                }
+
+                fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TLengthProtocolExt;
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "GetImageRequest",
+                    }) + __protocol.i64_field_len(Some(1), *&self.id)
+                        + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+
+            pub trait ImageService {}
+
+            impl ::std::default::Default for ImageServiceGetImageResultRecv {
+                fn default() -> Self {
+                    ImageServiceGetImageResultRecv::Ok(::std::default::Default::default())
+                }
+            }
+            #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+            pub enum ImageServiceGetImageResultRecv {
+                Ok(GetImageResponse),
+            }
+
+            impl ::pilota::thrift::Message for ImageServiceGetImageResultRecv {
+                fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                    &self,
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TOutputProtocolExt;
+                    __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                        name: "ImageServiceGetImageResultRecv",
+                    })?;
+                    match self {
+                        ImageServiceGetImageResultRecv::Ok(value) => {
+                            __protocol.write_struct_field(
+                                0,
+                                value,
+                                ::pilota::thrift::TType::Struct,
+                            )?;
+                        }
+                    }
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+
+                fn decode<T: ::pilota::thrift::TInputProtocol>(
+                    __protocol: &mut T,
+                ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException>
+                {
+                    #[allow(unused_imports)]
+                    use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                    let mut ret = None;
+                    __protocol.read_struct_begin()?;
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        match field_ident.id {
+                            Some(0) => {
+                                if ret.is_none() {
+                                    let field_ident =
+                                        ::pilota::thrift::Message::decode(__protocol)?;
+                                    __protocol.struct_len(&field_ident);
+                                    ret = Some(ImageServiceGetImageResultRecv::Ok(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+                    }
+                    __protocol.read_field_end()?;
+                    __protocol.read_struct_end()?;
+                    if let Some(ret) = ret {
+                        ::std::result::Result::Ok(ret)
+                    } else {
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            "received empty union from remote Message",
+                        ))
+                    }
+                }
+
+                fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                    __protocol: &'a mut T,
+                ) -> ::std::pin::Pin<
+                    ::std::boxed::Box<
+                        dyn ::std::future::Future<
+                                Output = ::std::result::Result<
+                                    Self,
+                                    ::pilota::thrift::ThriftException,
+                                >,
+                            > + Send
+                            + 'a,
+                    >,
+                > {
+                    ::std::boxed::Box::pin(async move {
+                        let mut ret = None;
+                        __protocol.read_struct_begin().await?;
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            match field_ident.id {
+                                Some(0) => {
+                                    if ret.is_none() {
+                                        let field_ident = <GetImageResponse as ::pilota::thrift::Message>::decode_async(__protocol).await?;
+
+                                        ret = Some(ImageServiceGetImageResultRecv::Ok(field_ident));
+                                    } else {
+                                        return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message"
+                                        ));
+                                    }
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+                        }
+                        __protocol.read_field_end().await?;
+                        __protocol.read_struct_end().await?;
+                        if let Some(ret) = ret {
+                            ::std::result::Result::Ok(ret)
+                        } else {
+                            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received empty union from remote Message",
+                            ))
+                        }
+                    })
+                }
+
+                fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                    #[allow(unused_imports)]
+                    use ::pilota::thrift::TLengthProtocolExt;
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "ImageServiceGetImageResultRecv",
+                    }) + match self {
+                        ImageServiceGetImageResultRecv::Ok(value) => {
+                            __protocol.struct_field_len(Some(0), value)
+                        }
+                    } + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
             pub use ::common::article::image::Image;
             pub mod cdn {
 

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultRecv.rs
@@ -1,0 +1,147 @@
+
+impl ::std::default::Default for AuthorServiceGetAuthorResultRecv {
+    fn default() -> Self {
+        AuthorServiceGetAuthorResultRecv::Ok(::std::default::Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+pub enum AuthorServiceGetAuthorResultRecv {
+    Ok(GetAuthorResponse),
+}
+
+impl ::pilota::thrift::Message for AuthorServiceGetAuthorResultRecv {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+            name: "AuthorServiceGetAuthorResultRecv",
+        })?;
+        match self {
+            AuthorServiceGetAuthorResultRecv::Ok(value) => {
+                __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
+            }
+        }
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+        let mut ret = None;
+        __protocol.read_struct_begin()?;
+        loop {
+            let field_ident = __protocol.read_field_begin()?;
+            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                __protocol.field_stop_len();
+                break;
+            } else {
+                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+            }
+            match field_ident.id {
+                Some(0) => {
+                    if ret.is_none() {
+                        let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                        __protocol.struct_len(&field_ident);
+                        ret = Some(AuthorServiceGetAuthorResultRecv::Ok(field_ident));
+                    } else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received multiple fields for union from remote Message",
+                            ),
+                        );
+                    }
+                }
+                _ => {
+                    __protocol.skip(field_ident.field_type)?;
+                }
+            }
+        }
+        __protocol.read_field_end()?;
+        __protocol.read_struct_end()?;
+        if let Some(ret) = ret {
+            ::std::result::Result::Ok(ret)
+        } else {
+            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "received empty union from remote Message",
+            ))
+        }
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut ret = None;
+            __protocol.read_struct_begin().await?;
+            loop {
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    break;
+                } else {
+                }
+                match field_ident.id {
+                    Some(0) => {
+                        if ret.is_none() {
+                            let field_ident =
+                                <GetAuthorResponse as ::pilota::thrift::Message>::decode_async(
+                                    __protocol,
+                                )
+                                .await?;
+
+                            ret = Some(AuthorServiceGetAuthorResultRecv::Ok(field_ident));
+                        } else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ),
+                            );
+                        }
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+                    }
+                }
+            }
+            __protocol.read_field_end().await?;
+            __protocol.read_struct_end().await?;
+            if let Some(ret) = ret {
+                ::std::result::Result::Ok(ret)
+            } else {
+                ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "received empty union from remote Message",
+                ))
+            }
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "AuthorServiceGetAuthorResultRecv",
+        }) + match self {
+            AuthorServiceGetAuthorResultRecv::Ok(value) => {
+                __protocol.struct_field_len(Some(0), value)
+            }
+        } + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/enum_AuthorServiceGetAuthorResultSend.rs
@@ -1,0 +1,147 @@
+
+impl ::std::default::Default for AuthorServiceGetAuthorResultSend {
+    fn default() -> Self {
+        AuthorServiceGetAuthorResultSend::Ok(::std::default::Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+pub enum AuthorServiceGetAuthorResultSend {
+    Ok(GetAuthorResponse),
+}
+
+impl ::pilota::thrift::Message for AuthorServiceGetAuthorResultSend {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+            name: "AuthorServiceGetAuthorResultSend",
+        })?;
+        match self {
+            AuthorServiceGetAuthorResultSend::Ok(value) => {
+                __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
+            }
+        }
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+        let mut ret = None;
+        __protocol.read_struct_begin()?;
+        loop {
+            let field_ident = __protocol.read_field_begin()?;
+            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                __protocol.field_stop_len();
+                break;
+            } else {
+                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+            }
+            match field_ident.id {
+                Some(0) => {
+                    if ret.is_none() {
+                        let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                        __protocol.struct_len(&field_ident);
+                        ret = Some(AuthorServiceGetAuthorResultSend::Ok(field_ident));
+                    } else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received multiple fields for union from remote Message",
+                            ),
+                        );
+                    }
+                }
+                _ => {
+                    __protocol.skip(field_ident.field_type)?;
+                }
+            }
+        }
+        __protocol.read_field_end()?;
+        __protocol.read_struct_end()?;
+        if let Some(ret) = ret {
+            ::std::result::Result::Ok(ret)
+        } else {
+            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "received empty union from remote Message",
+            ))
+        }
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut ret = None;
+            __protocol.read_struct_begin().await?;
+            loop {
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    break;
+                } else {
+                }
+                match field_ident.id {
+                    Some(0) => {
+                        if ret.is_none() {
+                            let field_ident =
+                                <GetAuthorResponse as ::pilota::thrift::Message>::decode_async(
+                                    __protocol,
+                                )
+                                .await?;
+
+                            ret = Some(AuthorServiceGetAuthorResultSend::Ok(field_ident));
+                        } else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ),
+                            );
+                        }
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+                    }
+                }
+            }
+            __protocol.read_field_end().await?;
+            __protocol.read_struct_end().await?;
+            if let Some(ret) = ret {
+                ::std::result::Result::Ok(ret)
+            } else {
+                ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "received empty union from remote Message",
+                ))
+            }
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "AuthorServiceGetAuthorResultSend",
+        }) + match self {
+            AuthorServiceGetAuthorResultSend::Ok(value) => {
+                __protocol.struct_field_len(Some(0), value)
+            }
+        } + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/message_AuthorServiceGetAuthorArgsRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/message_AuthorServiceGetAuthorArgsRecv.rs
@@ -1,0 +1,151 @@
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+pub struct AuthorServiceGetAuthorArgsRecv {
+    pub req: GetAuthorRequest,
+}
+impl ::pilota::thrift::Message for AuthorServiceGetAuthorArgsRecv {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        let struct_ident = ::pilota::thrift::TStructIdentifier {
+            name: "AuthorServiceGetAuthorArgsRecv",
+        };
+
+        __protocol.write_struct_begin(&struct_ident)?;
+        __protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+        let mut var_1 = None;
+
+        let mut __pilota_decoding_field_id = None;
+
+        __protocol.read_struct_begin()?;
+        if let ::std::result::Result::Err(mut err) = (|| {
+            loop {
+                let field_ident = __protocol.read_field_begin()?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    __protocol.field_stop_len();
+                    break;
+                } else {
+                    __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                        var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type)?;
+                    }
+                }
+
+                __protocol.read_field_end()?;
+                __protocol.field_end_len();
+            }
+            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+        })() {
+            if let Some(field_id) = __pilota_decoding_field_id {
+                err.prepend_msg(&format!(
+                    "decode struct `AuthorServiceGetAuthorArgsRecv` field(#{}) failed, caused by: ",
+                    field_id
+                ));
+            }
+            return ::std::result::Result::Err(err);
+        };
+        __protocol.read_struct_end()?;
+
+        let Some(var_1) = var_1 else {
+            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "field req is required".to_string(),
+            ));
+        };
+
+        let data = Self { req: var_1 };
+        ::std::result::Result::Ok(data)
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut var_1 = None;
+
+            let mut __pilota_decoding_field_id = None;
+
+            __protocol.read_struct_begin().await?;
+            if let ::std::result::Result::Err(mut err) = async {
+                loop {
+                    let field_ident = __protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    } else {
+                    }
+                    __pilota_decoding_field_id = field_ident.id;
+                    match field_ident.id {
+                        Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            var_1 = Some(
+                                <GetAuthorRequest as ::pilota::thrift::Message>::decode_async(
+                                    __protocol,
+                                )
+                                .await?,
+                            );
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+
+                    __protocol.read_field_end().await?;
+                }
+                ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+            }
+            .await
+            {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `AuthorServiceGetAuthorArgsRecv` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+            __protocol.read_struct_end().await?;
+
+            let Some(var_1) = var_1 else {
+                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "field req is required".to_string(),
+                ));
+            };
+
+            let data = Self { req: var_1 };
+            ::std::result::Result::Ok(data)
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "AuthorServiceGetAuthorArgsRecv",
+        }) + __protocol.struct_field_len(Some(1), &self.req)
+            + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/message_AuthorServiceGetAuthorArgsSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/message_AuthorServiceGetAuthorArgsSend.rs
@@ -1,0 +1,151 @@
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+pub struct AuthorServiceGetAuthorArgsSend {
+    pub req: GetAuthorRequest,
+}
+impl ::pilota::thrift::Message for AuthorServiceGetAuthorArgsSend {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        let struct_ident = ::pilota::thrift::TStructIdentifier {
+            name: "AuthorServiceGetAuthorArgsSend",
+        };
+
+        __protocol.write_struct_begin(&struct_ident)?;
+        __protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+        let mut var_1 = None;
+
+        let mut __pilota_decoding_field_id = None;
+
+        __protocol.read_struct_begin()?;
+        if let ::std::result::Result::Err(mut err) = (|| {
+            loop {
+                let field_ident = __protocol.read_field_begin()?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    __protocol.field_stop_len();
+                    break;
+                } else {
+                    __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                        var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type)?;
+                    }
+                }
+
+                __protocol.read_field_end()?;
+                __protocol.field_end_len();
+            }
+            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+        })() {
+            if let Some(field_id) = __pilota_decoding_field_id {
+                err.prepend_msg(&format!(
+                    "decode struct `AuthorServiceGetAuthorArgsSend` field(#{}) failed, caused by: ",
+                    field_id
+                ));
+            }
+            return ::std::result::Result::Err(err);
+        };
+        __protocol.read_struct_end()?;
+
+        let Some(var_1) = var_1 else {
+            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "field req is required".to_string(),
+            ));
+        };
+
+        let data = Self { req: var_1 };
+        ::std::result::Result::Ok(data)
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut var_1 = None;
+
+            let mut __pilota_decoding_field_id = None;
+
+            __protocol.read_struct_begin().await?;
+            if let ::std::result::Result::Err(mut err) = async {
+                loop {
+                    let field_ident = __protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    } else {
+                    }
+                    __pilota_decoding_field_id = field_ident.id;
+                    match field_ident.id {
+                        Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            var_1 = Some(
+                                <GetAuthorRequest as ::pilota::thrift::Message>::decode_async(
+                                    __protocol,
+                                )
+                                .await?,
+                            );
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+
+                    __protocol.read_field_end().await?;
+                }
+                ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+            }
+            .await
+            {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `AuthorServiceGetAuthorArgsSend` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+            __protocol.read_struct_end().await?;
+
+            let Some(var_1) = var_1 else {
+                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "field req is required".to_string(),
+                ));
+            };
+
+            let data = Self { req: var_1 };
+            ::std::result::Result::Ok(data)
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "AuthorServiceGetAuthorArgsSend",
+        }) + __protocol.struct_field_len(Some(1), &self.req)
+            + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/message_GetAuthorRequest.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/message_GetAuthorRequest.rs
@@ -1,0 +1,149 @@
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+pub struct GetAuthorRequest {
+    pub id: i64,
+}
+impl ::pilota::thrift::Message for GetAuthorRequest {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        let struct_ident = ::pilota::thrift::TStructIdentifier {
+            name: "GetAuthorRequest",
+        };
+
+        __protocol.write_struct_begin(&struct_ident)?;
+        __protocol.write_i64_field(1, *&self.id)?;
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+        let mut var_1 = None;
+
+        let mut __pilota_decoding_field_id = None;
+
+        __protocol.read_struct_begin()?;
+        if let ::std::result::Result::Err(mut err) = (|| {
+            loop {
+                let field_ident = __protocol.read_field_begin()?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    __protocol.field_stop_len();
+                    break;
+                } else {
+                    __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64 => {
+                        var_1 = Some(__protocol.read_i64()?);
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type)?;
+                    }
+                }
+
+                __protocol.read_field_end()?;
+                __protocol.field_end_len();
+            }
+            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+        })() {
+            if let Some(field_id) = __pilota_decoding_field_id {
+                err.prepend_msg(&format!(
+                    "decode struct `GetAuthorRequest` field(#{}) failed, caused by: ",
+                    field_id
+                ));
+            }
+            return ::std::result::Result::Err(err);
+        };
+        __protocol.read_struct_end()?;
+
+        let Some(var_1) = var_1 else {
+            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "field id is required".to_string(),
+            ));
+        };
+
+        let data = Self { id: var_1 };
+        ::std::result::Result::Ok(data)
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut var_1 = None;
+
+            let mut __pilota_decoding_field_id = None;
+
+            __protocol.read_struct_begin().await?;
+            if let ::std::result::Result::Err(mut err) = async {
+                loop {
+                    let field_ident = __protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    } else {
+                    }
+                    __pilota_decoding_field_id = field_ident.id;
+                    match field_ident.id {
+                        Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64 => {
+                            var_1 = Some(__protocol.read_i64().await?);
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+
+                    __protocol.read_field_end().await?;
+                }
+                ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+            }
+            .await
+            {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!(
+                        "decode struct `GetAuthorRequest` field(#{}) failed, caused by: ",
+                        field_id
+                    ));
+                }
+                return ::std::result::Result::Err(err);
+            };
+            __protocol.read_struct_end().await?;
+
+            let Some(var_1) = var_1 else {
+                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "field id is required".to_string(),
+                ));
+            };
+
+            let data = Self { id: var_1 };
+            ::std::result::Result::Ok(data)
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "GetAuthorRequest",
+        }) + __protocol.i64_field_len(Some(1), *&self.id)
+            + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/message_GetAuthorResponse.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/message_GetAuthorResponse.rs
@@ -1,0 +1,152 @@
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+pub struct GetAuthorResponse {
+    pub author: ::common::author::Author,
+}
+impl ::pilota::thrift::Message for GetAuthorResponse {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        let struct_ident = ::pilota::thrift::TStructIdentifier {
+            name: "GetAuthorResponse",
+        };
+
+        __protocol.write_struct_begin(&struct_ident)?;
+        __protocol.write_struct_field(1, &self.author, ::pilota::thrift::TType::Struct)?;
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+        let mut var_1 = None;
+
+        let mut __pilota_decoding_field_id = None;
+
+        __protocol.read_struct_begin()?;
+        if let ::std::result::Result::Err(mut err) = (|| {
+            loop {
+                let field_ident = __protocol.read_field_begin()?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    __protocol.field_stop_len();
+                    break;
+                } else {
+                    __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                        var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type)?;
+                    }
+                }
+
+                __protocol.read_field_end()?;
+                __protocol.field_end_len();
+            }
+            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+        })() {
+            if let Some(field_id) = __pilota_decoding_field_id {
+                err.prepend_msg(&format!(
+                    "decode struct `GetAuthorResponse` field(#{}) failed, caused by: ",
+                    field_id
+                ));
+            }
+            return ::std::result::Result::Err(err);
+        };
+        __protocol.read_struct_end()?;
+
+        let Some(var_1) = var_1 else {
+            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "field author is required".to_string(),
+            ));
+        };
+
+        let data = Self { author: var_1 };
+        ::std::result::Result::Ok(data)
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut var_1 = None;
+
+            let mut __pilota_decoding_field_id = None;
+
+            __protocol.read_struct_begin().await?;
+            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<::common::author::Author as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetAuthorResponse` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+            __protocol.read_struct_end().await?;
+
+            let Some(var_1) = var_1 else {
+                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "field author is required".to_string(),
+                ));
+            };
+
+            let data = Self { author: var_1 };
+            ::std::result::Result::Ok(data)
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "GetAuthorResponse",
+        }) + __protocol.struct_field_len(Some(1), &self.author)
+            + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/mod.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/mod.rs
@@ -1,1 +1,8 @@
+include!("service_AuthorService.rs");
+include!("enum_AuthorServiceGetAuthorResultRecv.rs");
+include!("message_AuthorServiceGetAuthorArgsRecv.rs");
+include!("enum_AuthorServiceGetAuthorResultSend.rs");
+include!("message_GetAuthorResponse.rs");
+include!("message_AuthorServiceGetAuthorArgsSend.rs");
+include!("message_GetAuthorRequest.rs");
 include!("message_Author.rs");

--- a/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/service_AuthorService.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/author/src/author/service_AuthorService.rs
@@ -1,0 +1,2 @@
+
+pub trait AuthorService {}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultRecv.rs
@@ -1,0 +1,147 @@
+
+impl ::std::default::Default for ImageServiceGetImageResultRecv {
+    fn default() -> Self {
+        ImageServiceGetImageResultRecv::Ok(::std::default::Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+pub enum ImageServiceGetImageResultRecv {
+    Ok(GetImageResponse),
+}
+
+impl ::pilota::thrift::Message for ImageServiceGetImageResultRecv {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+            name: "ImageServiceGetImageResultRecv",
+        })?;
+        match self {
+            ImageServiceGetImageResultRecv::Ok(value) => {
+                __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
+            }
+        }
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+        let mut ret = None;
+        __protocol.read_struct_begin()?;
+        loop {
+            let field_ident = __protocol.read_field_begin()?;
+            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                __protocol.field_stop_len();
+                break;
+            } else {
+                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+            }
+            match field_ident.id {
+                Some(0) => {
+                    if ret.is_none() {
+                        let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                        __protocol.struct_len(&field_ident);
+                        ret = Some(ImageServiceGetImageResultRecv::Ok(field_ident));
+                    } else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received multiple fields for union from remote Message",
+                            ),
+                        );
+                    }
+                }
+                _ => {
+                    __protocol.skip(field_ident.field_type)?;
+                }
+            }
+        }
+        __protocol.read_field_end()?;
+        __protocol.read_struct_end()?;
+        if let Some(ret) = ret {
+            ::std::result::Result::Ok(ret)
+        } else {
+            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "received empty union from remote Message",
+            ))
+        }
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut ret = None;
+            __protocol.read_struct_begin().await?;
+            loop {
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    break;
+                } else {
+                }
+                match field_ident.id {
+                    Some(0) => {
+                        if ret.is_none() {
+                            let field_ident =
+                                <GetImageResponse as ::pilota::thrift::Message>::decode_async(
+                                    __protocol,
+                                )
+                                .await?;
+
+                            ret = Some(ImageServiceGetImageResultRecv::Ok(field_ident));
+                        } else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ),
+                            );
+                        }
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+                    }
+                }
+            }
+            __protocol.read_field_end().await?;
+            __protocol.read_struct_end().await?;
+            if let Some(ret) = ret {
+                ::std::result::Result::Ok(ret)
+            } else {
+                ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "received empty union from remote Message",
+                ))
+            }
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "ImageServiceGetImageResultRecv",
+        }) + match self {
+            ImageServiceGetImageResultRecv::Ok(value) => {
+                __protocol.struct_field_len(Some(0), value)
+            }
+        } + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/enum_ImageServiceGetImageResultSend.rs
@@ -1,0 +1,147 @@
+
+impl ::std::default::Default for ImageServiceGetImageResultSend {
+    fn default() -> Self {
+        ImageServiceGetImageResultSend::Ok(::std::default::Default::default())
+    }
+}
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+pub enum ImageServiceGetImageResultSend {
+    Ok(GetImageResponse),
+}
+
+impl ::pilota::thrift::Message for ImageServiceGetImageResultSend {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+            name: "ImageServiceGetImageResultSend",
+        })?;
+        match self {
+            ImageServiceGetImageResultSend::Ok(value) => {
+                __protocol.write_struct_field(0, value, ::pilota::thrift::TType::Struct)?;
+            }
+        }
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+        let mut ret = None;
+        __protocol.read_struct_begin()?;
+        loop {
+            let field_ident = __protocol.read_field_begin()?;
+            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                __protocol.field_stop_len();
+                break;
+            } else {
+                __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+            }
+            match field_ident.id {
+                Some(0) => {
+                    if ret.is_none() {
+                        let field_ident = ::pilota::thrift::Message::decode(__protocol)?;
+                        __protocol.struct_len(&field_ident);
+                        ret = Some(ImageServiceGetImageResultSend::Ok(field_ident));
+                    } else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "received multiple fields for union from remote Message",
+                            ),
+                        );
+                    }
+                }
+                _ => {
+                    __protocol.skip(field_ident.field_type)?;
+                }
+            }
+        }
+        __protocol.read_field_end()?;
+        __protocol.read_struct_end()?;
+        if let Some(ret) = ret {
+            ::std::result::Result::Ok(ret)
+        } else {
+            ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "received empty union from remote Message",
+            ))
+        }
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut ret = None;
+            __protocol.read_struct_begin().await?;
+            loop {
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    break;
+                } else {
+                }
+                match field_ident.id {
+                    Some(0) => {
+                        if ret.is_none() {
+                            let field_ident =
+                                <GetImageResponse as ::pilota::thrift::Message>::decode_async(
+                                    __protocol,
+                                )
+                                .await?;
+
+                            ret = Some(ImageServiceGetImageResultSend::Ok(field_ident));
+                        } else {
+                            return ::std::result::Result::Err(
+                                ::pilota::thrift::new_protocol_exception(
+                                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                    "received multiple fields for union from remote Message",
+                                ),
+                            );
+                        }
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+                    }
+                }
+            }
+            __protocol.read_field_end().await?;
+            __protocol.read_struct_end().await?;
+            if let Some(ret) = ret {
+                ::std::result::Result::Ok(ret)
+            } else {
+                ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "received empty union from remote Message",
+                ))
+            }
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "ImageServiceGetImageResultSend",
+        }) + match self {
+            ImageServiceGetImageResultSend::Ok(value) => {
+                __protocol.struct_field_len(Some(0), value)
+            }
+        } + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/message_GetImageRequest.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/message_GetImageRequest.rs
@@ -1,0 +1,149 @@
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+pub struct GetImageRequest {
+    pub id: i64,
+}
+impl ::pilota::thrift::Message for GetImageRequest {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        let struct_ident = ::pilota::thrift::TStructIdentifier {
+            name: "GetImageRequest",
+        };
+
+        __protocol.write_struct_begin(&struct_ident)?;
+        __protocol.write_i64_field(1, *&self.id)?;
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+        let mut var_1 = None;
+
+        let mut __pilota_decoding_field_id = None;
+
+        __protocol.read_struct_begin()?;
+        if let ::std::result::Result::Err(mut err) = (|| {
+            loop {
+                let field_ident = __protocol.read_field_begin()?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    __protocol.field_stop_len();
+                    break;
+                } else {
+                    __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64 => {
+                        var_1 = Some(__protocol.read_i64()?);
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type)?;
+                    }
+                }
+
+                __protocol.read_field_end()?;
+                __protocol.field_end_len();
+            }
+            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+        })() {
+            if let Some(field_id) = __pilota_decoding_field_id {
+                err.prepend_msg(&format!(
+                    "decode struct `GetImageRequest` field(#{}) failed, caused by: ",
+                    field_id
+                ));
+            }
+            return ::std::result::Result::Err(err);
+        };
+        __protocol.read_struct_end()?;
+
+        let Some(var_1) = var_1 else {
+            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "field id is required".to_string(),
+            ));
+        };
+
+        let data = Self { id: var_1 };
+        ::std::result::Result::Ok(data)
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut var_1 = None;
+
+            let mut __pilota_decoding_field_id = None;
+
+            __protocol.read_struct_begin().await?;
+            if let ::std::result::Result::Err(mut err) = async {
+                loop {
+                    let field_ident = __protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    } else {
+                    }
+                    __pilota_decoding_field_id = field_ident.id;
+                    match field_ident.id {
+                        Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64 => {
+                            var_1 = Some(__protocol.read_i64().await?);
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+
+                    __protocol.read_field_end().await?;
+                }
+                ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+            }
+            .await
+            {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!(
+                        "decode struct `GetImageRequest` field(#{}) failed, caused by: ",
+                        field_id
+                    ));
+                }
+                return ::std::result::Result::Err(err);
+            };
+            __protocol.read_struct_end().await?;
+
+            let Some(var_1) = var_1 else {
+                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "field id is required".to_string(),
+                ));
+            };
+
+            let data = Self { id: var_1 };
+            ::std::result::Result::Ok(data)
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "GetImageRequest",
+        }) + __protocol.i64_field_len(Some(1), *&self.id)
+            + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/message_GetImageResponse.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/message_GetImageResponse.rs
@@ -1,0 +1,152 @@
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+pub struct GetImageResponse {
+    pub image: ::common::article::image::Image,
+}
+impl ::pilota::thrift::Message for GetImageResponse {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        let struct_ident = ::pilota::thrift::TStructIdentifier {
+            name: "GetImageResponse",
+        };
+
+        __protocol.write_struct_begin(&struct_ident)?;
+        __protocol.write_struct_field(1, &self.image, ::pilota::thrift::TType::Struct)?;
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+        let mut var_1 = None;
+
+        let mut __pilota_decoding_field_id = None;
+
+        __protocol.read_struct_begin()?;
+        if let ::std::result::Result::Err(mut err) = (|| {
+            loop {
+                let field_ident = __protocol.read_field_begin()?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    __protocol.field_stop_len();
+                    break;
+                } else {
+                    __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                        var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type)?;
+                    }
+                }
+
+                __protocol.read_field_end()?;
+                __protocol.field_end_len();
+            }
+            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+        })() {
+            if let Some(field_id) = __pilota_decoding_field_id {
+                err.prepend_msg(&format!(
+                    "decode struct `GetImageResponse` field(#{}) failed, caused by: ",
+                    field_id
+                ));
+            }
+            return ::std::result::Result::Err(err);
+        };
+        __protocol.read_struct_end()?;
+
+        let Some(var_1) = var_1 else {
+            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "field image is required".to_string(),
+            ));
+        };
+
+        let data = Self { image: var_1 };
+        ::std::result::Result::Ok(data)
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut var_1 = None;
+
+            let mut __pilota_decoding_field_id = None;
+
+            __protocol.read_struct_begin().await?;
+            if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct  => {
+                    var_1 = Some(<::common::article::image::Image as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `GetImageResponse` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+            __protocol.read_struct_end().await?;
+
+            let Some(var_1) = var_1 else {
+                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "field image is required".to_string(),
+                ));
+            };
+
+            let data = Self { image: var_1 };
+            ::std::result::Result::Ok(data)
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "GetImageResponse",
+        }) + __protocol.struct_field_len(Some(1), &self.image)
+            + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/message_ImageServiceGetImageArgsRecv.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/message_ImageServiceGetImageArgsRecv.rs
@@ -1,0 +1,151 @@
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+pub struct ImageServiceGetImageArgsRecv {
+    pub req: GetImageRequest,
+}
+impl ::pilota::thrift::Message for ImageServiceGetImageArgsRecv {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        let struct_ident = ::pilota::thrift::TStructIdentifier {
+            name: "ImageServiceGetImageArgsRecv",
+        };
+
+        __protocol.write_struct_begin(&struct_ident)?;
+        __protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+        let mut var_1 = None;
+
+        let mut __pilota_decoding_field_id = None;
+
+        __protocol.read_struct_begin()?;
+        if let ::std::result::Result::Err(mut err) = (|| {
+            loop {
+                let field_ident = __protocol.read_field_begin()?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    __protocol.field_stop_len();
+                    break;
+                } else {
+                    __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                        var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type)?;
+                    }
+                }
+
+                __protocol.read_field_end()?;
+                __protocol.field_end_len();
+            }
+            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+        })() {
+            if let Some(field_id) = __pilota_decoding_field_id {
+                err.prepend_msg(&format!(
+                    "decode struct `ImageServiceGetImageArgsRecv` field(#{}) failed, caused by: ",
+                    field_id
+                ));
+            }
+            return ::std::result::Result::Err(err);
+        };
+        __protocol.read_struct_end()?;
+
+        let Some(var_1) = var_1 else {
+            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "field req is required".to_string(),
+            ));
+        };
+
+        let data = Self { req: var_1 };
+        ::std::result::Result::Ok(data)
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut var_1 = None;
+
+            let mut __pilota_decoding_field_id = None;
+
+            __protocol.read_struct_begin().await?;
+            if let ::std::result::Result::Err(mut err) = async {
+                loop {
+                    let field_ident = __protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    } else {
+                    }
+                    __pilota_decoding_field_id = field_ident.id;
+                    match field_ident.id {
+                        Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            var_1 = Some(
+                                <GetImageRequest as ::pilota::thrift::Message>::decode_async(
+                                    __protocol,
+                                )
+                                .await?,
+                            );
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+
+                    __protocol.read_field_end().await?;
+                }
+                ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+            }
+            .await
+            {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `ImageServiceGetImageArgsRecv` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+            __protocol.read_struct_end().await?;
+
+            let Some(var_1) = var_1 else {
+                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "field req is required".to_string(),
+                ));
+            };
+
+            let data = Self { req: var_1 };
+            ::std::result::Result::Ok(data)
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "ImageServiceGetImageArgsRecv",
+        }) + __protocol.struct_field_len(Some(1), &self.req)
+            + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/message_ImageServiceGetImageArgsSend.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/message_ImageServiceGetImageArgsSend.rs
@@ -1,0 +1,151 @@
+#[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+pub struct ImageServiceGetImageArgsSend {
+    pub req: GetImageRequest,
+}
+impl ::pilota::thrift::Message for ImageServiceGetImageArgsSend {
+    fn encode<T: ::pilota::thrift::TOutputProtocol>(
+        &self,
+        __protocol: &mut T,
+    ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TOutputProtocolExt;
+        let struct_ident = ::pilota::thrift::TStructIdentifier {
+            name: "ImageServiceGetImageArgsSend",
+        };
+
+        __protocol.write_struct_begin(&struct_ident)?;
+        __protocol.write_struct_field(1, &self.req, ::pilota::thrift::TType::Struct)?;
+        __protocol.write_field_stop()?;
+        __protocol.write_struct_end()?;
+        ::std::result::Result::Ok(())
+    }
+
+    fn decode<T: ::pilota::thrift::TInputProtocol>(
+        __protocol: &mut T,
+    ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+        #[allow(unused_imports)]
+        use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+        let mut var_1 = None;
+
+        let mut __pilota_decoding_field_id = None;
+
+        __protocol.read_struct_begin()?;
+        if let ::std::result::Result::Err(mut err) = (|| {
+            loop {
+                let field_ident = __protocol.read_field_begin()?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                    __protocol.field_stop_len();
+                    break;
+                } else {
+                    __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                        var_1 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                    }
+                    _ => {
+                        __protocol.skip(field_ident.field_type)?;
+                    }
+                }
+
+                __protocol.read_field_end()?;
+                __protocol.field_end_len();
+            }
+            ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+        })() {
+            if let Some(field_id) = __pilota_decoding_field_id {
+                err.prepend_msg(&format!(
+                    "decode struct `ImageServiceGetImageArgsSend` field(#{}) failed, caused by: ",
+                    field_id
+                ));
+            }
+            return ::std::result::Result::Err(err);
+        };
+        __protocol.read_struct_end()?;
+
+        let Some(var_1) = var_1 else {
+            return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                "field req is required".to_string(),
+            ));
+        };
+
+        let data = Self { req: var_1 };
+        ::std::result::Result::Ok(data)
+    }
+
+    fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+        __protocol: &'a mut T,
+    ) -> ::std::pin::Pin<
+        ::std::boxed::Box<
+            dyn ::std::future::Future<
+                    Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        ::std::boxed::Box::pin(async move {
+            let mut var_1 = None;
+
+            let mut __pilota_decoding_field_id = None;
+
+            __protocol.read_struct_begin().await?;
+            if let ::std::result::Result::Err(mut err) = async {
+                loop {
+                    let field_ident = __protocol.read_field_begin().await?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        break;
+                    } else {
+                    }
+                    __pilota_decoding_field_id = field_ident.id;
+                    match field_ident.id {
+                        Some(1) if field_ident.field_type == ::pilota::thrift::TType::Struct => {
+                            var_1 = Some(
+                                <GetImageRequest as ::pilota::thrift::Message>::decode_async(
+                                    __protocol,
+                                )
+                                .await?,
+                            );
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type).await?;
+                        }
+                    }
+
+                    __protocol.read_field_end().await?;
+                }
+                ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+            }
+            .await
+            {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `ImageServiceGetImageArgsSend` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+            __protocol.read_struct_end().await?;
+
+            let Some(var_1) = var_1 else {
+                return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                    ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                    "field req is required".to_string(),
+                ));
+            };
+
+            let data = Self { req: var_1 };
+            ::std::result::Result::Ok(data)
+        })
+    }
+
+    fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+        #[allow(unused_imports)]
+        use ::pilota::thrift::TLengthProtocolExt;
+        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+            name: "ImageServiceGetImageArgsSend",
+        }) + __protocol.struct_field_len(Some(1), &self.req)
+            + __protocol.field_stop_len()
+            + __protocol.struct_end_len()
+    }
+}

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/mod.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/mod.rs
@@ -1,1 +1,8 @@
+include!("message_ImageServiceGetImageArgsRecv.rs");
+include!("enum_ImageServiceGetImageResultSend.rs");
+include!("message_GetImageResponse.rs");
+include!("message_ImageServiceGetImageArgsSend.rs");
+include!("message_GetImageRequest.rs");
+include!("service_ImageService.rs");
+include!("enum_ImageServiceGetImageResultRecv.rs");
 include!("message_Image.rs");

--- a/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/service_ImageService.rs
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/image/src/article/image/service_ImageService.rs
@@ -1,0 +1,2 @@
+
+pub trait ImageService {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Merges re-pub items with direct codegen items in workspace codegen and updates generated thrift test outputs; bumps pilota-build to 0.13.2.
> 
> - **pilota-build**:
>   - **Workspace codegen**: Merge `re_pubs` into existing module `mod_items` (extend per-module instead of rebuilding map).
> - **Test fixtures (thrift workspace + split)**:
>   - Update generated outputs to include service traits (`AuthorService`, `ImageService`) and corresponding RPC args/results messages (`GetAuthor*`, `GetImage*`).
> - **Version**:
>   - Bump `pilota-build` to `0.13.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68ff058ba36e86228e4b4f03dcbe10552f38ac7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->