### PR TITLE
feat(pilota-build): add with_comments option for builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.13.4"
+version = "0.13.5"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/codegen/mod.rs
+++ b/pilota-build/src/codegen/mod.rs
@@ -122,14 +122,22 @@ where
                         ""
                     };
 
-                    let leading_comment = f.leading_comments.to_string();
-                    let trailing_comment = f.trailing_comments.to_string();
+                    if self.config.with_comments {
+                        let leading_comment = f.leading_comments.to_string();
+                        let trailing_comment = f.trailing_comments.to_string();
 
-                    format! {
-                        r#"
+                        format! {
+                            r#"
                         {leading_comment}
                         {attrs}
                         {deprecated_attr}pub {name}: {ty},{trailing_comment}"#
+                        }
+                    } else {
+                        format! {
+                            r#"
+                        {attrs}
+                        {deprecated_attr}pub {name}: {ty},"#
+                        }
                     }
                 })
             })
@@ -151,7 +159,11 @@ where
             ""
         };
 
-        let trailing_comment = s.trailing_comments.to_string();
+        let trailing_comment = if self.config.with_comments {
+            s.trailing_comments.as_str()
+        } else {
+            ""
+        };
 
         stream.push_str(&format! {
             r#"#[derive(Clone, PartialEq)]
@@ -177,14 +189,19 @@ where
                     tracing::trace!("write item {}", item.symbol_name());
 
                     // write leading comments
-                    let comments = match &*item {
-                        middle::rir::Item::Message(s) => s.leading_comments.to_string(),
-                        middle::rir::Item::Enum(e) => e.leading_comments.to_string(),
-                        middle::rir::Item::Service(s) => s.leading_comments.to_string(),
-                        middle::rir::Item::NewType(t) => t.leading_comments.to_string(),
-                        middle::rir::Item::Const(c) => c.leading_comments.to_string(),
-                        _ => String::new(),
+                    let comments = if self.config.with_comments {
+                        match &*item {
+                            middle::rir::Item::Message(s) => s.leading_comments.as_str(),
+                            middle::rir::Item::Enum(e) => e.leading_comments.as_str(),
+                            middle::rir::Item::Service(s) => s.leading_comments.as_str(),
+                            middle::rir::Item::NewType(t) => t.leading_comments.as_str(),
+                            middle::rir::Item::Const(c) => c.leading_comments.as_str(),
+                            _ => "",
+                        }
+                    } else {
+                        ""
                     };
+
                     if !comments.is_empty() {
                         stream.push_str(&format!("\n{comments}\n"));
                     }
@@ -404,7 +421,11 @@ where
                         format!("({fields})")
                     };
 
-                    let leading_comment = v.leading_comments.to_string();
+                    let leading_comment = if self.config.with_comments {
+                        v.leading_comments.as_str()
+                    } else {
+                        ""
+                    };
 
                     format!(
                         r#"{leading_comment}
@@ -418,7 +439,11 @@ where
         if self.cache.keep_unknown_fields.contains(&def_id) && keep {
             variants.push_str("_UnknownFields(::pilota::BytesVec),");
         }
-        let trailing_comment = e.trailing_comments.to_string();
+        let trailing_comment = if self.config.with_comments {
+            e.trailing_comments.as_str()
+        } else {
+            ""
+        };
         stream.push_str(&format! {
             r#"
             #[derive(Clone, PartialEq)]
@@ -625,7 +650,7 @@ where
                 for file_id in mod_files.get(mod_path).unwrap().iter() {
                     let file = this.file(*file_id).unwrap();
                     // 2.1.1 comments
-                    if !file.comments.is_empty() {
+                    if !file.comments.is_empty() && this.config.with_comments {
                         stream.push_str(&format!("\n{}\n", file.comments));
                     }
 

--- a/pilota-build/src/codegen/workspace.rs
+++ b/pilota-build/src/codegen/workspace.rs
@@ -110,6 +110,8 @@ where
     members = [
     {members}
     ]
+    edition = "2024"
+    resolver = "3"
 
     [workspace.dependencies]
     pilota = "*"

--- a/pilota-build/src/lib.rs
+++ b/pilota-build/src/lib.rs
@@ -88,6 +88,7 @@ pub struct Builder<MkB, P> {
     with_descriptor: bool,
     with_field_mask: bool,
     temp_dir: Option<tempfile::TempDir>,
+    with_comments: bool,
 }
 
 impl Builder<MkThriftBackend, ThriftParser> {
@@ -111,6 +112,7 @@ impl Builder<MkThriftBackend, ThriftParser> {
             with_descriptor: false,
             with_field_mask: false,
             temp_dir: None,
+            with_comments: false,
         }
     }
 }
@@ -155,6 +157,7 @@ impl Builder<MkPbBackend, ProtobufParser> {
             with_descriptor: false,
             with_field_mask: false,
             temp_dir,
+            with_comments: false,
         }
     }
 }
@@ -187,6 +190,7 @@ impl<MkB, P> Builder<MkB, P> {
             with_descriptor: self.with_descriptor,
             with_field_mask: self.with_field_mask,
             temp_dir: self.temp_dir,
+            with_comments: self.with_comments,
         }
     }
 
@@ -259,6 +263,14 @@ impl<MkB, P> Builder<MkB, P> {
         self.with_field_mask = on;
         self
     }
+
+    /**
+     * Generate comments for the generated code
+     */
+    pub fn with_comments(mut self, on: bool) -> Self {
+        self.with_comments = on;
+        self
+    }
 }
 
 pub enum Output {
@@ -319,6 +331,7 @@ where
         split: bool,
         with_descriptor: bool,
         with_field_mask: bool,
+        with_comments: bool,
     ) -> Context {
         parser.inputs(services.iter().map(|s| &s.path));
         let ParseResult {
@@ -409,6 +422,7 @@ where
             with_descriptor,
             with_field_mask,
             !ignore_unused,
+            with_comments,
         )
     }
 
@@ -430,6 +444,7 @@ where
             self.split,
             self.with_descriptor,
             self.with_field_mask,
+            self.with_comments,
         );
 
         cx.exec_plugin(BoxedPlugin);
@@ -517,6 +532,7 @@ where
             self.split,
             self.with_descriptor,
             self.with_field_mask,
+            self.with_comments,
         );
 
         std::thread::scope(|_scope| {

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -76,6 +76,7 @@ pub struct Config {
     pub with_field_mask: bool,
     pub touch_all: bool,
     pub common_crate_name: FastStr,
+    pub with_comments: bool,
 }
 
 #[derive(Clone)]
@@ -469,6 +470,7 @@ impl ContextBuilder {
         with_descriptor: bool,
         with_field_mask: bool,
         touch_all: bool,
+        with_comments: bool,
     ) -> Context {
         let mode = Arc::new(self.mode);
         SPECIAL_NAMINGS.get_or_init(|| special_namings);
@@ -490,6 +492,7 @@ impl ContextBuilder {
                 with_field_mask,
                 touch_all,
                 common_crate_name,
+                with_comments,
             },
             cache: Cache {
                 adjusts: Default::default(),
@@ -1734,6 +1737,7 @@ mod tests {
                 with_field_mask: false,
                 touch_all: false,
                 common_crate_name: "common".into(),
+                with_comments: false,
             },
             cache: Cache {
                 adjusts: Arc::new(DashMap::default()),

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -246,6 +246,7 @@ fn test_with_split_builder<F: FnOnce(&Path, &Path)>(
 fn test_thrift(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     test_with_builder(source, target, |source, target| {
         crate::Builder::thrift()
+            .with_comments(true)
             .ignore_unused(false)
             .compile_with_config(
                 vec![IdlService::from_path(source.to_owned())],
@@ -265,6 +266,7 @@ fn test_thrift_workspace(
         .collect();
     test_with_builder_workspace(input_dir, output_dir, |_, target| {
         crate::Builder::thrift()
+            .with_comments(true)
             .ignore_unused(false)
             .compile_with_config(services, crate::Output::Workspace(target.into()));
     });
@@ -281,6 +283,7 @@ fn test_thrift_workspace_with_split(
         .collect();
     test_with_builder_workspace(input_dir, output_dir, |_, target| {
         crate::Builder::thrift()
+            .with_comments(true)
             .ignore_unused(false)
             .split_generated_files(true)
             .compile_with_config(services, crate::Output::Workspace(target.into()))
@@ -294,6 +297,7 @@ fn test_thrift_with_split(
 ) {
     test_with_split_builder(source, target, gen_dir, |source, target| {
         crate::Builder::thrift()
+            .with_comments(true)
             .ignore_unused(false)
             .split_generated_files(true)
             .compile_with_config(

--- a/pilota-build/test_data/plugin/serde.rs
+++ b/pilota-build/test_data/plugin/serde.rs
@@ -196,7 +196,6 @@ pub mod serde {
                     + __protocol.struct_end_len()
             }
         }
-
         #[derive(
             PartialOrd,
             Hash,

--- a/pilota-build/test_data/thrift_workspace/output/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace/output/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
+edition = "2024"
 members = [
     "article",
     "author",
     "common",
     "image",
 ]
+resolver = "3"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/pilota-build/test_data/thrift_workspace_with_split/output/Cargo.toml
+++ b/pilota-build/test_data/thrift_workspace_with_split/output/Cargo.toml
@@ -1,10 +1,12 @@
 [workspace]
+edition = "2024"
 members = [
     "article",
     "author",
     "common",
     "image",
 ]
+resolver = "3"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/pilota-build/test_data/unknown_fields.rs
+++ b/pilota-build/test_data/unknown_fields.rs
@@ -172,7 +172,6 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-
         #[derive(
             PartialOrd,
             Hash,
@@ -568,7 +567,6 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-
         #[derive(
             PartialOrd,
             Hash,
@@ -582,7 +580,7 @@ pub mod unknown_fields {
             PartialEq,
         )]
         pub struct D {
-            pub td: Td, // test trailing comments
+            pub td: Td,
             pub _unknown_fields: ::pilota::BytesVec,
         }
         impl ::pilota::thrift::Message for D {
@@ -752,7 +750,6 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-
         pub trait Test {}
         #[derive(
             PartialOrd,
@@ -885,7 +882,6 @@ pub mod unknown_fields {
             }
         }
         pub const TEST_LIST: [&'static str; 2] = ["hello", "world"];
-
         #[derive(
             PartialOrd,
             Hash,
@@ -1200,7 +1196,6 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-
         #[derive(
             PartialOrd,
             Hash,
@@ -1660,7 +1655,6 @@ pub mod unknown_fields {
             map.insert(1i32, ::std::vec!["hello"]);
             map
         });
-
         #[derive(
             PartialOrd,
             Hash,
@@ -1844,7 +1838,6 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-
         #[derive(
             PartialOrd,
             Hash,
@@ -2676,7 +2669,6 @@ pub mod unknown_fields {
                     + __protocol.struct_end_len()
             }
         }
-
         #[derive(
             PartialOrd,
             Hash,
@@ -2785,7 +2777,6 @@ pub mod unknown_fields {
                 __protocol.i32_len(self.inner())
             }
         }
-
         #[derive(
             PartialOrd,
             Hash,

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.13.3"
+version = "0.13.4"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-parser/src/parser/annotation.rs
+++ b/pilota-thrift-parser/src/parser/annotation.rs
@@ -8,13 +8,13 @@ use crate::{
 
 impl Annotation {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Annotations, extra::Err<Rich<'a, char>>> {
-        let leading_blank = Components::blank().or_not();
+        let leading_blank = Components::blank_with_comments().or_not();
 
         let key = Ident::ident_with_dot();
         let value = Literal::parse();
 
         let annotation = key
-            .then_ignore(just("=").padded_by(Components::blank().or_not()))
+            .then_ignore(just("=").padded_by(Components::blank_with_comments().or_not()))
             .then(value)
             .map(|(key, value)| Annotation { key, value })
             .then_ignore(Components::blank_with_comments().or_not());
@@ -133,5 +133,19 @@ mod tests {
         assert_eq!(res[2].value.to_string(), "DenseFoo");
         assert_eq!(res[3].key, "java.final");
         assert_eq!(res[3].value.to_string(), "");
+    }
+
+    #[test]
+    fn test_annotation_comment() {
+        let input = r#" // comment
+        ( /* comment */
+            cpp.type /* comment */ = /* comment */ "DenseFoo", // comment
+            python.type = "DenseFoo", // comment
+        // comment
+        )"#;
+        let res = Annotation::get_parser().parse(input).unwrap();
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].key, "cpp.type");
+        assert_eq!(res[0].value.to_string(), "DenseFoo");
     }
 }

--- a/pilota-thrift-parser/src/parser/constant.rs
+++ b/pilota-thrift-parser/src/parser/constant.rs
@@ -197,4 +197,12 @@ mod tests {
         let input = r#"const string aXa1 = "hello""#;
         let _c = Constant::get_parser().parse(input).unwrap();
     }
+
+    #[test]
+    fn test_constant_comment() {
+        let input = r#"
+        /* comment */ const /* comment */ string /* comment */ aXa1 = /* comment */ "hello" // comment
+        "#;
+        let _c = Constant::get_parser().parse(input).unwrap();
+    }
 }

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -15,10 +15,10 @@ impl EnumValue {
             .then_ignore(Components::blank().or_not())
             .then(Ident::get_parser())
             .then(
-                Components::blank()
+                Components::blank_with_comments()
                     .or_not()
                     .ignore_then(just("="))
-                    .ignore_then(Components::blank().or_not())
+                    .ignore_then(Components::blank_with_comments().or_not())
                     .ignore_then(IntConstant::parse())
                     .or_not(),
             )
@@ -114,5 +114,16 @@ mod tests {
 }"#,
             )
             .unwrap();
+    }
+
+    #[test]
+    fn test_enum_comment() {
+        let input = r#"
+        /* comment */ enum /* comment */ Sex /* comment */ {
+            /* comment */ UNKNOWN = 0, // comment
+            /* comment */ MALE = 1, // comment
+            /* comment */ FEMALE = 2, // comment
+        }"#;
+        let _ = Enum::get_parser().parse(input).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/field.rs
+++ b/pilota-thrift-parser/src/parser/field.rs
@@ -80,4 +80,12 @@ mod tests {
             .parse(r#"2: required bytet_i.Injection Injection,"#)
             .unwrap();
     }
+
+    #[test]
+    fn test_field_comment() {
+        let input = r#"
+        /* comment */ 1: /* comment */ required /* comment */ string /* comment */ LogID = /* comment */ "xxx" // comment
+        "#;
+        let _f = Field::get_parser().parse(input).unwrap();
+    }
 }

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -29,13 +29,9 @@ impl Function {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then(
-                just("oneway")
-                    .then_ignore(Components::blank_with_comments())
-                    .or_not(),
-            )
+            .then(just("oneway").then_ignore(Components::blank()).or_not())
             .then(Type::get_parser())
-            .then_ignore(Components::blank_with_comments())
+            .then_ignore(Components::blank())
             .then(Ident::get_parser())
             .then_ignore(just("(").padded_by(Components::blank().or_not()))
             .then(fields.clone().or_not())
@@ -97,8 +93,8 @@ mod tests {
             .parse(
                 r#"oneway void pingServer(
                             1: required string(go.tag = 'json:"source_service"') source,
-                            2: optional list<map<i64, set<double>>> nestedDataPoints
-                        ) (api.version = "2.5", deprecated = "false")"#,
+                            2: optional list<map<i64 /* comment */ , set<double>>> nestedDataPoints /* comment */
+                        ) throws (1: ServiceException ex /* comment */) (api.version = "2.5", deprecated = "false")"#,
             )
             .unwrap();
     }
@@ -107,6 +103,17 @@ mod tests {
     fn test_func3() {
         let _f = Function::get_parser()
             .parse(r#"Err test_enum_var_type_name_conflict (1: Request req);"#)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_func_comment() {
+        let _f = Function::get_parser()
+            .parse(r#"// comment
+                        void pingServer( /* comment */
+                            1: required /* comment */ string /* comment */ (go.tag = 'json:"source_service"') source /* comment */,
+                            2: optional list<map<i64 /* comment */ , set<double>>> nestedDataPoints /* comment */
+                        ) /* comment */ (api.version = "2.5", deprecated = "false")"#)
             .unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -13,8 +13,7 @@ impl Include {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("include"))
-            .then_ignore(Components::blank_with_comments())
+            .then_ignore(just("include").padded_by(Components::blank().or_not()))
             .then(Literal::parse())
             .then_ignore(Components::list_separator().or_not())
             .then(Components::trailing_comment().or_not())
@@ -33,8 +32,7 @@ impl CppInclude {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("cpp_include"))
-            .then_ignore(Components::blank())
+            .then_ignore(just("cpp_include").padded_by(Components::blank().or_not()))
             .then(Literal::parse())
             .then_ignore(Components::list_separator().or_not())
             .then(Components::trailing_comment().or_not())
@@ -63,6 +61,26 @@ mod tests {
     fn test_cpp_include() {
         let _f = CppInclude::parse()
             .parse(r#"cpp_include "shared.thrift""#)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_include_comment() {
+        let _f = Include::get_parser()
+            .parse(
+                r#"// comment
+                        include "shared.thrift" // comment"#,
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_cpp_include_comment() {
+        let _f = CppInclude::parse()
+            .parse(
+                r#"// comment
+                        cpp_include "shared.thrift" // comment"#,
+            )
             .unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -28,7 +28,7 @@ impl Path {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, Path, extra::Err<Rich<'a, char>>> {
         Components::blank()
             .ignore_then(Ident::get_parser())
-            .separated_by(just('.').padded_by(Components::blank()))
+            .separated_by(just('.'))
             .at_least(1)
             .collect()
             .then_ignore(Components::blank_without_newline())

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -11,8 +11,9 @@ impl Namespace {
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
             .then_ignore(just("namespace"))
-            .then_ignore(Components::blank_with_comments())
-            .then(Scope::parse().padded_by(Components::blank()))
+            .then_ignore(Components::blank())
+            .then(Scope::parse())
+            .then_ignore(Components::blank())
             .then(Path::parse())
             .then(Annotation::get_parser().or_not())
             .then_ignore(Components::list_separator().or_not())
@@ -57,5 +58,13 @@ mod tests {
         let _ = Namespace::get_parser()
             .parse("namespace py.twisted ThriftTest")
             .unwrap();
+    }
+
+    #[test]
+    fn test_namespace_comment() {
+        let input = r#"
+        /* comment */ namespace * foo.bar // comment
+        "#;
+        let _ = Namespace::get_parser().parse(input).unwrap();
     }
 }

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -93,7 +93,7 @@ mod tests {
                         ) (api.version = "2.5", deprecated = "false")
 
                         }"#,
-        );
+                    ).unwrap();
     }
 
     #[test]

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -150,4 +150,13 @@ mod tests {
         }"#;
         Struct::get_parser().parse(str).unwrap();
     }
+
+    #[test]
+    fn test_struct_comment() {
+        let input = r#"
+        /* comment */ struct Test {
+            /* comment */ 1: /* comment */ required /* comment */ string /* comment */ Service, // comment
+        }"#;
+        let _ = Struct::get_parser().parse(input).unwrap();
+    }
 }

--- a/pilota-thrift-parser/src/parser/thrift.rs
+++ b/pilota-thrift-parser/src/parser/thrift.rs
@@ -192,7 +192,7 @@ impl File {
             .repeated()
             .collect()
             .then(Components::comment().repeated().collect::<Vec<_>>())
-            .then_ignore(Components::blank())
+            .then_ignore(Components::blank().or_not())
             .then_ignore(end())
             .map(|(items, c): (Vec<Item>, Vec<FastStr>)| {
                 let mut comments = String::default();

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -36,11 +36,15 @@ impl Type {
             .then_ignore(Components::not_alphanumeric_or_underscore());
 
             let list = just("list")
-                .ignore_then(just("<").padded_by(Components::blank().or_not()))
+                .ignore_then(just("<").padded_by(Components::blank_with_comments().or_not()))
                 .ignore_then(self_parser.clone())
-                .then_ignore(Components::blank().or_not())
+                .then_ignore(Components::blank_with_comments().or_not())
                 .then_ignore(just(">"))
-                .then(Components::blank().ignore_then(CppType::parse()).or_not())
+                .then(
+                    Components::blank_with_comments()
+                        .ignore_then(CppType::parse())
+                        .or_not(),
+                )
                 .map(|(inner_type, cpp_type)| Ty::List {
                     value: Arc::new(inner_type),
                     cpp_type,
@@ -48,11 +52,15 @@ impl Type {
                 .boxed();
 
             let set = just("set")
-                .ignore_then(Components::blank().ignore_then(CppType::parse()).or_not())
+                .ignore_then(
+                    Components::blank_with_comments()
+                        .ignore_then(CppType::parse())
+                        .or_not(),
+                )
                 .then_ignore(just("<"))
-                .padded_by(Components::blank().or_not())
+                .padded_by(Components::blank_with_comments().or_not())
                 .then(self_parser.clone())
-                .then_ignore(Components::blank().or_not())
+                .then_ignore(Components::blank_with_comments().or_not())
                 .then_ignore(just(">"))
                 .map(|(cpp_type, inner_type)| Ty::Set {
                     value: Arc::new(inner_type),
@@ -61,12 +69,20 @@ impl Type {
                 .boxed();
 
             let map_parser = just("map")
-                .ignore_then(Components::blank().ignore_then(CppType::parse()).or_not())
-                .then_ignore(just("<").padded_by(Components::blank().or_not()))
+                .ignore_then(
+                    Components::blank_with_comments()
+                        .ignore_then(CppType::parse())
+                        .or_not(),
+                )
+                .then_ignore(just("<").padded_by(Components::blank_with_comments().or_not()))
                 .then(self_parser.clone())
-                .then_ignore(Components::list_separator().padded_by(Components::blank().or_not()))
+                .then_ignore(Components::blank_with_comments().or_not())
+                .then_ignore(
+                    Components::list_separator()
+                        .padded_by(Components::blank_with_comments().or_not()),
+                )
                 .then(self_parser.clone())
-                .then_ignore(Components::blank().or_not())
+                .then_ignore(Components::blank_with_comments().or_not())
                 .then_ignore(just(">"))
                 .map(|((cpp_type, key_type), value_type)| Ty::Map {
                     key: Arc::new(key_type),
@@ -78,11 +94,7 @@ impl Type {
             let ty_parser = choice((base_ty, list, set, map_parser, Path::parse().map(Ty::Path)));
 
             ty_parser
-                .then(
-                    Annotation::get_parser()
-                        .or_not()
-                        .padded_by(Components::blank().or_not()),
-                )
+                .then(Annotation::get_parser().or_not())
                 .map(|(ty, an)| Type(ty, an.unwrap_or_default()))
                 .boxed()
         })
@@ -99,7 +111,36 @@ mod tests {
     #[test]
     fn test_type() {
         let parser = Type::get_parser();
+
+        let input = "i32";
+        let _res = parser.parse(input).unwrap();
+
         let input = "map<i32, string>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "list<i32>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "set<i32>";
+        let _res = parser.parse(input).unwrap();
+    }
+
+    #[test]
+    fn test_type_comment() {
+        let parser = Type::get_parser();
+        let input = "map</* comment */ i32 /* comment */ , string /* comment */ > /* comment */ (go.tag = '1')";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "list</* comment */ i32 /* comment */ > /* comment */ (go.tag = '1')";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "set</* comment */ i32 /* comment */ > /* comment */ (go.tag = '1')";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "i32 /* comment */ (go.tag = '1')";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "string /* comment */ (go.tag = '1')";
         let _res = parser.parse(input).unwrap();
     }
 

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -11,8 +11,9 @@ impl Typedef {
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
             .then_ignore(just("typedef"))
-            .then_ignore(Components::blank_with_comments())
-            .then(Type::get_parser().padded_by(Components::blank()))
+            .then_ignore(Components::blank())
+            .then(Type::get_parser())
+            .then_ignore(Components::blank())
             .then(Ident::get_parser())
             .then(Annotation::get_parser().or_not())
             .then_ignore(Components::list_separator().or_not())
@@ -37,5 +38,12 @@ mod tests {
     #[test]
     fn test_type_def() {
         let _td = Typedef::get_parser().parse("typedef i32 Int32,").unwrap();
+    }
+
+    #[test]
+    fn test_type_def_comment() {
+        let _td = Typedef::get_parser()
+            .parse("typedef i32 Int32 /* comment */")
+            .unwrap();
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
The comments in user idl, will be checked by rust compiler, when these comments are generated in rust file.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
We add a option for the control of comments, so when you need comments codegen, you should make sure that your comments is compatible with rust format.
