### PR TITLE
fix(pilota-build): compile error caused by struct init (thrift const, struct default value, etc.) when field mask is enabled

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - run: exit 0
 
   test-linux:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ dependencies = [
  "pilota",
  "pilota-thrift-parser",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -1092,8 +1092,10 @@ static FILE_DESCRIPTOR_{filename_upper}: ::std::sync::LazyLock<::pilota_thrift_r
         if ::pilota_thrift_reflect::service::Register::contains(path) {{
             continue;
         }}
-        let include_file_descriptor =
-            {super_mod}find_mod_file_descriptor(path).expect("include file descriptor must exist");
+        let include_file_descriptor = match {super_mod}find_mod_file_descriptor(path) {{
+            Some(fd) => fd,
+            None => panic!("include file descriptor must exist, path: {{}}", path),
+        }};
         ::pilota_thrift_reflect::service::Register::register(
             include_file_descriptor.filepath.clone(),
             include_file_descriptor.clone(),

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -227,7 +227,7 @@ impl ThriftBackend {
                 __protocol.write_{name}_begin(::pilota::thrift::TMapIdentifier {{
                     key_type: {key_ttype},
                     value_type: {val_ttype},
-                    size: {ident}.keys().filter(|key| map_fm.str(key).1).count(),
+                    size: ({ident}).keys().filter(|key| map_fm.str(key).1).count(),
                 }})?;
                 for (key, val) in {ident} {{
                     let (item_fm, exist) = map_fm.str(key.as_str());
@@ -515,7 +515,7 @@ impl ThriftBackend {
                 __protocol.write_{name}_begin(::pilota::thrift::TMapIdentifier {{
                     key_type: {key_ttype},
                     value_type: {val_ttype},
-                    size: {ident}.keys().filter(|key| map_fm.str(key).1).count(),
+                    size: ({ident}).keys().filter(|key| map_fm.str(key).1).count(),
                 }})?;
                 for (key, val) in {ident} {{
                     let (item_fm, is_exist) = map_fm.str(key);
@@ -559,7 +559,7 @@ impl ThriftBackend {
                 __protocol.write_{name}_begin(::pilota::thrift::TMapIdentifier {{
                     key_type: {key_ttype},
                     value_type: {val_ttype},
-                    size: {ident}.keys().filter(|key| map_fm.int(**key as i32).1).count(),
+                    size: ({ident}).keys().filter(|key| map_fm.int(**key as i32).1).count(),
                 }})?;
                 for (key, val) in {ident} {{
                     let (item_fm, is_exist) = map_fm.int(*key as i32);

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -1408,7 +1408,11 @@ impl Context {
                     })
                     .try_collect()?;
                 let is_const = fields.iter().all(|(_, is_const)| *is_const);
-                let fields = fields.into_iter().map(|f| f.0).join(",");
+                let mut fields = fields.into_iter().map(|f| f.0).collect::<Vec<_>>();
+                if !def.is_wrapper && self.config.with_field_mask {
+                    fields.push("_field_mask: ::std::option::Option::None".to_string());
+                }
+                let fields = fields.join(",");
 
                 let name = self.cur_related_item_path(*did);
 

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -255,6 +255,19 @@ fn test_thrift(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     });
 }
 
+fn test_thrift_with_field_mask(source: impl AsRef<Path>, target: impl AsRef<Path>) {
+    test_with_builder(source, target, |source, target| {
+        crate::Builder::thrift()
+            .with_comments(true)
+            .with_field_mask(true)
+            .ignore_unused(false)
+            .compile_with_config(
+                vec![IdlService::from_path(source.to_owned())],
+                crate::Output::File(target.into()),
+            )
+    })
+}
+
 fn test_thrift_workspace(
     input_dir: impl AsRef<Path>,
     output_dir: impl AsRef<Path>,
@@ -348,6 +361,27 @@ fn test_thrift_gen() {
                 let mut rs_path = path.clone();
                 rs_path.set_extension("rs");
                 test_thrift(path, rs_path);
+            }
+        }
+    });
+}
+
+#[test]
+fn test_thrift_gen_with_field_mask() {
+    let test_data_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test_data")
+        .join("thrift_with_field_mask");
+
+    test_data_dir.read_dir().unwrap().for_each(|f| {
+        let f = f.unwrap();
+
+        let path = f.path();
+
+        if let Some(ext) = path.extension() {
+            if ext == "thrift" {
+                let mut rs_path = path.clone();
+                rs_path.set_extension("rs");
+                test_thrift_with_field_mask(path, rs_path);
             }
         }
     });

--- a/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
@@ -1,0 +1,904 @@
+pub mod struct_init_with_field_mask {
+    #![allow(warnings, clippy::all)]
+
+    pub mod struct_init_with_field_mask {
+
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct Item {
+            pub id: i64,
+
+            pub title: ::pilota::FastStr,
+            pub _field_mask: ::std::option::Option<::pilota_thrift_fieldmask::FieldMask>,
+        }
+        impl ::pilota::thrift::Message for Item {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        ::std::result::Result::Ok(())
+                    } else {
+                        let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Item" };
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        let (field_fm, exist) = struct_fm.field(1);
+                        if exist {
+                            __protocol.write_i64_field(1, *&self.id)?;
+                        }
+                        let (field_fm, exist) = struct_fm.field(2);
+                        if exist {
+                            __protocol.write_faststr_field(2, (&self.title).clone())?;
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+                } else {
+                    let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Item" };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_i64_field(1, *&self.id)?;
+                    __protocol.write_faststr_field(2, (&self.title).clone())?;
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+                let mut var_2 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64 => {
+                                var_1 = Some(__protocol.read_i64()?);
+                            }
+                            Some(2)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_2 = Some(__protocol.read_faststr()?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `Item` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field id is required".to_string(),
+                    ));
+                };
+                let Some(var_2) = var_2 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field title is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    id: var_1,
+                    title: var_2,
+                    _field_mask: ::std::option::Option::None,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type == ::pilota::thrift::TType::I64 =>
+                                {
+                                    var_1 = Some(__protocol.read_i64().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_2 = Some(__protocol.read_faststr().await?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `Item` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field id is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_2) = var_2 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field title is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        id: var_1,
+                        title: var_2,
+                        _field_mask: ::std::option::Option::None,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        0
+                    } else {
+                        __protocol
+                            .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
+                            + {
+                                let (field_fm, exist) = struct_fm.field(1);
+                                if exist {
+                                    __protocol.i64_field_len(Some(1), *&self.id)
+                                } else {
+                                    0
+                                }
+                            }
+                            + {
+                                let (field_fm, exist) = struct_fm.field(2);
+                                if exist {
+                                    __protocol.faststr_field_len(Some(2), &self.title)
+                                } else {
+                                    0
+                                }
+                            }
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                } else {
+                    __protocol
+                        .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
+                        + __protocol.i64_field_len(Some(1), *&self.id)
+                        + __protocol.faststr_field_len(Some(2), &self.title)
+                        + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+        }
+        impl Item {
+            pub fn get_descriptor()
+            -> Option<&'static ::pilota_thrift_reflect::thrift_reflection::StructDescriptor>
+            {
+                let file_descriptor = get_file_descriptor_struct_init_with_field_mask();
+                file_descriptor.find_struct_by_name("Item")
+            }
+
+            pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {
+                self._field_mask = Some(field_mask.clone());
+            }
+        }
+        pub const DEFAULT_ITEM: Item = Item {
+            id: 1i64,
+            title: ::pilota::FastStr::from_static_str("a"),
+            _field_mask: ::std::option::Option::None,
+        };
+        pub static DEFAULT_ITEM_MAP: ::std::sync::LazyLock<::pilota::AHashMap<&'static str, Item>> =
+            ::std::sync::LazyLock::new(|| {
+                let mut map = ::pilota::AHashMap::with_capacity(1);
+                map.insert(
+                    "a",
+                    Item {
+                        id: 1i64,
+                        title: ::pilota::FastStr::from_static_str("a"),
+                        _field_mask: ::std::option::Option::None,
+                    },
+                );
+                map
+            });
+
+        impl ::std::default::Default for GetItemRequest {
+            fn default() -> Self {
+                GetItemRequest {
+                    id: ::std::default::Default::default(),
+                    item_opt: Some(DEFAULT_ITEM),
+                    item_opt2: Some(Item {
+                        id: 1i64,
+                        title: ::pilota::FastStr::from_static_str("a"),
+                        _field_mask: ::std::option::Option::None,
+                    }),
+                    test_map: ::std::default::Default::default(),
+                    test_map2: ::std::default::Default::default(),
+                    _field_mask: ::std::option::Option::None,
+                }
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
+        pub struct GetItemRequest {
+            pub id: i64,
+
+            pub item_opt: ::std::option::Option<Item>,
+
+            pub item_opt2: ::std::option::Option<Item>,
+
+            pub test_map: ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
+
+            pub test_map2: ::pilota::AHashMap<i64, ::pilota::FastStr>,
+            pub _field_mask: ::std::option::Option<::pilota_thrift_fieldmask::FieldMask>,
+        }
+        impl ::pilota::thrift::Message for GetItemRequest {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        ::std::result::Result::Ok(())
+                    } else {
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "GetItemRequest",
+                        };
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        let (field_fm, exist) = struct_fm.field(1);
+                        if exist {
+                            __protocol.write_i64_field(1, *&self.id)?;
+                        }
+                        if let Some(value) = self.item_opt.as_ref() {
+                            let (field_fm, exist) = struct_fm.field(2);
+                            if exist {
+                                __protocol.write_struct_field(
+                                    2,
+                                    value,
+                                    ::pilota::thrift::TType::Struct,
+                                )?;
+                            }
+                        }
+                        if let Some(value) = self.item_opt2.as_ref() {
+                            let (field_fm, exist) = struct_fm.field(3);
+                            if exist {
+                                __protocol.write_struct_field(
+                                    3,
+                                    value,
+                                    ::pilota::thrift::TType::Struct,
+                                )?;
+                            }
+                        }
+                        let (field_fm, exist) = struct_fm.field(4);
+                        if exist {
+                            if let Some(map_fm) = field_fm {
+                                __protocol.write_field_begin(::pilota::thrift::TType::Map, 4)?;
+                                __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                    key_type: ::pilota::thrift::TType::Binary,
+                                    value_type: ::pilota::thrift::TType::Binary,
+                                    size: (&self.test_map)
+                                        .keys()
+                                        .filter(|key| map_fm.str(key).1)
+                                        .count(),
+                                })?;
+                                for (key, val) in &self.test_map {
+                                    let (item_fm, is_exist) = map_fm.str(key);
+                                    if is_exist {
+                                        __protocol.write_faststr((key).clone())?;
+                                        __protocol.write_faststr((val).clone())?;
+                                    }
+                                }
+                                __protocol.write_map_end()?;
+                                __protocol.write_field_end()?;
+                            } else {
+                                __protocol.write_map_field(
+                                    4,
+                                    ::pilota::thrift::TType::Binary,
+                                    ::pilota::thrift::TType::Binary,
+                                    &&self.test_map,
+                                    |__protocol, key| {
+                                        __protocol.write_faststr((key).clone())?;
+                                        ::std::result::Result::Ok(())
+                                    },
+                                    |__protocol, val| {
+                                        __protocol.write_faststr((val).clone())?;
+                                        ::std::result::Result::Ok(())
+                                    },
+                                )?;
+                            }
+                        }
+                        let (field_fm, exist) = struct_fm.field(5);
+                        if exist {
+                            if let Some(map_fm) = field_fm {
+                                __protocol.write_field_begin(::pilota::thrift::TType::Map, 5)?;
+                                __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                    key_type: ::pilota::thrift::TType::I64,
+                                    value_type: ::pilota::thrift::TType::Binary,
+                                    size: (&self.test_map2)
+                                        .keys()
+                                        .filter(|key| map_fm.int(**key as i32).1)
+                                        .count(),
+                                })?;
+                                for (key, val) in &self.test_map2 {
+                                    let (item_fm, is_exist) = map_fm.int(*key as i32);
+                                    if is_exist {
+                                        __protocol.write_i64(*key)?;
+                                        __protocol.write_faststr((val).clone())?;
+                                    }
+                                }
+                                __protocol.write_map_end()?;
+                                __protocol.write_field_end()?;
+                            } else {
+                                __protocol.write_map_field(
+                                    5,
+                                    ::pilota::thrift::TType::I64,
+                                    ::pilota::thrift::TType::Binary,
+                                    &&self.test_map2,
+                                    |__protocol, key| {
+                                        __protocol.write_i64(*key)?;
+                                        ::std::result::Result::Ok(())
+                                    },
+                                    |__protocol, val| {
+                                        __protocol.write_faststr((val).clone())?;
+                                        ::std::result::Result::Ok(())
+                                    },
+                                )?;
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+                } else {
+                    let struct_ident = ::pilota::thrift::TStructIdentifier {
+                        name: "GetItemRequest",
+                    };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_i64_field(1, *&self.id)?;
+                    if let Some(value) = self.item_opt.as_ref() {
+                        __protocol.write_struct_field(2, value, ::pilota::thrift::TType::Struct)?;
+                    }
+                    if let Some(value) = self.item_opt2.as_ref() {
+                        __protocol.write_struct_field(3, value, ::pilota::thrift::TType::Struct)?;
+                    }
+                    __protocol.write_map_field(
+                        4,
+                        ::pilota::thrift::TType::Binary,
+                        ::pilota::thrift::TType::Binary,
+                        &&self.test_map,
+                        |__protocol, key| {
+                            __protocol.write_faststr((key).clone())?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_faststr((val).clone())?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                    __protocol.write_map_field(
+                        5,
+                        ::pilota::thrift::TType::I64,
+                        ::pilota::thrift::TType::Binary,
+                        &&self.test_map2,
+                        |__protocol, key| {
+                            __protocol.write_i64(*key)?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_faststr((val).clone())?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+                let mut var_2 = Some(DEFAULT_ITEM);
+                let mut var_3 = Some(Item {
+                    id: 1i64,
+                    title: ::pilota::FastStr::from_static_str("a"),
+                    _field_mask: ::std::option::Option::None,
+                });
+                let mut var_4 = None;
+                let mut var_5 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64 => {
+                                var_1 = Some(__protocol.read_i64()?);
+                            }
+                            Some(2)
+                                if field_ident.field_type == ::pilota::thrift::TType::Struct =>
+                            {
+                                var_2 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                            }
+                            Some(3)
+                                if field_ident.field_type == ::pilota::thrift::TType::Struct =>
+                            {
+                                var_3 = Some(::pilota::thrift::Message::decode(__protocol)?);
+                            }
+                            Some(4) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_4 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            __protocol.read_faststr()?,
+                                            __protocol.read_faststr()?,
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(5) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_5 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            __protocol.read_i64()?,
+                                            __protocol.read_faststr()?,
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `GetItemRequest` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field id is required".to_string(),
+                    ));
+                };
+                let Some(var_4) = var_4 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field test_map is required".to_string(),
+                    ));
+                };
+                let Some(var_5) = var_5 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field test_map2 is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    id: var_1,
+                    item_opt: var_2,
+                    item_opt2: var_3,
+                    test_map: var_4,
+                    test_map2: var_5,
+                    _field_mask: ::std::option::Option::None,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = Some(DEFAULT_ITEM);
+                    let mut var_3 = Some(Item {
+                        id: 1i64,
+                        title: ::pilota::FastStr::from_static_str("a"),
+                        _field_mask: ::std::option::Option::None,
+                    });
+                    let mut var_4 = None;
+                    let mut var_5 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type == ::pilota::thrift::TType::I64 =>
+                                {
+                                    var_1 = Some(__protocol.read_i64().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Struct =>
+                                {
+                                    var_2 = Some(
+                                        <Item as ::pilota::thrift::Message>::decode_async(
+                                            __protocol,
+                                        )
+                                        .await?,
+                                    );
+                                }
+                                Some(3)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Struct =>
+                                {
+                                    var_3 = Some(
+                                        <Item as ::pilota::thrift::Message>::decode_async(
+                                            __protocol,
+                                        )
+                                        .await?,
+                                    );
+                                }
+                                Some(4)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Map =>
+                                {
+                                    var_4 = Some({
+                                        let map_ident = __protocol.read_map_begin().await?;
+                                        let mut val =
+                                            ::pilota::AHashMap::with_capacity(map_ident.size);
+                                        for _ in 0..map_ident.size {
+                                            val.insert(
+                                                __protocol.read_faststr().await?,
+                                                __protocol.read_faststr().await?,
+                                            );
+                                        }
+                                        __protocol.read_map_end().await?;
+                                        val
+                                    });
+                                }
+                                Some(5)
+                                    if field_ident.field_type == ::pilota::thrift::TType::Map =>
+                                {
+                                    var_5 = Some({
+                                        let map_ident = __protocol.read_map_begin().await?;
+                                        let mut val =
+                                            ::pilota::AHashMap::with_capacity(map_ident.size);
+                                        for _ in 0..map_ident.size {
+                                            val.insert(
+                                                __protocol.read_i64().await?,
+                                                __protocol.read_faststr().await?,
+                                            );
+                                        }
+                                        __protocol.read_map_end().await?;
+                                        val
+                                    });
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `GetItemRequest` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field id is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_4) = var_4 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field test_map is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_5) = var_5 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field test_map2 is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        id: var_1,
+                        item_opt: var_2,
+                        item_opt2: var_3,
+                        test_map: var_4,
+                        test_map2: var_5,
+                        _field_mask: ::std::option::Option::None,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        0
+                    } else {
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "GetItemRequest",
+                        }) + {
+                            let (field_fm, exist) = struct_fm.field(1);
+                            if exist {
+                                __protocol.i64_field_len(Some(1), *&self.id)
+                            } else {
+                                0
+                            }
+                        } + self.item_opt.as_ref().map_or(0, |value| {
+                            let (field_fm, exist) = struct_fm.field(2);
+                            if exist {
+                                __protocol.struct_field_len(Some(2), value)
+                            } else {
+                                0
+                            }
+                        }) + self.item_opt2.as_ref().map_or(0, |value| {
+                            let (field_fm, exist) = struct_fm.field(3);
+                            if exist {
+                                __protocol.struct_field_len(Some(3), value)
+                            } else {
+                                0
+                            }
+                        }) + {
+                            let (field_fm, exist) = struct_fm.field(4);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::Binary,
+                                                value_type: ::pilota::thrift::TType::Binary,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in &self.test_map {
+                                        let (item_fm, exist) = map_fm.str(key);
+                                        if exist {
+                                            size += __protocol.faststr_len(key);
+                                            size += __protocol.faststr_len(val);
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(4),
+                                        ::pilota::thrift::TType::Binary,
+                                        ::pilota::thrift::TType::Binary,
+                                        &self.test_map,
+                                        |__protocol, key| __protocol.faststr_len(key),
+                                        |__protocol, val| __protocol.faststr_len(val),
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        } + {
+                            let (field_fm, exist) = struct_fm.field(5);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::I64,
+                                                value_type: ::pilota::thrift::TType::Binary,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in &self.test_map2 {
+                                        let (item_fm, is_exist) = map_fm.int(*key as i32);
+                                        if is_exist {
+                                            size += __protocol.i64_len(*key);
+                                            size += __protocol.faststr_len(val);
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(5),
+                                        ::pilota::thrift::TType::I64,
+                                        ::pilota::thrift::TType::Binary,
+                                        &self.test_map2,
+                                        |__protocol, key| __protocol.i64_len(*key),
+                                        |__protocol, val| __protocol.faststr_len(val),
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        } + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                } else {
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "GetItemRequest",
+                    }) + __protocol.i64_field_len(Some(1), *&self.id)
+                        + self
+                            .item_opt
+                            .as_ref()
+                            .map_or(0, |value| __protocol.struct_field_len(Some(2), value))
+                        + self
+                            .item_opt2
+                            .as_ref()
+                            .map_or(0, |value| __protocol.struct_field_len(Some(3), value))
+                        + __protocol.map_field_len(
+                            Some(4),
+                            ::pilota::thrift::TType::Binary,
+                            ::pilota::thrift::TType::Binary,
+                            &self.test_map,
+                            |__protocol, key| __protocol.faststr_len(key),
+                            |__protocol, val| __protocol.faststr_len(val),
+                        )
+                        + __protocol.map_field_len(
+                            Some(5),
+                            ::pilota::thrift::TType::I64,
+                            ::pilota::thrift::TType::Binary,
+                            &self.test_map2,
+                            |__protocol, key| __protocol.i64_len(*key),
+                            |__protocol, val| __protocol.faststr_len(val),
+                        )
+                        + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+        }
+        impl GetItemRequest {
+            pub fn get_descriptor()
+            -> Option<&'static ::pilota_thrift_reflect::thrift_reflection::StructDescriptor>
+            {
+                let file_descriptor = get_file_descriptor_struct_init_with_field_mask();
+                file_descriptor.find_struct_by_name("GetItemRequest")
+            }
+
+            pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {
+                self._field_mask = Some(field_mask.clone());
+                if let Some(value) = &mut self.item_opt {
+                    if let Some(fm) = field_mask.field(2).0 {
+                        value.set_field_mask(fm.clone());
+                    }
+                }
+                if let Some(value) = &mut self.item_opt2 {
+                    if let Some(fm) = field_mask.field(3).0 {
+                        value.set_field_mask(fm.clone());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.thrift
+++ b/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.thrift
@@ -1,0 +1,15 @@
+struct Item {
+    1: required i64 id,
+    2: required string title,
+}
+
+const Item default_item = {'id': 1, 'title': "a"}
+const map<string, Item> default_item_map = {'a': {'id': 1, 'title': "a"}}
+
+struct GetItemRequest {
+    1: required i64 id,
+    2: optional Item item_opt = default_item,
+    3: optional Item item_opt2 = {'id': 1, 'title': "a", 'content': "b"},
+    4: required map<string, string> test_map,
+    5: required map<i64, string> test_map2,
+}

--- a/pilota-thrift-reflect/Cargo.toml
+++ b/pilota-thrift-reflect/Cargo.toml
@@ -27,6 +27,7 @@ bytes.workspace = true
 dashmap.workspace = true
 faststr.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 chumsky.workspace = true
 
 [build-dependencies]

--- a/pilota-thrift-reflect/src/lib.rs
+++ b/pilota-thrift-reflect/src/lib.rs
@@ -1,8 +1,25 @@
 use std::collections::BTreeMap;
+use std::path::{Component, PathBuf};
 
 use ahash::AHashMap;
 use descriptor::thrift_reflection::ConstValueType;
 use pilota::{FastStr, OrderedFloat};
+
+fn normalize_path(path: &std::path::Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => {
+                normalized.push(component);
+            }
+        }
+    }
+    normalized
+}
 
 include!("descriptor.rs");
 pub use descriptor::*;
@@ -88,11 +105,13 @@ impl From<&pilota_thrift_parser::File> for thrift_reflection::FileDescriptor {
         for item in file.items.iter() {
             match item {
                 pilota_thrift_parser::Item::Include(include) => {
-                    let include_path = file
-                        .path
-                        .parent()
-                        .unwrap_or_else(|| std::path::Path::new(""))
-                        .join(include.path.0.as_str()); // relative path -> absolute path
+                    let include_path = normalize_path(
+                        &file
+                            .path
+                            .parent()
+                            .unwrap_or_else(|| std::path::Path::new(""))
+                            .join(include.path.0.as_str()),
+                    );
 
                     includes.insert(
                         FastStr::new(
@@ -538,5 +557,106 @@ impl From<(FastStr, &pilota_thrift_parser::Exception)> for thrift_reflection::St
             annotations: Annotations::from(&exception.annotations).0,
             ..Default::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_path_basic() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("/a/b/c.thrift")),
+            std::path::PathBuf::from("/a/b/c.thrift")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_with_dot() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("/a/./b/c.thrift")),
+            std::path::PathBuf::from("/a/b/c.thrift")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_with_double_dot() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("/a/b/../c.thrift")),
+            std::path::PathBuf::from("/a/c.thrift")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_with_multiple_double_dots() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("/a/b/c/../../d.thrift")),
+            std::path::PathBuf::from("/a/d.thrift")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_with_mixed_dots() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("/a/./b/../c/./d.thrift")),
+            std::path::PathBuf::from("/a/c/d.thrift")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_empty_path() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("")),
+            std::path::PathBuf::from("")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_only_dot() {
+        assert_eq!(
+            normalize_path(std::path::Path::new(".")),
+            std::path::PathBuf::from("")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_only_double_dot() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("..")),
+            std::path::PathBuf::from("")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_double_dot_at_root() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("/../a.thrift")),
+            std::path::PathBuf::from("/a.thrift")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_relative_path() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("a/b/../c.thrift")),
+            std::path::PathBuf::from("a/c.thrift")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_consecutive_double_dots() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("/a/b/c/../../../d.thrift")),
+            std::path::PathBuf::from("/d.thrift")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_multiple_dots_in_sequence() {
+        assert_eq!(
+            normalize_path(std::path::Path::new("/a/././b/./c.thrift")),
+            std::path::PathBuf::from("/a/b/c.thrift")
+        );
     }
 }

--- a/pilota-thrift-reflect/src/service.rs
+++ b/pilota-thrift-reflect/src/service.rs
@@ -152,9 +152,9 @@ impl TypeDescriptor {
         let ty = self.name.as_str().into();
         match ty {
             ThriftType::Path(path) => {
-                println!("path: {}", path);
-                println!("self.filepath: {}", self.filepath);
-                println!("Register: {:?}", GLOBAL_DESCRIPTOR);
+                tracing::trace!("path: {}", path);
+                tracing::trace!("self.filepath: {}", self.filepath);
+                tracing::trace!("Register: {:?}", GLOBAL_DESCRIPTOR);
                 let cur_file_desc = Register::get(self.filepath.as_str()).unwrap();
                 let include_path = IncludePath::try_from(path.as_str()).unwrap();
 


### PR DESCRIPTION
… struct default value, etc.) when field mask is enabled

## Motivation

Fix the compile error of the generated code caused by struct init when field mask is enabled.

When field mask is enabled, a `_field_mask` field will be added to each generated struct. But in the struct init code (const, default value, etc.), the lack of `_field_mask` will cause compile error.

Thrift:
``` thrift
struct Item {
    1: required i64 id,
    2: required string title,
    3: required string content,

    10: optional map<string, string> extra,
}

const Item default_item = {'id': 1, 'title': "a", 'content': "b"}
```

Generated Code:
``` rust
pub struct Item {
    pub id: i64,

    pub title: ::pilota::FastStr,

    pub content: ::pilota::FastStr,

    pub extra: ::std::option::Option<
        ::pilota::AHashMap<::pilota::FastStr, ::pilota::FastStr>,
    >,
    pub _field_mask: ::std::option::Option<::pilota_thrift_fieldmask::FieldMask>,
}

pub const DEFAULT_ITEM: Item = Item {
    id: 1i64,
    title: ::pilota::FastStr::from_static_str("a"),
    content: ::pilota::FastStr::from_static_str("b"),
    extra: None,
};
```

Compile error:
```
error[E0063]: missing field `_field_mask` in initializer of `Item`
    --> /Users/bytedance/Workspace/src/temp/rust-test/target/debug/build/lust-gen-e8599c44f51e0b4b/out/lust_gen.rs:1097:48
     |
1097 |                 pub const DEFAULT_ITEM: Item = Item {
     |                                                ^^^^ missing `_field_mask`
```

## Solution

In `lit_into_ty`, while generating struct init code, if the field mask is enabled, add `_field_mask: ::std::option::Option::None` to fields declaration.