### PR TITLE
chore(pilota-build): add position info for default value type check error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.13.2"
+version = "0.13.3"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -1433,7 +1433,26 @@ impl Context {
                 assert!(l.is_empty());
                 ("::std::collections::BTreeMap::new()".into(), false)
             }
-            _ => panic!("unexpected literal {lit:?} with ty {ty:?}"),
+            _ => {
+                let (def_path, idl_file) = with_cur_item(|def_id| {
+                    let def_path = self.item_path(def_id).iter().join("::");
+                    let file_path = self
+                        .db
+                        .node(def_id)
+                        .and_then(|node| {
+                            self.db
+                                .file_paths()
+                                .get(&node.file_id)
+                                .map(|path| path.display().to_string())
+                        })
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    (def_path, file_path)
+                });
+
+                panic!(
+                    "unexpected literal {lit:?} with ty {ty}, position: (def_path: {def_path} in idl_file: {idl_file})"
+                );
+            }
         })
     }
 


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

the previous error for default value type check is hard to find the error position, such as:

the idl definition:
<img width="351" height="103" alt="截屏2025-12-12 16 08 08" src="https://github.com/user-attachments/assets/2d0d52ea-7310-4651-8086-9b70ee674e51" />

the error info:

<img width="826" height="73" alt="截屏2025-12-12 16 09 20" src="https://github.com/user-attachments/assets/1e5efabe-71fa-4242-83cf-8d15f476c85f" />


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

we add def path and idl file path for help:

<img width="1188" height="87" alt="截屏2025-12-12 15 52 56" src="https://github.com/user-attachments/assets/c6ff5d92-211a-4f40-b20c-f0bb6af04852" />

