### PR TITLE
fix(pilota-thrift-parser): allow annotation list splited by white spa…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,18 +210,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -508,12 +508,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2077,18 +2077,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.13.1"
+version = "0.13.2"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -23,8 +23,8 @@ impl Annotation {
             Components::list_separator().padded_by(Components::blank_with_comments().or_not());
 
         let annotation_list = annotation
-            .separated_by(separator)
-            .allow_trailing()
+            .then_ignore(separator.or_not())
+            .repeated()
             .collect::<Vec<Annotation>>()
             .padded_by(Components::blank_with_comments().or_not());
 
@@ -65,7 +65,7 @@ mod tests {
         );
 
         let input = r#"(
-            cpp.type = "DenseFoo",
+            cpp.type = "DenseFoo"
             python.type ="DenseFoo", 
             go.type ="DenseFoo";
             java.final=""
@@ -84,7 +84,7 @@ mod tests {
         let input = r#"(
             // comment before first annotation
             cpp.type = "DenseFoo"; // cpp.type
-            python.type ="DenseFoo", go.type ="DenseFoo";
+            python.type ="DenseFoo" go.type ="DenseFoo";
             java.final="")"#;
         let res = Annotation::get_parser().parse(input).unwrap();
         assert_eq!(res.len(), 4);
@@ -105,6 +105,19 @@ mod tests {
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].key, "cpp.type");
         assert_eq!(res[0].value.to_string(), "DenseFoo");
+
+        let input = r#"(
+            cpp.type = "DenseFoo" go.type ="DenseFoo"
+            python.type = "DenseFoo"
+        )"#;
+        let res = Annotation::get_parser().parse(input).unwrap();
+        assert_eq!(res.len(), 3);
+        assert_eq!(res[0].key, "cpp.type");
+        assert_eq!(res[0].value.to_string(), "DenseFoo");
+        assert_eq!(res[1].key, "go.type");
+        assert_eq!(res[1].value.to_string(), "DenseFoo");
+        assert_eq!(res[2].key, "python.type");
+        assert_eq!(res[1].value.to_string(), "DenseFoo");
 
         let input = r#"(
             cpp.type = "DenseFoo";


### PR DESCRIPTION
…ce chars

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

The existing idls use whitespace chars as the separator for annotation list.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Allow this way, and the new annotation syntax is

```
Annotations ::= "(" AnnotationList? ")"
AnnotationList ::= Annotation (ListSeparator Annotation)* ListSeparator?
Annotation ::= Identifier "=" Literal
ListSeparator ::= "," | ";"|" "
```
