### PR TITLE
fix(pilota-thrift-parser): adapt the thrift annotation syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -8,27 +8,29 @@ use crate::{
 
 impl Annotation {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
-        let key = Ident::ident_with_dot();
+        let leading_blank = Components::blank().or_not();
 
+        let key = Ident::ident_with_dot();
         let value = Literal::parse();
 
-        Components::blank()
-            .or_not()
+        let annotation = key
+            .then_ignore(just("=").padded_by(Components::blank().or_not()))
+            .then(value)
+            .map(|(key, value)| Annotation { key, value })
+            .then_ignore(Components::blank_with_comments().or_not());
+
+        let separator =
+            Components::list_separator().padded_by(Components::blank_with_comments().or_not());
+
+        let annotation_list = annotation
+            .separated_by(separator)
+            .allow_trailing()
+            .collect::<Vec<Annotation>>()
+            .padded_by(Components::blank_with_comments().or_not());
+
+        leading_blank
             .ignore_then(just("("))
-            .ignore_then(
-                key.padded_by(Components::blank().or_not())
-                    .then_ignore(just("=").padded_by(Components::blank().or_not()))
-                    .then(value)
-                    .then_ignore(
-                        Components::list_separator()
-                            .padded_by(Components::blank().or_not())
-                            .or_not(),
-                    )
-                    .map(|(key, value)| Annotation { key, value })
-                    .repeated()
-                    .at_least(1)
-                    .collect::<Vec<Annotation>>(),
-            )
+            .ignore_then(annotation_list)
             .then_ignore(just(")"))
             .map(Annotations)
     }
@@ -39,16 +41,84 @@ mod tests {
     use super::*;
     #[test]
     fn test_annotations() {
-        let _a = Annotation::get_parser()
-            .parse(r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"")"#)
-            .unwrap();
+        let input = r#"  ()"#;
+        let res = Annotation::get_parser().parse(input).unwrap();
+        assert_eq!(res.len(), 0);
+
+        let input = r#" (go.tag = "json:\"Ids\" split:\"type=tenant\"")"#;
+        let res = Annotation::get_parser().parse(input).unwrap();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].key, "go.tag");
+        assert_eq!(
+            res[0].value.to_string(),
+            "json:\"Ids\" split:\"type=tenant\""
+        );
+
+        let input = r#"(go.tag = "json:\"Ids\" split:\"type=tenant\"";
+        )"#;
+        let res = Annotation::get_parser().parse(input).unwrap();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].key, "go.tag");
+        assert_eq!(
+            res[0].value.to_string(),
+            "json:\"Ids\" split:\"type=tenant\""
+        );
 
         let input = r#"(
             cpp.type = "DenseFoo",
-            python.type ="DenseFoo",
-            java.final="",
-            )"#;
+            python.type ="DenseFoo", 
+            go.type ="DenseFoo";
+            java.final=""
+        )"#;
         let res = Annotation::get_parser().parse(input).unwrap();
-        assert_eq!(res.len(), 3);
+        assert_eq!(res.len(), 4);
+        assert_eq!(res[0].key, "cpp.type");
+        assert_eq!(res[0].value.to_string(), "DenseFoo");
+        assert_eq!(res[1].key, "python.type");
+        assert_eq!(res[1].value.to_string(), "DenseFoo");
+        assert_eq!(res[2].key, "go.type");
+        assert_eq!(res[2].value.to_string(), "DenseFoo");
+        assert_eq!(res[3].key, "java.final");
+        assert_eq!(res[3].value.to_string(), "");
+
+        let input = r#"(
+            // comment before first annotation
+            cpp.type = "DenseFoo"; // cpp.type
+            python.type ="DenseFoo", go.type ="DenseFoo";
+            java.final="")"#;
+        let res = Annotation::get_parser().parse(input).unwrap();
+        assert_eq!(res.len(), 4);
+        assert_eq!(res[0].key, "cpp.type");
+        assert_eq!(res[0].value.to_string(), "DenseFoo");
+        assert_eq!(res[1].key, "python.type");
+        assert_eq!(res[1].value.to_string(), "DenseFoo");
+        assert_eq!(res[2].key, "go.type");
+        assert_eq!(res[2].value.to_string(), "DenseFoo");
+        assert_eq!(res[3].key, "java.final");
+        assert_eq!(res[3].value.to_string(), "");
+
+        let input = r#"(
+            /* separated comment */
+            cpp.type = "DenseFoo"
+        )"#;
+        let res = Annotation::get_parser().parse(input).unwrap();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res[0].key, "cpp.type");
+        assert_eq!(res[0].value.to_string(), "DenseFoo");
+
+        let input = r#"(
+            cpp.type = "DenseFoo";
+            python.type ="DenseFoo", go.type ="DenseFoo"; /* go.type */
+            java.final="",)"#;
+        let res = Annotation::get_parser().parse(input).unwrap();
+        assert_eq!(res.len(), 4);
+        assert_eq!(res[0].key, "cpp.type");
+        assert_eq!(res[0].value.to_string(), "DenseFoo");
+        assert_eq!(res[1].key, "python.type");
+        assert_eq!(res[1].value.to_string(), "DenseFoo");
+        assert_eq!(res[2].key, "go.type");
+        assert_eq!(res[2].value.to_string(), "DenseFoo");
+        assert_eq!(res[3].key, "java.final");
+        assert_eq!(res[3].value.to_string(), "");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The annotation syntax is not defined in the official web. As there are existing idls, we should try best to be compatible with     them.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
We allow the annotations syntax below: 

```Annotations ::= "(" AnnotationList? ")"
AnnotationList ::= Annotation (ListSeparator Annotation)* ListSeparator?
Annotation ::= Identifier "=" Literal
ListSeparator ::= "," | ";"

// For example.

(
            cpp.type = "DenseFoo",
            python.type ="DenseFoo", 
            go.type ="DenseFoo";
            java.final=""
        )
```
