### PR TITLE
fix(pilota-build): incorrect merge function signature for cycled-enum

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           cargo test --doc --workspace
 
   test-linux-aarch64:
-    runs-on: [self-hosted, Linux, aarch64]
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
           cargo test --doc --workspace
 
   test-macos:
-    runs-on: [self-hosted, macOS]
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -78,7 +78,7 @@ jobs:
           cargo test --doc --workspace
 
   test-windows:
-    runs-on: [self-hosted, Windows]
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -96,7 +96,7 @@ jobs:
           cargo test --doc --workspace
 
   lint:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -116,7 +116,7 @@ jobs:
         run: |
           cargo fmt -- --check
   coverage:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
       contents: read

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -6,7 +6,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -8,10 +8,11 @@ on:
 jobs:
   security-audit:
     permissions: write-all
-    runs-on: [self-hosted, Linux, amd64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Run cargo audit
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "serde",
  "version_check",
@@ -45,15 +45,15 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c269894b6fe5e9d7ada0cf69b5bf847ff35bc25fc271f08e1d080fce80339a"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
 ]
@@ -120,9 +120,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "boxcar"
@@ -132,15 +132,15 @@ checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -153,9 +153,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -210,18 +210,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "concolor"
@@ -390,9 +390,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "faststr"
-version = "0.2.32"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baec6a0289d7f1fe5665586ef7340af82e3037207bef60f5785e57569776f0c8"
+checksum = "1ca7d44d22004409a61c393afb3369c8f7bb74abcae49fe249ee01dcc3002113"
 dependencies = [
  "bytes",
  "rkyv",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -434,6 +434,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -507,13 +520,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.12.1"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -566,15 +587,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -587,10 +608,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linkedbytes"
@@ -611,9 +638,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -636,14 +663,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.13",
+ "regex-automata 0.4.14",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -703,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -847,7 +874,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -906,7 +933,7 @@ dependencies = [
  "pilota-thrift-parser",
  "pilota-thrift-reflect",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -918,7 +945,7 @@ dependencies = [
  "bytes",
  "chumsky",
  "faststr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -932,7 +959,7 @@ dependencies = [
  "faststr",
  "pilota",
  "pilota-thrift-parser",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -971,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "ppv-lite86"
@@ -985,28 +1012,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.103"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.8",
+ "regex-syntax 0.8.10",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -1050,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f2fedc3b7dafdc2851bc52f277377c5473d378859be234bc7ebb593144d01"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -1086,9 +1123,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1125,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1135,7 +1172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1149,11 +1186,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1162,7 +1199,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1191,19 +1228,19 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.8",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1219,13 +1256,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.8",
+ "regex-syntax 0.8.10",
 ]
 
 [[package]]
@@ -1236,9 +1273,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rend"
@@ -1248,12 +1285,12 @@ checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 
 [[package]]
 name = "rkyv"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a640b26f007713818e9a9b65d34da1cf58538207b052916a83d80e43f3ffa4"
+checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
 dependencies = [
  "bytes",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -1266,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.12"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd83f5f173ff41e00337d97f6572e416d022ef8a19f371817259ae960324c482"
+checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1293,7 +1330,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1302,14 +1339,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1333,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa"
@@ -1412,6 +1449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,22 +1486,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -1499,9 +1542,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -1511,9 +1554,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stacker"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f8b29fb42aafcea4edeeb6b2f2d7ecd0d969c48b4cf0d2e64aafc471dd6e59"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1524,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1546,14 +1589,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1574,11 +1617,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1594,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1639,9 +1682,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -1649,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1664,33 +1707,33 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1710,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1738,7 +1781,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.13",
+ "regex-automata 0.4.14",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -1755,9 +1798,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1772,6 +1815,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,9 +1828,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1824,14 +1873,23 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1842,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1852,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1865,18 +1923,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2070,6 +2162,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,20 +2257,26 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/pilota-build/src/codegen/pb/mod.rs
+++ b/pilota-build/src/codegen/pb/mod.rs
@@ -385,7 +385,7 @@ impl ProtobufBackend {
                     };
 
                     let path = self.cx.cur_related_item_path(did);
-                    format!("{path}::merge(&mut {ident}, tag, wire_type, buf, ctx)").into()
+                    format!("{path}::merge({ident}, tag, wire_type, buf, ctx)").into()
                 } else {
                     let module = self.ty_module(ty);
                     let merge_fn = format!("::pilota::pb::encoding::{module}::{merge_fn}");
@@ -680,6 +680,7 @@ impl CodegenBackend for ProtobufBackend {
             return;
         }
         let name = self.cx.rust_name(def_id);
+        let is_cycled = self.cx.db.type_graph().is_cycled(def_id);
 
         let encoded_len = e
             .variants
@@ -711,16 +712,47 @@ impl CodegenBackend for ProtobufBackend {
             })
             .join(",");
 
-        let merge = e.variants.iter().map(|variant| {
-            let tag = variant.id.unwrap() as u32;
-            let variant_name = self.cx.rust_name(variant.did);
-            let merge = self.codegen_merge_field(
-                "value".into(),
-                variant.fields.first().unwrap(),
-                FieldKind::Required,
-            );
-            format! {
-                r#"{tag} => {{
+        let merge = e
+            .variants
+            .iter()
+            .map(|variant| {
+                let tag = variant.id.unwrap() as u32;
+                let variant_name = self.cx.rust_name(variant.did);
+                let merge = self.codegen_merge_field(
+                    "value".into(),
+                    variant.fields.first().unwrap(),
+                    FieldKind::Required,
+                );
+
+                if is_cycled {
+                    format! {
+                        r#"{tag} => {{
+                    match field.as_mut() {{
+                        ::core::option::Option::Some(boxed) => {{
+                            match &mut **boxed {{
+                                {name}::{variant_name}(value) => {{
+                                    {merge}?;
+                                }},
+                                _ => {{
+                                    let mut owned_value = ::core::default::Default::default();
+                                    let value = &mut owned_value;
+                                    {merge}?;
+                                    **boxed = {name}::{variant_name}(owned_value);
+                                }},
+                            }}
+                        }},
+                        ::core::option::Option::None => {{
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            {merge}?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new({name}::{variant_name}(owned_value)));
+                        }},
+                    }}
+                }},"#
+                    }
+                } else {
+                    format! {
+                        r#"{tag} => {{
                     match field {{
                         ::core::option::Option::Some({name}::{variant_name}(value)) => {{
                             {merge}?;
@@ -733,8 +765,10 @@ impl CodegenBackend for ProtobufBackend {
                         }},
                     }}
                 }},"#
-            }
-        }).join("");
+                    }
+                }
+            })
+            .join("");
 
         let file_id = self.cx.node(def_id).unwrap().file_id;
         let mut getter_impl = String::new();
@@ -760,6 +794,12 @@ impl CodegenBackend for ProtobufBackend {
             }
         }
 
+        let merge_param_type = if is_cycled {
+            "::core::option::Option<::std::boxed::Box<Self>>"
+        } else {
+            "::core::option::Option<Self>"
+        };
+
         stream.push_str(&format! {
             r#"
 
@@ -781,7 +821,7 @@ impl CodegenBackend for ProtobufBackend {
 
                 #[inline]
                 pub fn merge(
-                    field: &mut ::core::option::Option<Self>,
+                    field: &mut {merge_param_type},
                     tag: u32,
                     wire_type: ::pilota::pb::encoding::WireType,
                     buf: &mut ::pilota::Bytes,

--- a/pilota-build/test_data/protobuf/oneof.proto
+++ b/pilota-build/test_data/protobuf/oneof.proto
@@ -19,3 +19,62 @@ message Test {
     }
     optional Enum e = 10;
 }
+
+message A {
+  oneof b {
+    NoneValue none_value = 1;
+    double float64_value = 11;
+    sint64 int64_value = 12;
+    string string_value = 13;
+    bool bool_value = 14;
+    C c = 33;
+    D d = 34;
+    E e = 35;
+    ListValue list_value = 51;
+    TupleValue tuple_value = 52;
+    DictValue dict_value = 53;
+    NamedTupleValue named_tuple_value = 54;
+  }
+}
+
+message NoneValue {}
+
+message ListValue {
+  repeated A values = 1;
+}
+
+message TupleValue {
+  repeated A values = 1;
+}
+
+message DictValue {
+  map<string, A> fields = 1;
+}
+
+message PairValue {
+  string key = 1;
+  A value = 2;
+}
+
+message NamedTupleValue {
+  string name = 1;
+  repeated PairValue values = 2;
+}
+
+message C {
+  string name = 1;
+}
+
+message E {
+  string name = 1;
+}
+
+message D {
+  enum F {
+    UNKNOWN = 0;
+  }
+  F type_spec_class = 1;
+  A a = 2;
+  string name = 3;
+  int32 num = 4;
+}

--- a/pilota-build/test_data/protobuf/oneof.rs
+++ b/pilota-build/test_data/protobuf/oneof.rs
@@ -62,7 +62,7 @@ pub mod oneof {
                 }
                 2 | 4 => {
                     let mut _inner_pilota_value = &mut self.r#type;
-                    test::Type::merge(&mut _inner_pilota_value, tag, wire_type, buf, ctx).map_err(
+                    test::Type::merge(_inner_pilota_value, tag, wire_type, buf, ctx).map_err(
                         |mut error| {
                             error.push(STRUCT_NAME, stringify!(r#type));
                             error
@@ -79,7 +79,7 @@ pub mod oneof {
                 }
                 6 | 8 => {
                     let mut _inner_pilota_value = &mut self.test;
-                    test::Test::merge(&mut _inner_pilota_value, tag, wire_type, buf, ctx).map_err(
+                    test::Test::merge(_inner_pilota_value, tag, wire_type, buf, ctx).map_err(
                         |mut error| {
                             error.push(STRUCT_NAME, stringify!(test));
                             error
@@ -96,6 +96,355 @@ pub mod oneof {
                     )
                     .map_err(|mut error| {
                         error.push(STRUCT_NAME, stringify!(e));
+                        error
+                    })
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub struct D {
+        pub type_spec_class: d::F,
+
+        pub a: ::std::option::Option<::std::boxed::Box<A>>,
+
+        pub name: ::pilota::FastStr,
+
+        pub num: i32,
+    }
+    impl ::pilota::pb::Message for D {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::int32::encoded_len(ctx, 1, &self.type_spec_class)
+                + self.a.as_ref().map_or(0, |msg| {
+                    ::pilota::pb::encoding::message::encoded_len(ctx, 2, msg)
+                })
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 3, &self.name)
+                + ::pilota::pb::encoding::int32::encoded_len(ctx, 4, &self.num)
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::int32::encode(1, &self.type_spec_class, buf);
+            if let Some(_pilota_inner_value) = self.a.as_ref() {
+                ::pilota::pb::encoding::message::encode(2, _pilota_inner_value, buf);
+            }
+            ::pilota::pb::encoding::faststr::encode(3, &self.name, buf);
+            ::pilota::pb::encoding::int32::encode(4, &self.num, buf);
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(D);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.type_spec_class;
+                    ::pilota::pb::encoding::int32::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(type_spec_class));
+                            error
+                        })
+                }
+                2 => {
+                    let mut _inner_pilota_value = &mut self.a;
+                    ::pilota::pb::encoding::message::merge(
+                        wire_type,
+                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(a));
+                        error
+                    })
+                }
+                3 => {
+                    let mut _inner_pilota_value = &mut self.name;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(name));
+                            error
+                        })
+                }
+                4 => {
+                    let mut _inner_pilota_value = &mut self.num;
+                    ::pilota::pb::encoding::int32::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(num));
+                            error
+                        })
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub struct TupleValue {
+        pub values: ::std::vec::Vec<A>,
+    }
+    impl ::pilota::pb::Message for TupleValue {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::message::encoded_len_repeated(ctx, 1, &self.values)
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            for msg in &self.values {
+                ::pilota::pb::encoding::message::encode(1, msg, buf);
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(TupleValue);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.values;
+                    ::pilota::pb::encoding::message::merge_repeated(
+                        wire_type,
+                        _inner_pilota_value,
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(values));
+                        error
+                    })
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub struct DictValue {
+        pub fields: ::pilota::AHashMap<::pilota::FastStr, A>,
+    }
+    impl ::pilota::pb::Message for DictValue {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::hash_map::encoded_len(
+                ctx,
+                ::pilota::pb::encoding::faststr::encoded_len,
+                ::pilota::pb::encoding::message::encoded_len,
+                1,
+                &self.fields,
+            )
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::hash_map::encode(
+                ::pilota::pb::encoding::faststr::encode,
+                ::pilota::pb::encoding::faststr::encoded_len,
+                ::pilota::pb::encoding::message::encode,
+                ::pilota::pb::encoding::message::encoded_len,
+                1,
+                &self.fields,
+                buf,
+            );
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(DictValue);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.fields;
+                    ::pilota::pb::encoding::hash_map::merge(
+                        ::pilota::pb::encoding::faststr::merge,
+                        ::pilota::pb::encoding::message::merge,
+                        &mut _inner_pilota_value,
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(fields));
+                        error
+                    })
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub struct A {
+        pub b: ::std::option::Option<::std::boxed::Box<a::B>>,
+    }
+    impl ::pilota::pb::Message for A {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + self.b.as_ref().map_or(0, |msg| msg.encoded_len(ctx))
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            if let Some(_pilota_inner_value) = self.b.as_ref() {
+                _pilota_inner_value.encode(buf);
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(A);
+
+            match tag {
+                1 | 11 | 12 | 13 | 14 | 33 | 34 | 35 | 51 | 52 | 53 | 54 => {
+                    let mut _inner_pilota_value = &mut self.b;
+                    a::B::merge(_inner_pilota_value, tag, wire_type, buf, ctx).map_err(
+                        |mut error| {
+                            error.push(STRUCT_NAME, stringify!(b));
+                            error
+                        },
+                    )
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub struct PairValue {
+        pub key: ::pilota::FastStr,
+
+        pub value: ::std::option::Option<A>,
+    }
+    impl ::pilota::pb::Message for PairValue {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.key)
+                + self.value.as_ref().map_or(0, |msg| {
+                    ::pilota::pb::encoding::message::encoded_len(ctx, 2, msg)
+                })
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::faststr::encode(1, &self.key, buf);
+            if let Some(_pilota_inner_value) = self.value.as_ref() {
+                ::pilota::pb::encoding::message::encode(2, _pilota_inner_value, buf);
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(PairValue);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.key;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(key));
+                            error
+                        })
+                }
+                2 => {
+                    let mut _inner_pilota_value = &mut self.value;
+                    ::pilota::pb::encoding::message::merge(
+                        wire_type,
+                        _inner_pilota_value.get_or_insert_with(::core::default::Default::default),
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(value));
+                        error
+                    })
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub struct NamedTupleValue {
+        pub name: ::pilota::FastStr,
+
+        pub values: ::std::vec::Vec<PairValue>,
+    }
+    impl ::pilota::pb::Message for NamedTupleValue {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.name)
+                + ::pilota::pb::encoding::message::encoded_len_repeated(ctx, 2, &self.values)
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::faststr::encode(1, &self.name, buf);
+            for msg in &self.values {
+                ::pilota::pb::encoding::message::encode(2, msg, buf);
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(NamedTupleValue);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.name;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(name));
+                            error
+                        })
+                }
+                2 => {
+                    let mut _inner_pilota_value = &mut self.values;
+                    ::pilota::pb::encoding::message::merge_repeated(
+                        wire_type,
+                        _inner_pilota_value,
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(values));
                         error
                     })
                 }
@@ -144,29 +493,229 @@ pub mod oneof {
         }
     }
 
-    pub mod test {
-        use ::pilota::{Buf as _, BufMut as _};
+    #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+    pub struct C {
+        pub name: ::pilota::FastStr,
+    }
+    impl ::pilota::pb::Message for C {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.name)
+        }
 
-        impl ::std::default::Default for Test {
-            fn default() -> Self {
-                Test::A(::std::default::Default::default())
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::faststr::encode(1, &self.name, buf);
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(C);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.name;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(name));
+                            error
+                        })
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
             }
         }
-        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
-        pub enum Test {
-            A(::pilota::FastStr),
-
-            B(i32),
+    }
+    #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+    pub struct NoneValue {}
+    impl ::pilota::pb::Message for NoneValue {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0
         }
 
-        impl Test {
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {}
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            match tag {
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+    #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+    pub struct E {
+        pub name: ::pilota::FastStr,
+    }
+    impl ::pilota::pb::Message for E {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.name)
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::faststr::encode(1, &self.name, buf);
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(E);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.name;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(name));
+                            error
+                        })
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+    #[derive(Debug, Default, Clone, PartialEq)]
+    pub struct ListValue {
+        pub values: ::std::vec::Vec<A>,
+    }
+    impl ::pilota::pb::Message for ListValue {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::message::encoded_len_repeated(ctx, 1, &self.values)
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            for msg in &self.values {
+                ::pilota::pb::encoding::message::encode(1, msg, buf);
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(ListValue);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.values;
+                    ::pilota::pb::encoding::message::merge_repeated(
+                        wire_type,
+                        _inner_pilota_value,
+                        buf,
+                        ctx,
+                    )
+                    .map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(values));
+                        error
+                    })
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+
+    pub mod a {
+        use ::pilota::{Buf as _, BufMut as _};
+
+        impl ::std::default::Default for B {
+            fn default() -> Self {
+                B::NoneValue(::std::default::Default::default())
+            }
+        }
+        #[derive(Debug, Clone, PartialEq)]
+        pub enum B {
+            NoneValue(super::NoneValue),
+
+            Float64Value(f64),
+
+            Int64Value(i64),
+
+            StringValue(::pilota::FastStr),
+
+            BoolValue(bool),
+
+            C(super::C),
+
+            D(super::D),
+
+            E(super::E),
+
+            ListValue(super::ListValue),
+
+            TupleValue(super::TupleValue),
+
+            DictValue(super::DictValue),
+
+            NamedTupleValue(super::NamedTupleValue),
+        }
+
+        impl B {
             pub fn encode(&self, buf: &mut ::pilota::LinkedBytes) {
                 match self {
-                    Test::A(value) => {
-                        ::pilota::pb::encoding::faststr::encode(6, &*value, buf);
+                    B::NoneValue(value) => {
+                        ::pilota::pb::encoding::message::encode(1, (&*value), buf);
                     }
-                    Test::B(value) => {
-                        ::pilota::pb::encoding::int32::encode(8, &*value, buf);
+                    B::Float64Value(value) => {
+                        ::pilota::pb::encoding::double::encode(11, &*value, buf);
+                    }
+                    B::Int64Value(value) => {
+                        ::pilota::pb::encoding::int64::encode(12, &*value, buf);
+                    }
+                    B::StringValue(value) => {
+                        ::pilota::pb::encoding::faststr::encode(13, &*value, buf);
+                    }
+                    B::BoolValue(value) => {
+                        ::pilota::pb::encoding::bool::encode(14, &*value, buf);
+                    }
+                    B::C(value) => {
+                        ::pilota::pb::encoding::message::encode(33, (&*value), buf);
+                    }
+                    B::D(value) => {
+                        ::pilota::pb::encoding::message::encode(34, (&*value), buf);
+                    }
+                    B::E(value) => {
+                        ::pilota::pb::encoding::message::encode(35, (&*value), buf);
+                    }
+                    B::ListValue(value) => {
+                        ::pilota::pb::encoding::message::encode(51, (&*value), buf);
+                    }
+                    B::TupleValue(value) => {
+                        ::pilota::pb::encoding::message::encode(52, (&*value), buf);
+                    }
+                    B::DictValue(value) => {
+                        ::pilota::pb::encoding::message::encode(53, (&*value), buf);
+                    }
+                    B::NamedTupleValue(value) => {
+                        ::pilota::pb::encoding::message::encode(54, (&*value), buf);
                     }
                 }
             }
@@ -174,47 +723,351 @@ pub mod oneof {
             #[inline]
             pub fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
                 match self {
-                    Test::A(value) => ::pilota::pb::encoding::faststr::encoded_len(ctx, 6, &*value),
-                    Test::B(value) => ::pilota::pb::encoding::int32::encoded_len(ctx, 8, &*value),
+                    B::NoneValue(value) => {
+                        ::pilota::pb::encoding::message::encoded_len(ctx, 1, &*value)
+                    }
+                    B::Float64Value(value) => {
+                        ::pilota::pb::encoding::double::encoded_len(ctx, 11, &*value)
+                    }
+                    B::Int64Value(value) => {
+                        ::pilota::pb::encoding::int64::encoded_len(ctx, 12, &*value)
+                    }
+                    B::StringValue(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 13, &*value)
+                    }
+                    B::BoolValue(value) => {
+                        ::pilota::pb::encoding::bool::encoded_len(ctx, 14, &*value)
+                    }
+                    B::C(value) => ::pilota::pb::encoding::message::encoded_len(ctx, 33, &*value),
+                    B::D(value) => ::pilota::pb::encoding::message::encoded_len(ctx, 34, &*value),
+                    B::E(value) => ::pilota::pb::encoding::message::encoded_len(ctx, 35, &*value),
+                    B::ListValue(value) => {
+                        ::pilota::pb::encoding::message::encoded_len(ctx, 51, &*value)
+                    }
+                    B::TupleValue(value) => {
+                        ::pilota::pb::encoding::message::encoded_len(ctx, 52, &*value)
+                    }
+                    B::DictValue(value) => {
+                        ::pilota::pb::encoding::message::encoded_len(ctx, 53, &*value)
+                    }
+                    B::NamedTupleValue(value) => {
+                        ::pilota::pb::encoding::message::encoded_len(ctx, 54, &*value)
+                    }
                 }
             }
 
             #[inline]
             pub fn merge(
-                field: &mut ::core::option::Option<Self>,
+                field: &mut ::core::option::Option<::std::boxed::Box<Self>>,
                 tag: u32,
                 wire_type: ::pilota::pb::encoding::WireType,
                 buf: &mut ::pilota::Bytes,
                 ctx: &mut ::pilota::pb::encoding::DecodeContext,
             ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
                 match tag {
-                    6 => match field {
-                        ::core::option::Option::Some(Test::A(value)) => {
-                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                    1 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::NoneValue(value) => {
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::NoneValue(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::NoneValue(owned_value),
+                            ));
                         }
-                        _ => {
+                    },
+                    11 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::Float64Value(value) => {
+                                ::pilota::pb::encoding::double::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::double::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::Float64Value(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::double::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::Float64Value(owned_value),
+                            ));
+                        }
+                    },
+                    12 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::Int64Value(value) => {
+                                ::pilota::pb::encoding::int64::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::int64::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::Int64Value(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::int64::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::Int64Value(owned_value),
+                            ));
+                        }
+                    },
+                    13 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::StringValue(value) => {
+                                ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::StringValue(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
                             let mut owned_value = ::core::default::Default::default();
                             let value = &mut owned_value;
                             ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
-                            *field = ::core::option::Option::Some(Test::A(owned_value));
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::StringValue(owned_value),
+                            ));
                         }
                     },
-                    8 => match field {
-                        ::core::option::Option::Some(Test::B(value)) => {
-                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
-                        }
-                        _ => {
+                    14 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::BoolValue(value) => {
+                                ::pilota::pb::encoding::bool::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::bool::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::BoolValue(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
                             let mut owned_value = ::core::default::Default::default();
                             let value = &mut owned_value;
-                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
-                            *field = ::core::option::Option::Some(Test::B(owned_value));
+                            ::pilota::pb::encoding::bool::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::BoolValue(owned_value),
+                            ));
                         }
                     },
-                    _ => unreachable!(concat!("invalid ", stringify!(Test), " tag: {}"), tag),
+                    33 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::C(value) => {
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::C(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(B::C(
+                                owned_value,
+                            )));
+                        }
+                    },
+                    34 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::D(value) => {
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::D(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(B::D(
+                                owned_value,
+                            )));
+                        }
+                    },
+                    35 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::E(value) => {
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::E(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(B::E(
+                                owned_value,
+                            )));
+                        }
+                    },
+                    51 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::ListValue(value) => {
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::ListValue(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::ListValue(owned_value),
+                            ));
+                        }
+                    },
+                    52 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::TupleValue(value) => {
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::TupleValue(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::TupleValue(owned_value),
+                            ));
+                        }
+                    },
+                    53 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::DictValue(value) => {
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::DictValue(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::DictValue(owned_value),
+                            ));
+                        }
+                    },
+                    54 => match field.as_mut() {
+                        ::core::option::Option::Some(boxed) => match &mut **boxed {
+                            B::NamedTupleValue(value) => {
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            }
+                            _ => {
+                                let mut owned_value = ::core::default::Default::default();
+                                let value = &mut owned_value;
+                                ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                                **boxed = B::NamedTupleValue(owned_value);
+                            }
+                        },
+                        ::core::option::Option::None => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::message::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(::std::boxed::Box::new(
+                                B::NamedTupleValue(owned_value),
+                            ));
+                        }
+                    },
+                    _ => unreachable!(concat!("invalid ", stringify!(B), " tag: {}"), tag),
                 };
                 ::core::result::Result::Ok(())
             }
         }
+    }
+
+    pub mod d {
+        use ::pilota::{Buf as _, BufMut as _};
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct F(i32);
+
+        impl F {
+            pub const UNKNOWN: Self = Self(0);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
+
+            pub fn to_string(&self) -> ::std::string::String {
+                match self {
+                    Self(0) => ::std::string::String::from("UNKNOWN"),
+                    Self(val) => val.to_string(),
+                }
+            }
+
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
+                match value {
+                    0 => Some(Self::UNKNOWN),
+                    _ => None,
+                }
+            }
+        }
+
+        impl ::std::convert::From<i32> for F {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
+
+        impl ::std::convert::From<F> for i32 {
+            fn from(value: F) -> i32 {
+                value.0
+            }
+        }
+    }
+
+    pub mod test {
+        use ::pilota::{Buf as _, BufMut as _};
+
         impl ::std::default::Default for Type {
             fn default() -> Self {
                 Type::S(::std::default::Default::default())
@@ -279,6 +1132,74 @@ pub mod oneof {
                         }
                     },
                     _ => unreachable!(concat!("invalid ", stringify!(Type), " tag: {}"), tag),
+                };
+                ::core::result::Result::Ok(())
+            }
+        }
+        impl ::std::default::Default for Test {
+            fn default() -> Self {
+                Test::A(::std::default::Default::default())
+            }
+        }
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Clone, PartialEq)]
+        pub enum Test {
+            A(::pilota::FastStr),
+
+            B(i32),
+        }
+
+        impl Test {
+            pub fn encode(&self, buf: &mut ::pilota::LinkedBytes) {
+                match self {
+                    Test::A(value) => {
+                        ::pilota::pb::encoding::faststr::encode(6, &*value, buf);
+                    }
+                    Test::B(value) => {
+                        ::pilota::pb::encoding::int32::encode(8, &*value, buf);
+                    }
+                }
+            }
+
+            #[inline]
+            pub fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+                match self {
+                    Test::A(value) => ::pilota::pb::encoding::faststr::encoded_len(ctx, 6, &*value),
+                    Test::B(value) => ::pilota::pb::encoding::int32::encoded_len(ctx, 8, &*value),
+                }
+            }
+
+            #[inline]
+            pub fn merge(
+                field: &mut ::core::option::Option<Self>,
+                tag: u32,
+                wire_type: ::pilota::pb::encoding::WireType,
+                buf: &mut ::pilota::Bytes,
+                ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+                match tag {
+                    6 => match field {
+                        ::core::option::Option::Some(Test::A(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(Test::A(owned_value));
+                        }
+                    },
+                    8 => match field {
+                        ::core::option::Option::Some(Test::B(value)) => {
+                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(Test::B(owned_value));
+                        }
+                    },
+                    _ => unreachable!(concat!("invalid ", stringify!(Test), " tag: {}"), tag),
                 };
                 ::core::result::Result::Ok(())
             }

--- a/pilota-build/test_data/protobuf_with_descriptor/nested.rs
+++ b/pilota-build/test_data/protobuf_with_descriptor/nested.rs
@@ -192,7 +192,7 @@ pub mod nested {
                         2 | 3 => {
                             let mut _inner_pilota_value = &mut self.contact_info;
                             contact::ContactInfo::merge(
-                                &mut _inner_pilota_value,
+                                _inner_pilota_value,
                                 tag,
                                 wire_type,
                                 buf,

--- a/pilota-build/test_data/protobuf_with_descriptor/oneof.rs
+++ b/pilota-build/test_data/protobuf_with_descriptor/oneof.rs
@@ -129,7 +129,7 @@ pub mod oneof {
                         2 | 3 => {
                             let mut _inner_pilota_value = &mut self.contact_info;
                             contact::ContactInfo::merge(
-                                &mut _inner_pilota_value,
+                                _inner_pilota_value,
                                 tag,
                                 wire_type,
                                 buf,


### PR DESCRIPTION
## Motivation

Fix the compile error of the pb generated code caused by nested enum.

For nested enum, pilota-build will use `::std::option::Option` and `::std::boxed::Box` to wrap the real enum type in struct field declaration. But the `merge` method of the enum type only accept `::std::option::Option<Self>`.

```
error[E0308]: mismatched types
   --> /data00/home/shenyuji/tmp/rust-test/target/debug/build/pb-gen-229d3f2befcfa45d/out/pb_gen.rs:37:37
    |
 37 |                         a::B::merge(&mut _inner_pilota_value, tag, wire_type, buf, ctx).map_err(
    |                         ----------- ^^^^^^^^^^^^^^^^^^^^^^^^ expected `&mut Option<B>`, found `&mut &mut Option<Box<B>>`
    |                         |
    |                         arguments to this function are incorrect
    |
    = note: expected mutable reference `&mut std::option::Option<B>`
               found mutable reference `&mut &mut std::option::Option<Box<B>>`
note: associated function defined here
   --> /data00/home/shenyuji/tmp/rust-test/target/debug/build/pb-gen-229d3f2befcfa45d/out/pb_gen.rs:662:24
    |
662 |                 pub fn merge(
    |                        ^^^^^
663 |                     field: &mut ::core::option::Option<Self>,
    |                     ----------------------------------------
```

## Solution

Change the type of the first param of the nested-enum `merge` method from `&mut Option<Self>` to `&mut Option<Box<T>>`.
