### PR TITLE
Fix some unexpected behavior for thrift field mask.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .idea
+.trae
 **/target
 
 */src/test/gen/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-fieldmask"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "ahash",
  "ariadne",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.13.6"
+version = "0.13.7"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/codegen/pb/mod.rs
+++ b/pilota-build/src/codegen/pb/mod.rs
@@ -108,7 +108,8 @@ impl ProtobufBackend {
                                 | "double"
                         );
                         if packable && is_proto3 {
-                            // Special case for int32: we may need a generic convert variant to support enums.
+                            // Special case for int32: we may need a generic convert variant to
+                            // support enums.
                             if module_str == "int32" {
                                 quote!(encoded_len_packed_convert)
                             } else {

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -165,10 +165,8 @@ impl ThriftBackend {
                     format!("&self.{field_name}").into(),
                 );
                 format! {
-                r#"let (field_fm, exist) = struct_fm.field({field_id});
-                if exist {{
-                    {write_field_with_field_mask}
-                }}"#
+                r#"let (field_fm, _) = struct_fm.field({field_id});
+                {write_field_with_field_mask}"#
                 }
                 .into()
             };

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -719,13 +719,19 @@ impl CodegenBackend for ThriftBackend {
             .join("");
 
         let idl_name = s.name.raw_str();
+        if self.config.with_descriptor {
+            stream.push_str(&format! {
+                r#"impl {name} {{
+                    pub fn get_descriptor() -> Option<&'static ::pilota_thrift_reflect::thrift_reflection::StructDescriptor> {{
+                        let file_descriptor = get_file_descriptor_{filename_lower}();
+                        file_descriptor.find_struct_by_name("{idl_name}")
+                    }}
+                }}"#
+            });
+        }
+
         stream.push_str(&format! {
             r#"impl {name} {{
-                pub fn get_descriptor() -> Option<&'static ::pilota_thrift_reflect::thrift_reflection::StructDescriptor> {{
-                    let file_descriptor = get_file_descriptor_{filename_lower}();
-                    file_descriptor.find_struct_by_name("{idl_name}")
-                }}
-
                 pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {{
                     self._field_mask = Some(field_mask.clone());
                     {set_inner_field_mask}

--- a/pilota-build/src/codegen/thrift/ty.rs
+++ b/pilota-build/src/codegen/thrift/ty.rs
@@ -153,6 +153,17 @@ impl ThriftBackend {
             ) => {
                 self.encode_map_with_int_field_mask(k, v, ident, "map")
             }
+            ty::Map(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.encode_map_with_enum_field_mask(k, v, ident, "map")
+                    } else {
+                        self.encode_map(k, v, ident, "map")
+                    }
+                } else {
+                    self.encode_map(k, v, ident, "map")
+                }
+            }
             ty::Map(k, v) => {
                 self.encode_map(k, v, ident, "map")
             }
@@ -167,6 +178,17 @@ impl ThriftBackend {
                 ty::I8 | ty::I16 | ty::I32 | ty::I64 |ty::U8
             ) => {
                 self.encode_map_with_int_field_mask(k, v, ident, "btree_map")
+            }
+            ty::BTreeMap(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.encode_map_with_enum_field_mask(k, v, ident, "btree_map")
+                    } else {
+                        self.encode_map(k, v, ident, "btree_map")
+                    }
+                } else {
+                    self.encode_map(k, v, ident, "btree_map")
+                }
             }
             ty::BTreeMap(k, v) => {
                 self.encode_map(k, v, ident, "btree_map")
@@ -272,6 +294,47 @@ impl ThriftBackend {
                 }})?;
                 for (key, val) in {ident} {{
                     let (item_fm, exist) = map_fm.int(*key as i32);
+                    if exist {{
+                        {write_key}
+                        {write_val_with_field_mask}
+                    }}
+                }}
+                __protocol.write_{name}_end()?;
+            }} else {{
+                __protocol.write_{name}({key_ttype}, {val_ttype}, &{ident}, |__protocol, key| {{
+                    {write_key}
+                    ::std::result::Result::Ok(())
+                }}, |__protocol, val| {{
+                    {write_val}
+                    ::std::result::Result::Ok(())
+                }})?;
+            }}"#
+        }
+        .into()
+    }
+
+    fn encode_map_with_enum_field_mask(
+        &self,
+        k: &Ty,
+        v: &Ty,
+        ident: FastStr,
+        name: &str,
+    ) -> FastStr {
+        let key_ttype = self.ttype(k);
+        let val_ttype = self.ttype(v);
+        let write_key = self.codegen_encode_ty(k, "key".into());
+        let write_val = self.codegen_encode_ty(v, "val".into());
+        let write_val_with_field_mask = self.codegen_encode_ty_with_field_mask(v, "val".into());
+
+        format! {
+            r#"if let Some(map_fm) = item_fm {{
+                __protocol.write_{name}_begin(::pilota::thrift::TMapIdentifier {{
+                    key_type: {key_ttype},
+                    value_type: {val_ttype},
+                    size: ({ident}).keys().filter(|key| map_fm.int(key.inner() as i32).1).count(),
+                }})?;
+                for (key, val) in {ident} {{
+                    let (item_fm, exist) = map_fm.int(key.inner() as i32);
                     if exist {{
                         {write_key}
                         {write_val_with_field_mask}
@@ -436,11 +499,33 @@ impl ThriftBackend {
             ty::Map(k, v) if matches!(k.kind, ty::I8 | ty::I16 | ty::I32 | ty::I64 | ty::U8) => {
                 self.encode_map_field_with_int_field_mask(k, v, id, ident, "map")
             }
+            ty::Map(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.encode_map_field_with_enum_field_mask(k, v, id, ident, "map")
+                    } else {
+                        self.encode_map_field(k, v, id, ident, "map")
+                    }
+                } else {
+                    self.encode_map_field(k, v, id, ident, "map")
+                }
+            }
             ty::BTreeMap(k, v) if matches!(k.kind, ty::String | ty::FastStr) => {
                 self.encode_map_field_with_str_field_mask(k, v, id, ident, "btree_map")
             }
             ty::BTreeMap(k, v) if matches!(k.kind, ty::I8 | ty::I16 | ty::I32 | ty::I64 | ty::U8) => {
                 self.encode_map_field_with_int_field_mask(k, v, id, ident, "btree_map")
+            }
+            ty::BTreeMap(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.encode_map_field_with_enum_field_mask(k, v, id, ident, "btree_map")
+                    } else {
+                        self.encode_map_field(k, v, id, ident, "btree_map")
+                    }
+                } else {
+                    self.encode_map_field(k, v, id, ident, "btree_map")
+                }
             }
             ty::Map(k, v) => {
                 self.encode_map_field(k, v, id, ident, "map")
@@ -583,6 +668,50 @@ impl ThriftBackend {
             .into()
     }
 
+    fn encode_map_field_with_enum_field_mask(
+        &self,
+        k: &Ty,
+        v: &Ty,
+        id: i16,
+        ident: FastStr,
+        name: &str,
+    ) -> FastStr {
+        let key_ttype = self.ttype(k);
+        let val_ttype = self.ttype(v);
+        let write_key = self.codegen_encode_ty(k, "key".into());
+        let write_val = self.codegen_encode_ty(v, "val".into());
+        let write_val_with_field_mask = self.codegen_encode_ty_with_field_mask(v, "val".into());
+
+        format! {
+            r#"if let Some(map_fm) = field_fm {{
+                __protocol.write_field_begin(::pilota::thrift::TType::Map, {id})?;
+                __protocol.write_{name}_begin(::pilota::thrift::TMapIdentifier {{
+                    key_type: {key_ttype},
+                    value_type: {val_ttype},
+                    size: ({ident}).keys().filter(|key| map_fm.int(key.inner() as i32).1).count(),
+                }})?;
+                for (key, val) in {ident} {{
+                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                    if is_exist {{
+                        {write_key}
+                        {write_val_with_field_mask}
+                    }}
+                }}
+                __protocol.write_{name}_end()?;
+                __protocol.write_field_end()?;
+            }} else {{
+                __protocol.write_{name}_field({id}, {key_ttype}, {val_ttype}, &{ident}, |__protocol, key| {{
+                        {write_key}
+                        ::std::result::Result::Ok(())
+                    }}, |__protocol, val| {{
+                        {write_val}
+                        ::std::result::Result::Ok(())
+                    }})?;
+        }}"#
+        }
+        .into()
+    }
+
     pub(crate) fn codegen_ty_size(&self, ty: &Ty, ident: FastStr) -> FastStr {
         match &ty.kind {
             ty::String => format!("__protocol.string_len({ident})").into(),
@@ -668,6 +797,17 @@ impl ThriftBackend {
             ty::Map(k, v) if matches!(k.kind, ty::I8 | ty::I16 | ty::I32 | ty::I64 | ty::U8) => {
                 self.map_size_with_int_field_mask(k, v, ident, "map")
             }
+            ty::Map(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.map_size_with_enum_field_mask(k, v, ident, "map")
+                    } else {
+                        self.map_size(k, v, ident, "map")
+                    }
+                } else {
+                    self.map_size(k, v, ident, "map")
+                }
+            }
             ty::Map(k, v) => self.map_size(k, v, ident, "map"),
             ty::BTreeMap(k, v) if matches!(k.kind, ty::String | ty::FastStr) => {
                 self.map_size_with_str_field_mask(k, v, ident, "btree_map")
@@ -676,6 +816,17 @@ impl ThriftBackend {
                 if matches!(k.kind, ty::I8 | ty::I16 | ty::I32 | ty::I64 | ty::U8) =>
             {
                 self.map_size_with_int_field_mask(k, v, ident, "btree_map")
+            }
+            ty::BTreeMap(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.map_size_with_enum_field_mask(k, v, ident, "btree_map")
+                    } else {
+                        self.map_size(k, v, ident, "btree_map")
+                    }
+                } else {
+                    self.map_size(k, v, ident, "btree_map")
+                }
             }
             ty::BTreeMap(k, v) => self.map_size(k, v, ident, "btree_map"),
             ty::Path(_) => format!(r#"__protocol.struct_len({ident})"#).into(),
@@ -764,6 +915,40 @@ impl ThriftBackend {
                 
                 for (key, val) in {ident} {{
                     let (item_fm, exist) = map_fm.int(*key as i32);
+                    if exist {{
+                        size += {add_key};
+                        size += {add_val_with_field_mask};
+                    }}
+                }}
+                size
+            }} else {{
+                __protocol.{name}_len({k_ttype}, {v_ttype}, {ident}, |__protocol, key| {{
+                    {add_key}
+                }}, |__protocol, val| {{
+                    {add_val}
+                }})
+            }}"#
+        }
+        .into()
+    }
+
+    fn map_size_with_enum_field_mask(&self, k: &Ty, v: &Ty, ident: FastStr, name: &str) -> FastStr {
+        let add_key = self.codegen_ty_size(k, "key".into());
+        let add_val = self.codegen_ty_size(v, "val".into());
+        let add_val_with_field_mask = self.codegen_ty_size_with_field_mask(v, "val".into());
+        let k_ttype = self.ttype(k);
+        let v_ttype = self.ttype(v);
+
+        format! {
+            r#"if let Some(map_fm) = item_fm {{
+                let mut size = __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {{
+                    key_type: {k_ttype},
+                    value_type: {v_ttype},
+                    size: 0,
+                }}) + __protocol.map_end_len();
+
+                for (key, val) in {ident} {{
+                    let (item_fm, exist) = map_fm.int(key.inner() as i32);
                     if exist {{
                         size += {add_key};
                         size += {add_val_with_field_mask};
@@ -882,6 +1067,17 @@ impl ThriftBackend {
             ty::Map(k, v) if matches!(k.kind, ty::I8 | ty::I16 | ty::I32 | ty::I64 | ty::U8) => {
                 self.map_field_size_with_int_field_mask(k, v, id, ident, "map")
             }
+            ty::Map(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.map_field_size_with_enum_field_mask(k, v, id, ident, "map")
+                    } else {
+                        self.map_field_size(k, v, id, ident, "map")
+                    }
+                } else {
+                    self.map_field_size(k, v, id, ident, "map")
+                }
+            }
             ty::Map(k, v) => self.map_field_size(k, v, id, ident, "map"),
             ty::BTreeMap(k, v) if matches!(k.kind, ty::String | ty::FastStr) => {
                 self.map_field_size_with_str_field_mask(k, v, id, ident, "btree_map")
@@ -890,6 +1086,17 @@ impl ThriftBackend {
                 if matches!(k.kind, ty::I8 | ty::I16 | ty::I32 | ty::I64 | ty::U8) =>
             {
                 self.map_field_size_with_int_field_mask(k, v, id, ident, "btree_map")
+            }
+            ty::BTreeMap(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.map_field_size_with_enum_field_mask(k, v, id, ident, "btree_map")
+                    } else {
+                        self.map_field_size(k, v, id, ident, "btree_map")
+                    }
+                } else {
+                    self.map_field_size(k, v, id, ident, "btree_map")
+                }
             }
             ty::BTreeMap(k, v) => self.map_field_size(k, v, id, ident, "btree_map"),
             ty::Path(p) if self.is_i32_enum(p.did) => {
@@ -994,6 +1201,46 @@ impl ThriftBackend {
                 }}) + __protocol.map_end_len();
                 for (key, val) in {ident} {{
                     let (item_fm, is_exist) = map_fm.int(*key as i32);
+                    if is_exist {{
+                        size += {add_key};
+                        size += {add_val_with_field_mask};
+                    }}
+                }}
+                size
+            }} else {{
+                __protocol.{name}_field_len(Some({id}), {k_ttype}, {v_ttype}, {ident}, |__protocol, key| {{
+                    {add_key}
+                }}, |__protocol, val| {{
+                    {add_val}
+                }})
+            }}"#
+        }
+        .into()
+    }
+
+    fn map_field_size_with_enum_field_mask(
+        &self,
+        k: &Ty,
+        v: &Ty,
+        id: i16,
+        ident: FastStr,
+        name: &str,
+    ) -> FastStr {
+        let add_key = self.codegen_ty_size(k, "key".into());
+        let add_val = self.codegen_ty_size(v, "val".into());
+        let add_val_with_field_mask = self.codegen_ty_size_with_field_mask(v, "val".into());
+        let k_ttype = self.ttype(k);
+        let v_ttype = self.ttype(v);
+
+        format! {
+            r#"if let Some(map_fm) = field_fm {{
+                let mut size = __protocol.field_begin_len(::pilota::thrift::TType::Map, None) + __protocol.field_end_len() + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {{
+                    key_type: {k_ttype},
+                    value_type: {v_ttype},
+                    size: 0,
+                }}) + __protocol.map_end_len();
+                for (key, val) in {ident} {{
+                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
                     if is_exist {{
                         size += {add_key};
                         size += {add_val_with_field_mask};
@@ -1150,6 +1397,17 @@ impl ThriftBackend {
             {
                 self.need_field_mask(v)
             }
+            ty::Map(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.need_field_mask(v)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
             ty::BTreeMap(k, v)
                 if matches!(
                     k.kind,
@@ -1157,6 +1415,17 @@ impl ThriftBackend {
                 ) =>
             {
                 self.need_field_mask(v)
+            }
+            ty::BTreeMap(k, v) if matches!(k.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &k.kind {
+                    if self.is_enum(p.did) {
+                        self.need_field_mask(v)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
             }
             ty::Path(p) if !self.is_i32_enum(p.did) => true,
             _ => false,
@@ -1212,6 +1481,16 @@ impl ThriftBackend {
                             r#"if !{field_mask}.all() {{
                             for (key, item) in {ident}.iter_mut() {{
                                 if let Some(item_fm) = {field_mask}.str(key).0 {{
+                                    {val_field_mask}
+                                }}
+                            }}
+                        }}"#
+                        )
+                        .into(),
+                        ty::Path(..) => format!(
+                            r#"if !{field_mask}.all() {{
+                            for (key, item) in {ident}.iter_mut() {{
+                                if let Some(item_fm) = {field_mask}.int(key.inner() as i32).0 {{
                                     {val_field_mask}
                                 }}
                             }}
@@ -1312,6 +1591,34 @@ impl ThriftBackend {
                     }}"#
                     )
                     .into()
+                } else {
+                    "".into()
+                }
+            }
+            ty::Map(key, val) | ty::BTreeMap(key, val) if matches!(key.kind, ty::Path(..)) => {
+                if let ty::Path(p) = &key.kind {
+                    if self.is_enum(p.did) {
+                        let item_field_mask =
+                            self.codegen_iter_item_field_mask(val, "item".into(), "item_fm".into());
+                        if !item_field_mask.is_empty() {
+                            format!(
+                                r#"if let Some(map_mask) = {field_mask}.field({id}).0 {{
+                              if !map_mask.all() {{
+                                for (key, item) in {ident}.iter_mut() {{
+                                    if let Some(item_fm) = map_mask.int(key.inner() as i32).0 {{
+                                        {item_field_mask}
+                                        }}
+                                    }}
+                                }}
+                          }}"#
+                            )
+                            .into()
+                        } else {
+                            "".into()
+                        }
+                    } else {
+                        "".into()
+                    }
                 } else {
                     "".into()
                 }

--- a/pilota-build/src/test/enum_key_map_tests.rs
+++ b/pilota-build/src/test/enum_key_map_tests.rs
@@ -1,0 +1,255 @@
+use pilota::{AHashMap, FastStr};
+
+// 包含生成的测试代码
+include!("../../test_data/thrift_with_field_mask/enum_key_map.rs");
+
+// 使用正确的模块路径
+use std::collections::{HashMap, HashSet};
+
+use enum_key_map::enum_key_map::{EnumKeyMapTest, Item, Status};
+
+fn create_test_data() -> EnumKeyMapTest {
+    let mut status_map: AHashMap<Status, FastStr> = AHashMap::new();
+    status_map.insert(Status::ACTIVE, FastStr::from_static_str("active_status"));
+    status_map.insert(
+        Status::INACTIVE,
+        FastStr::from_static_str("inactive_status"),
+    );
+
+    let mut status_item_map: AHashMap<Status, Item> = AHashMap::new();
+    status_item_map.insert(
+        Status::ACTIVE,
+        Item {
+            id: 100,
+            name: FastStr::from_static_str("active_item"),
+            _field_mask: None,
+        },
+    );
+    status_item_map.insert(
+        Status::PENDING,
+        Item {
+            id: 200,
+            name: FastStr::from_static_str("pending_item"),
+            _field_mask: None,
+        },
+    );
+
+    let mut status_list_map: AHashMap<Status, Vec<Item>> = AHashMap::new();
+    status_list_map.insert(
+        Status::ACTIVE,
+        vec![
+            Item {
+                id: 1,
+                name: FastStr::from_static_str("list_item_1"),
+                _field_mask: None,
+            },
+            Item {
+                id: 2,
+                name: FastStr::from_static_str("list_item_2"),
+                _field_mask: None,
+            },
+        ],
+    );
+
+    EnumKeyMapTest {
+        status_map,
+        status_item_map,
+        status_list_map: Some(status_list_map),
+        _field_mask: None,
+    }
+}
+
+#[test]
+fn test_enum_key_roundtrip_conversion() {
+    let status = Status::ACTIVE;
+
+    // 测试 enum 到 i32 的转换
+    let i32_val: i32 = status.into();
+    assert_eq!(i32_val, 1);
+
+    // 测试 i32 到 enum 的转换
+    let status_from_i32 = Status::from(2);
+    assert_eq!(status_from_i32, Status::INACTIVE);
+
+    // 测试 inner 方法
+    assert_eq!(status.inner(), 1);
+
+    // 测试 try_from_i32
+    assert_eq!(Status::try_from_i32(3), Some(Status::PENDING));
+    assert_eq!(Status::try_from_i32(999), None);
+}
+
+#[test]
+fn test_enum_key_map_data_integrity() {
+    let test_data = create_test_data();
+
+    // 验证创建的数据完整性
+    assert_eq!(test_data.status_map.len(), 2);
+    assert_eq!(test_data.status_item_map.len(), 2);
+    assert!(test_data.status_list_map.is_some());
+
+    // 验证具体值
+    assert_eq!(
+        test_data.status_map.get(&Status::ACTIVE).unwrap(),
+        &FastStr::from_static_str("active_status")
+    );
+
+    let active_item = test_data.status_item_map.get(&Status::ACTIVE).unwrap();
+    assert_eq!(active_item.id, 100);
+    assert_eq!(active_item.name, FastStr::from_static_str("active_item"));
+
+    let pending_item = test_data.status_item_map.get(&Status::PENDING).unwrap();
+    assert_eq!(pending_item.id, 200);
+    assert_eq!(pending_item.name, FastStr::from_static_str("pending_item"));
+
+    // 验证 list map
+    let list_items = test_data
+        .status_list_map
+        .as_ref()
+        .unwrap()
+        .get(&Status::ACTIVE)
+        .unwrap();
+    assert_eq!(list_items.len(), 2);
+    assert_eq!(list_items[0].id, 1);
+    assert_eq!(list_items[1].id, 2);
+}
+
+#[test]
+fn test_enum_key_hashable_and_comparable() {
+    // 测试 enum 可以作为 HashMap 的 key
+    let mut map: HashMap<Status, String> = HashMap::new();
+    map.insert(Status::ACTIVE, "active".to_string());
+    map.insert(Status::INACTIVE, "inactive".to_string());
+
+    assert_eq!(map.len(), 2);
+    assert_eq!(map.get(&Status::ACTIVE), Some(&"active".to_string()));
+
+    // 测试 enum 可以在 HashSet 中
+    let mut set: HashSet<Status> = HashSet::new();
+    set.insert(Status::ACTIVE);
+    set.insert(Status::PENDING);
+
+    assert_eq!(set.len(), 2);
+    assert!(set.contains(&Status::ACTIVE));
+
+    // 测试 enum 比较
+    assert_eq!(Status::ACTIVE, Status::ACTIVE);
+    assert_ne!(Status::ACTIVE, Status::INACTIVE);
+
+    // 测试排序（enum 应该支持 Ord）
+    let mut statuses = vec![Status::PENDING, Status::ACTIVE, Status::INACTIVE];
+    statuses.sort();
+    assert_eq!(statuses[0], Status::ACTIVE); // value=1
+    assert_eq!(statuses[1], Status::INACTIVE); // value=2
+    assert_eq!(statuses[2], Status::PENDING); // value=3
+}
+
+#[test]
+fn test_enum_key_map_clone_and_debug() {
+    let test_data = create_test_data();
+
+    // 测试 clone
+    let cloned = test_data.clone();
+    assert_eq!(cloned.status_map.len(), test_data.status_map.len());
+    assert_eq!(
+        cloned.status_item_map.len(),
+        test_data.status_item_map.len()
+    );
+
+    // 验证 clone 后的数据独立
+    assert_eq!(
+        cloned.status_map.get(&Status::ACTIVE),
+        test_data.status_map.get(&Status::ACTIVE)
+    );
+
+    // 测试 debug 输出（确保不会 panic）
+    let debug_str = format!("{:?}", cloned);
+    assert!(!debug_str.is_empty());
+    assert!(debug_str.contains("EnumKeyMapTest"));
+}
+
+#[test]
+fn test_enum_key_default_and_partial_construction() {
+    // 测试默认值
+    let default_item = Item::default();
+    assert_eq!(default_item.id, 0);
+    assert_eq!(default_item.name, "");
+    assert!(default_item._field_mask.is_none());
+
+    // 测试部分构造
+    let partial_item = Item {
+        id: 42,
+        ..Default::default()
+    };
+    assert_eq!(partial_item.id, 42);
+    assert_eq!(partial_item.name, "");
+
+    // 测试部分构造的 struct
+    let partial_test = EnumKeyMapTest {
+        status_map: {
+            let mut m = AHashMap::new();
+            m.insert(Status::PENDING, FastStr::from_static_str("pending"));
+            m
+        },
+        ..Default::default()
+    };
+    assert_eq!(partial_test.status_map.len(), 1);
+    assert!(partial_test.status_item_map.is_empty());
+    assert!(partial_test.status_list_map.is_none());
+}
+
+#[test]
+fn test_enum_key_iteration_patterns() {
+    let test_data = create_test_data();
+
+    // 测试迭代所有 key-value 对
+    let mut keys: Vec<&Status> = Vec::new();
+    for key in test_data.status_map.keys() {
+        keys.push(key);
+    }
+    assert_eq!(keys.len(), 2);
+
+    // 测试过滤迭代
+    let active_values: Vec<&FastStr> = test_data
+        .status_map
+        .iter()
+        .filter(|(k, _)| **k == Status::ACTIVE)
+        .map(|(_, v)| v)
+        .collect();
+    assert_eq!(active_values.len(), 1);
+    assert_eq!(*active_values[0], "active_status");
+
+    // 测试修改迭代
+    let mut modified_data = create_test_data();
+    for (key, item) in &mut modified_data.status_item_map {
+        if *key == Status::ACTIVE {
+            item.id += 1000; // ACTIVE 的 id 增加 1000
+        }
+    }
+
+    let active_modified = modified_data.status_item_map.get(&Status::ACTIVE).unwrap();
+    assert_eq!(active_modified.id, 1100); // 原来是 100
+
+    let pending_unmodified = modified_data.status_item_map.get(&Status::PENDING).unwrap();
+    assert_eq!(pending_unmodified.id, 200); // 保持不变
+}
+
+#[test]
+fn test_enum_key_map_equality() {
+    let data1 = create_test_data();
+    let data2 = create_test_data();
+
+    // 相同数据应该相等
+    assert_eq!(data1, data2);
+
+    // 不同数据不应该相等
+    let mut different_data = create_test_data();
+    different_data.status_map.clear();
+    assert_ne!(data1, different_data);
+
+    // 修改某个字段后不应该相等
+    let mut modified_data = create_test_data();
+    *modified_data.status_map.get_mut(&Status::ACTIVE).unwrap() =
+        FastStr::from_static_str("modified");
+    assert_ne!(data1, modified_data);
+}

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -659,3 +659,5 @@ fn test_pb_options() {
             );
     });
 }
+
+mod enum_key_map_tests;

--- a/pilota-build/test_data/thrift_with_field_mask/complex_enum_key_map.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/complex_enum_key_map.rs
@@ -1,0 +1,1299 @@
+pub mod complex_enum_key_map {
+    #![allow(warnings, clippy::all)]
+
+    pub mod complex_enum_key_map {
+
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Priority(i32);
+
+        impl Priority {
+            pub const LOW: Self = Self(1);
+            pub const MEDIUM: Self = Self(2);
+            pub const HIGH: Self = Self(3);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
+
+            pub fn to_string(&self) -> ::std::string::String {
+                match self {
+                    Self(1) => ::std::string::String::from("LOW"),
+                    Self(2) => ::std::string::String::from("MEDIUM"),
+                    Self(3) => ::std::string::String::from("HIGH"),
+                    Self(val) => val.to_string(),
+                }
+            }
+
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
+                match value {
+                    1 => Some(Self::LOW),
+                    2 => Some(Self::MEDIUM),
+                    3 => Some(Self::HIGH),
+                    _ => None,
+                }
+            }
+        }
+
+        impl ::std::convert::From<i32> for Priority {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
+
+        impl ::std::convert::From<Priority> for i32 {
+            fn from(value: Priority) -> i32 {
+                value.0
+            }
+        }
+
+        impl ::pilota::thrift::Message for Priority {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                __protocol.write_i32(self.inner())?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                let value = __protocol.read_i32()?;
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Priority, value: {}", value),
+                        )
+                    },
+                )?)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let value = __protocol.read_i32().await?;
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Priority, value: {}", value),
+                            )
+                        },
+                    )?)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.i32_len(self.inner())
+            }
+        }
+
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct NestedItem {
+            pub value: i32,
+
+            pub label: ::std::option::Option<::pilota::FastStr>,
+            pub _field_mask: ::std::option::Option<::pilota_thrift_fieldmask::FieldMask>,
+        }
+        impl ::pilota::thrift::Message for NestedItem {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        ::std::result::Result::Ok(())
+                    } else {
+                        let struct_ident =
+                            ::pilota::thrift::TStructIdentifier { name: "NestedItem" };
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        let (field_fm, _) = struct_fm.field(1);
+                        __protocol.write_i32_field(1, *&self.value)?;
+                        if let Some(value) = self.label.as_ref() {
+                            let (field_fm, exist) = struct_fm.field(2);
+                            if exist {
+                                __protocol.write_faststr_field(2, (value).clone())?;
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+                } else {
+                    let struct_ident = ::pilota::thrift::TStructIdentifier { name: "NestedItem" };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_i32_field(1, *&self.value)?;
+                    if let Some(value) = self.label.as_ref() {
+                        __protocol.write_faststr_field(2, (value).clone())?;
+                    }
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+                let mut var_2 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1) if field_ident.field_type == ::pilota::thrift::TType::I32 => {
+                                var_1 = Some(__protocol.read_i32()?);
+                            }
+                            Some(2)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_2 = Some(__protocol.read_faststr()?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `NestedItem` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field value is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    value: var_1,
+                    label: var_2,
+                    _field_mask: ::std::option::Option::None,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type == ::pilota::thrift::TType::I32 =>
+                                {
+                                    var_1 = Some(__protocol.read_i32().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_2 = Some(__protocol.read_faststr().await?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `NestedItem` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field value is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        value: var_1,
+                        label: var_2,
+                        _field_mask: ::std::option::Option::None,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        0
+                    } else {
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "NestedItem",
+                        }) + {
+                            let (field_fm, exist) = struct_fm.field(1);
+                            if exist {
+                                __protocol.i32_field_len(Some(1), *&self.value)
+                            } else {
+                                0
+                            }
+                        } + self.label.as_ref().map_or(0, |value| {
+                            let (field_fm, exist) = struct_fm.field(2);
+                            if exist {
+                                __protocol.faststr_field_len(Some(2), value)
+                            } else {
+                                0
+                            }
+                        }) + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                } else {
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "NestedItem",
+                    }) + __protocol.i32_field_len(Some(1), *&self.value)
+                        + self
+                            .label
+                            .as_ref()
+                            .map_or(0, |value| __protocol.faststr_field_len(Some(2), value))
+                        + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+        }
+        impl NestedItem {
+            pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {
+                self._field_mask = Some(field_mask.clone());
+            }
+        }
+
+        #[derive(Debug, Default, Clone, PartialEq)]
+        pub struct ComplexEnumKeyMapTest {
+            pub priority_counts: ::pilota::AHashMap<Priority, i32>,
+
+            pub priority_items: ::pilota::AHashMap<Priority, NestedItem>,
+
+            pub nested_maps:
+                ::pilota::AHashMap<Priority, ::pilota::AHashMap<::pilota::FastStr, i32>>,
+
+            pub priority_item_lists:
+                ::std::option::Option<::pilota::AHashMap<Priority, ::std::vec::Vec<NestedItem>>>,
+            pub _field_mask: ::std::option::Option<::pilota_thrift_fieldmask::FieldMask>,
+        }
+        impl ::pilota::thrift::Message for ComplexEnumKeyMapTest {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        ::std::result::Result::Ok(())
+                    } else {
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "ComplexEnumKeyMapTest",
+                        };
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        let (field_fm, _) = struct_fm.field(1);
+                        if let Some(map_fm) = field_fm {
+                            __protocol.write_field_begin(::pilota::thrift::TType::Map, 1)?;
+                            __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                key_type: ::pilota::thrift::TType::I32,
+                                value_type: ::pilota::thrift::TType::I32,
+                                size: (&self.priority_counts)
+                                    .keys()
+                                    .filter(|key| map_fm.int(key.inner() as i32).1)
+                                    .count(),
+                            })?;
+                            for (key, val) in &self.priority_counts {
+                                let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                if is_exist {
+                                    __protocol.write_struct(key)?;
+                                    __protocol.write_i32(*val)?;
+                                }
+                            }
+                            __protocol.write_map_end()?;
+                            __protocol.write_field_end()?;
+                        } else {
+                            __protocol.write_map_field(
+                                1,
+                                ::pilota::thrift::TType::I32,
+                                ::pilota::thrift::TType::I32,
+                                &&self.priority_counts,
+                                |__protocol, key| {
+                                    __protocol.write_struct(key)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_i32(*val)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                        }
+                        let (field_fm, _) = struct_fm.field(2);
+                        if let Some(map_fm) = field_fm {
+                            __protocol.write_field_begin(::pilota::thrift::TType::Map, 2)?;
+                            __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                key_type: ::pilota::thrift::TType::I32,
+                                value_type: ::pilota::thrift::TType::Struct,
+                                size: (&self.priority_items)
+                                    .keys()
+                                    .filter(|key| map_fm.int(key.inner() as i32).1)
+                                    .count(),
+                            })?;
+                            for (key, val) in &self.priority_items {
+                                let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                if is_exist {
+                                    __protocol.write_struct(key)?;
+                                    __protocol.write_struct(val)?;
+                                }
+                            }
+                            __protocol.write_map_end()?;
+                            __protocol.write_field_end()?;
+                        } else {
+                            __protocol.write_map_field(
+                                2,
+                                ::pilota::thrift::TType::I32,
+                                ::pilota::thrift::TType::Struct,
+                                &&self.priority_items,
+                                |__protocol, key| {
+                                    __protocol.write_struct(key)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_struct(val)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                        }
+                        let (field_fm, _) = struct_fm.field(3);
+                        if let Some(map_fm) = field_fm {
+                            __protocol.write_field_begin(::pilota::thrift::TType::Map, 3)?;
+                            __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                key_type: ::pilota::thrift::TType::I32,
+                                value_type: ::pilota::thrift::TType::Map,
+                                size: (&self.nested_maps)
+                                    .keys()
+                                    .filter(|key| map_fm.int(key.inner() as i32).1)
+                                    .count(),
+                            })?;
+                            for (key, val) in &self.nested_maps {
+                                let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                if is_exist {
+                                    __protocol.write_struct(key)?;
+                                    if let Some(map_fm) = item_fm {
+                                        __protocol.write_map_begin(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::Binary,
+                                                value_type: ::pilota::thrift::TType::I32,
+                                                size: (val)
+                                                    .keys()
+                                                    .filter(|key| map_fm.str(key).1)
+                                                    .count(),
+                                            },
+                                        )?;
+                                        for (key, val) in val {
+                                            let (item_fm, exist) = map_fm.str(key.as_str());
+                                            if exist {
+                                                __protocol.write_faststr((key).clone())?;
+                                                __protocol.write_i32(*val)?;
+                                            }
+                                        }
+                                        __protocol.write_map_end()?;
+                                    } else {
+                                        __protocol.write_map(
+                                            ::pilota::thrift::TType::Binary,
+                                            ::pilota::thrift::TType::I32,
+                                            &val,
+                                            |__protocol, key| {
+                                                __protocol.write_faststr((key).clone())?;
+                                                ::std::result::Result::Ok(())
+                                            },
+                                            |__protocol, val| {
+                                                __protocol.write_i32(*val)?;
+                                                ::std::result::Result::Ok(())
+                                            },
+                                        )?;
+                                    }
+                                }
+                            }
+                            __protocol.write_map_end()?;
+                            __protocol.write_field_end()?;
+                        } else {
+                            __protocol.write_map_field(
+                                3,
+                                ::pilota::thrift::TType::I32,
+                                ::pilota::thrift::TType::Map,
+                                &&self.nested_maps,
+                                |__protocol, key| {
+                                    __protocol.write_struct(key)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_map(
+                                        ::pilota::thrift::TType::Binary,
+                                        ::pilota::thrift::TType::I32,
+                                        &val,
+                                        |__protocol, key| {
+                                            __protocol.write_faststr((key).clone())?;
+                                            ::std::result::Result::Ok(())
+                                        },
+                                        |__protocol, val| {
+                                            __protocol.write_i32(*val)?;
+                                            ::std::result::Result::Ok(())
+                                        },
+                                    )?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                        }
+                        if let Some(value) = self.priority_item_lists.as_ref() {
+                            let (field_fm, exist) = struct_fm.field(4);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    __protocol
+                                        .write_field_begin(::pilota::thrift::TType::Map, 4)?;
+                                    __protocol.write_map_begin(
+                                        ::pilota::thrift::TMapIdentifier {
+                                            key_type: ::pilota::thrift::TType::I32,
+                                            value_type: ::pilota::thrift::TType::List,
+                                            size: (value)
+                                                .keys()
+                                                .filter(|key| map_fm.int(key.inner() as i32).1)
+                                                .count(),
+                                        },
+                                    )?;
+                                    for (key, val) in value {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            __protocol.write_struct(key)?;
+                                            if let Some(list_fm) = item_fm {
+                                                __protocol.write_list_begin(
+                                                    ::pilota::thrift::TListIdentifier {
+                                                        element_type:
+                                                            ::pilota::thrift::TType::Struct,
+                                                        size: (0..(val).len())
+                                                            .filter(|idx| {
+                                                                list_fm.int(*idx as i32).1
+                                                            })
+                                                            .count(),
+                                                    },
+                                                )?;
+                                                let mut idx = 0;
+                                                for val in val {
+                                                    let (item_fm, exist) = list_fm.int(idx as i32);
+                                                    if exist {
+                                                        __protocol.write_struct(val)?;
+                                                    }
+                                                    idx += 1;
+                                                }
+                                                __protocol.write_list_end()?;
+                                            } else {
+                                                __protocol.write_list(
+                                                    ::pilota::thrift::TType::Struct,
+                                                    &val,
+                                                    |__protocol, val| {
+                                                        __protocol.write_struct(val)?;
+                                                        ::std::result::Result::Ok(())
+                                                    },
+                                                )?;
+                                            }
+                                        }
+                                    }
+                                    __protocol.write_map_end()?;
+                                    __protocol.write_field_end()?;
+                                } else {
+                                    __protocol.write_map_field(
+                                        4,
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::List,
+                                        &value,
+                                        |__protocol, key| {
+                                            __protocol.write_struct(key)?;
+                                            ::std::result::Result::Ok(())
+                                        },
+                                        |__protocol, val| {
+                                            __protocol.write_list(
+                                                ::pilota::thrift::TType::Struct,
+                                                &val,
+                                                |__protocol, val| {
+                                                    __protocol.write_struct(val)?;
+                                                    ::std::result::Result::Ok(())
+                                                },
+                                            )?;
+                                            ::std::result::Result::Ok(())
+                                        },
+                                    )?;
+                                }
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+                } else {
+                    let struct_ident = ::pilota::thrift::TStructIdentifier {
+                        name: "ComplexEnumKeyMapTest",
+                    };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_map_field(
+                        1,
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::I32,
+                        &&self.priority_counts,
+                        |__protocol, key| {
+                            __protocol.write_struct(key)?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_i32(*val)?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                    __protocol.write_map_field(
+                        2,
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::Struct,
+                        &&self.priority_items,
+                        |__protocol, key| {
+                            __protocol.write_struct(key)?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_struct(val)?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                    __protocol.write_map_field(
+                        3,
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::Map,
+                        &&self.nested_maps,
+                        |__protocol, key| {
+                            __protocol.write_struct(key)?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_map(
+                                ::pilota::thrift::TType::Binary,
+                                ::pilota::thrift::TType::I32,
+                                &val,
+                                |__protocol, key| {
+                                    __protocol.write_faststr((key).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_i32(*val)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                    if let Some(value) = self.priority_item_lists.as_ref() {
+                        __protocol.write_map_field(
+                            4,
+                            ::pilota::thrift::TType::I32,
+                            ::pilota::thrift::TType::List,
+                            &value,
+                            |__protocol, key| {
+                                __protocol.write_struct(key)?;
+                                ::std::result::Result::Ok(())
+                            },
+                            |__protocol, val| {
+                                __protocol.write_list(
+                                    ::pilota::thrift::TType::Struct,
+                                    &val,
+                                    |__protocol, val| {
+                                        __protocol.write_struct(val)?;
+                                        ::std::result::Result::Ok(())
+                                    },
+                                )?;
+                                ::std::result::Result::Ok(())
+                            },
+                        )?;
+                    }
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+                let mut var_2 = None;
+                let mut var_3 = None;
+                let mut var_4 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_1 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                            __protocol.read_i32()?,
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(2) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_2 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_3 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                            {
+                                                let map_ident = __protocol.read_map_begin()?;
+                                                let mut val = ::pilota::AHashMap::with_capacity(
+                                                    map_ident.size,
+                                                );
+                                                for _ in 0..map_ident.size {
+                                                    val.insert(
+                                                        __protocol.read_faststr()?,
+                                                        __protocol.read_i32()?,
+                                                    );
+                                                }
+                                                __protocol.read_map_end()?;
+                                                val
+                                            },
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(4) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_4 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                            unsafe {
+                                                let list_ident = __protocol.read_list_begin()?;
+                                                let mut val: ::std::vec::Vec<NestedItem> =
+                                                    ::std::vec::Vec::with_capacity(list_ident.size);
+                                                for i in 0..list_ident.size {
+                                                    val.as_mut_ptr().offset(i as isize).write(
+                                                        ::pilota::thrift::Message::decode(
+                                                            __protocol,
+                                                        )?,
+                                                    );
+                                                }
+                                                val.set_len(list_ident.size);
+                                                __protocol.read_list_end()?;
+                                                val
+                                            },
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `ComplexEnumKeyMapTest` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field priority_counts is required".to_string(),
+                    ));
+                };
+                let Some(var_2) = var_2 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field priority_items is required".to_string(),
+                    ));
+                };
+                let Some(var_3) = var_3 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field nested_maps is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    priority_counts: var_1,
+                    priority_items: var_2,
+                    nested_maps: var_3,
+                    priority_item_lists: var_4,
+                    _field_mask: ::std::option::Option::None,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = None;
+                    let mut var_3 = None;
+                    let mut var_4 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_1 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(<Priority as ::pilota::thrift::Message>::decode_async(__protocol).await?, __protocol.read_i32().await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_2 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(<Priority as ::pilota::thrift::Message>::decode_async(__protocol).await?, <NestedItem as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_3 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(<Priority as ::pilota::thrift::Message>::decode_async(__protocol).await?, {
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(__protocol.read_faststr().await?, __protocol.read_i32().await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },Some(4) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_4 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(<Priority as ::pilota::thrift::Message>::decode_async(__protocol).await?, {
+                            let list_ident = __protocol.read_list_begin().await?;
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
+                            for _ in 0..list_ident.size {
+                                val.push(<NestedItem as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+                            };
+                            __protocol.read_list_end().await?;
+                            val
+                        });
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `ComplexEnumKeyMapTest` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field priority_counts is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_2) = var_2 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field priority_items is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_3) = var_3 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field nested_maps is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        priority_counts: var_1,
+                        priority_items: var_2,
+                        nested_maps: var_3,
+                        priority_item_lists: var_4,
+                        _field_mask: ::std::option::Option::None,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        0
+                    } else {
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "ComplexEnumKeyMapTest",
+                        }) + {
+                            let (field_fm, exist) = struct_fm.field(1);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::I32,
+                                                value_type: ::pilota::thrift::TType::I32,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in &self.priority_counts {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            size += __protocol.struct_len(key);
+                                            size += __protocol.i32_len(*val);
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(1),
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::I32,
+                                        &self.priority_counts,
+                                        |__protocol, key| __protocol.struct_len(key),
+                                        |__protocol, val| __protocol.i32_len(*val),
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        } + {
+                            let (field_fm, exist) = struct_fm.field(2);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::I32,
+                                                value_type: ::pilota::thrift::TType::Struct,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in &self.priority_items {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            size += __protocol.struct_len(key);
+                                            size += __protocol.struct_len(val);
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(2),
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::Struct,
+                                        &self.priority_items,
+                                        |__protocol, key| __protocol.struct_len(key),
+                                        |__protocol, val| __protocol.struct_len(val),
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        } + {
+                            let (field_fm, exist) = struct_fm.field(3);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::I32,
+                                                value_type: ::pilota::thrift::TType::Map,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in &self.nested_maps {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            size += __protocol.struct_len(key);
+                                            size += if let Some(map_fm) = item_fm {
+                                                let mut size = __protocol.map_begin_len(
+                                                    ::pilota::thrift::TMapIdentifier {
+                                                        key_type: ::pilota::thrift::TType::Binary,
+                                                        value_type: ::pilota::thrift::TType::I32,
+                                                        size: 0,
+                                                    },
+                                                ) + __protocol.map_end_len();
+                                                for (key, val) in val {
+                                                    let (item_fm, exist) = map_fm.str(key);
+                                                    if exist {
+                                                        size += __protocol.faststr_len(key);
+                                                        size += __protocol.i32_len(*val);
+                                                    }
+                                                }
+                                                size
+                                            } else {
+                                                __protocol.map_len(
+                                                    ::pilota::thrift::TType::Binary,
+                                                    ::pilota::thrift::TType::I32,
+                                                    val,
+                                                    |__protocol, key| __protocol.faststr_len(key),
+                                                    |__protocol, val| __protocol.i32_len(*val),
+                                                )
+                                            };
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(3),
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::Map,
+                                        &self.nested_maps,
+                                        |__protocol, key| __protocol.struct_len(key),
+                                        |__protocol, val| {
+                                            __protocol.map_len(
+                                                ::pilota::thrift::TType::Binary,
+                                                ::pilota::thrift::TType::I32,
+                                                val,
+                                                |__protocol, key| __protocol.faststr_len(key),
+                                                |__protocol, val| __protocol.i32_len(*val),
+                                            )
+                                        },
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        } + self.priority_item_lists.as_ref().map_or(0, |value| {
+                            let (field_fm, exist) = struct_fm.field(4);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::I32,
+                                                value_type: ::pilota::thrift::TType::List,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in value {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            size += __protocol.struct_len(key);
+                                            size += if let Some(list_fm) = item_fm {
+                                                let mut idx = 0;
+                                                let mut size = __protocol.list_begin_len(
+                                                    ::pilota::thrift::TListIdentifier {
+                                                        element_type:
+                                                            ::pilota::thrift::TType::Struct,
+                                                        size: 0,
+                                                    },
+                                                ) + __protocol.list_end_len();
+                                                for el in val {
+                                                    let item_fm = list_fm.int(idx as i32);
+                                                    size += __protocol.struct_len(el);
+                                                    idx += 1;
+                                                }
+                                                size
+                                            } else {
+                                                __protocol.list_len(
+                                                    ::pilota::thrift::TType::Struct,
+                                                    val,
+                                                    |__protocol, el| __protocol.struct_len(el),
+                                                )
+                                            };
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(4),
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::List,
+                                        value,
+                                        |__protocol, key| __protocol.struct_len(key),
+                                        |__protocol, val| {
+                                            __protocol.list_len(
+                                                ::pilota::thrift::TType::Struct,
+                                                val,
+                                                |__protocol, el| __protocol.struct_len(el),
+                                            )
+                                        },
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        }) + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                } else {
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "ComplexEnumKeyMapTest",
+                    }) + __protocol.map_field_len(
+                        Some(1),
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::I32,
+                        &self.priority_counts,
+                        |__protocol, key| __protocol.struct_len(key),
+                        |__protocol, val| __protocol.i32_len(*val),
+                    ) + __protocol.map_field_len(
+                        Some(2),
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::Struct,
+                        &self.priority_items,
+                        |__protocol, key| __protocol.struct_len(key),
+                        |__protocol, val| __protocol.struct_len(val),
+                    ) + __protocol.map_field_len(
+                        Some(3),
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::Map,
+                        &self.nested_maps,
+                        |__protocol, key| __protocol.struct_len(key),
+                        |__protocol, val| {
+                            __protocol.map_len(
+                                ::pilota::thrift::TType::Binary,
+                                ::pilota::thrift::TType::I32,
+                                val,
+                                |__protocol, key| __protocol.faststr_len(key),
+                                |__protocol, val| __protocol.i32_len(*val),
+                            )
+                        },
+                    ) + self.priority_item_lists.as_ref().map_or(0, |value| {
+                        __protocol.map_field_len(
+                            Some(4),
+                            ::pilota::thrift::TType::I32,
+                            ::pilota::thrift::TType::List,
+                            value,
+                            |__protocol, key| __protocol.struct_len(key),
+                            |__protocol, val| {
+                                __protocol.list_len(
+                                    ::pilota::thrift::TType::Struct,
+                                    val,
+                                    |__protocol, el| __protocol.struct_len(el),
+                                )
+                            },
+                        )
+                    }) + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+        }
+        impl ComplexEnumKeyMapTest {
+            pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {
+                self._field_mask = Some(field_mask.clone());
+                if let Some(map_mask) = field_mask.field(2).0 {
+                    if !map_mask.all() {
+                        for (key, item) in self.priority_items.iter_mut() {
+                            if let Some(item_fm) = map_mask.int(key.inner() as i32).0 {
+                                item.set_field_mask(item_fm.clone());
+                            }
+                        }
+                    }
+                }
+                if let Some(value) = &mut self.priority_item_lists {
+                    if let Some(map_mask) = field_mask.field(4).0 {
+                        if !map_mask.all() {
+                            for (key, item) in value.iter_mut() {
+                                if let Some(item_fm) = map_mask.int(key.inner() as i32).0 {
+                                    if !item_fm.all() {
+                                        for (idx, item) in item.iter_mut().enumerate() {
+                                            if let Some(item_fm) = item_fm.int(idx as i32).0 {
+                                                item.set_field_mask(item_fm.clone());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift_with_field_mask/complex_enum_key_map.thrift
+++ b/pilota-build/test_data/thrift_with_field_mask/complex_enum_key_map.thrift
@@ -1,0 +1,17 @@
+enum Priority {
+    Low = 1,
+    Medium = 2,
+    High = 3,
+}
+
+struct NestedItem {
+    1: required i32 value,
+    2: optional string label,
+}
+
+struct ComplexEnumKeyMapTest {
+    1: required map<Priority, i32> priority_counts,
+    2: required map<Priority, NestedItem> priority_items,
+    3: required map<Priority, map<string, i32>> nested_maps,
+    4: optional map<Priority, list<NestedItem>> priority_item_lists,
+}

--- a/pilota-build/test_data/thrift_with_field_mask/enum_key_map.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/enum_key_map.rs
@@ -1,0 +1,1048 @@
+pub mod enum_key_map {
+    #![allow(warnings, clippy::all)]
+
+    pub mod enum_key_map {
+
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq, Copy)]
+        #[repr(transparent)]
+        pub struct Status(i32);
+
+        impl Status {
+            pub const ACTIVE: Self = Self(1);
+            pub const INACTIVE: Self = Self(2);
+            pub const PENDING: Self = Self(3);
+
+            pub fn inner(&self) -> i32 {
+                self.0
+            }
+
+            pub fn to_string(&self) -> ::std::string::String {
+                match self {
+                    Self(1) => ::std::string::String::from("ACTIVE"),
+                    Self(2) => ::std::string::String::from("INACTIVE"),
+                    Self(3) => ::std::string::String::from("PENDING"),
+                    Self(val) => val.to_string(),
+                }
+            }
+
+            pub fn try_from_i32(value: i32) -> ::std::option::Option<Self> {
+                match value {
+                    1 => Some(Self::ACTIVE),
+                    2 => Some(Self::INACTIVE),
+                    3 => Some(Self::PENDING),
+                    _ => None,
+                }
+            }
+        }
+
+        impl ::std::convert::From<i32> for Status {
+            fn from(value: i32) -> Self {
+                Self(value)
+            }
+        }
+
+        impl ::std::convert::From<Status> for i32 {
+            fn from(value: Status) -> i32 {
+                value.0
+            }
+        }
+
+        impl ::pilota::thrift::Message for Status {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                __protocol.write_i32(self.inner())?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                let value = __protocol.read_i32()?;
+                ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                    |err| {
+                        ::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            format!("invalid enum value for Status, value: {}", value),
+                        )
+                    },
+                )?)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let value = __protocol.read_i32().await?;
+                    ::std::result::Result::Ok(::std::convert::TryFrom::try_from(value).map_err(
+                        |err| {
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                format!("invalid enum value for Status, value: {}", value),
+                            )
+                        },
+                    )?)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.i32_len(self.inner())
+            }
+        }
+
+        #[derive(PartialOrd, Hash, Eq, Ord, Debug, Default, Clone, PartialEq)]
+        pub struct Item {
+            pub id: i64,
+
+            pub name: ::pilota::FastStr,
+            pub _field_mask: ::std::option::Option<::pilota_thrift_fieldmask::FieldMask>,
+        }
+        impl ::pilota::thrift::Message for Item {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        ::std::result::Result::Ok(())
+                    } else {
+                        let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Item" };
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        let (field_fm, _) = struct_fm.field(1);
+                        __protocol.write_i64_field(1, *&self.id)?;
+                        let (field_fm, _) = struct_fm.field(2);
+                        __protocol.write_faststr_field(2, (&self.name).clone())?;
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+                } else {
+                    let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Item" };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_i64_field(1, *&self.id)?;
+                    __protocol.write_faststr_field(2, (&self.name).clone())?;
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+                let mut var_2 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1) if field_ident.field_type == ::pilota::thrift::TType::I64 => {
+                                var_1 = Some(__protocol.read_i64()?);
+                            }
+                            Some(2)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_2 = Some(__protocol.read_faststr()?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `Item` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field id is required".to_string(),
+                    ));
+                };
+                let Some(var_2) = var_2 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field name is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    id: var_1,
+                    name: var_2,
+                    _field_mask: ::std::option::Option::None,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type == ::pilota::thrift::TType::I64 =>
+                                {
+                                    var_1 = Some(__protocol.read_i64().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_2 = Some(__protocol.read_faststr().await?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `Item` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field id is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_2) = var_2 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field name is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        id: var_1,
+                        name: var_2,
+                        _field_mask: ::std::option::Option::None,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        0
+                    } else {
+                        __protocol
+                            .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
+                            + {
+                                let (field_fm, exist) = struct_fm.field(1);
+                                if exist {
+                                    __protocol.i64_field_len(Some(1), *&self.id)
+                                } else {
+                                    0
+                                }
+                            }
+                            + {
+                                let (field_fm, exist) = struct_fm.field(2);
+                                if exist {
+                                    __protocol.faststr_field_len(Some(2), &self.name)
+                                } else {
+                                    0
+                                }
+                            }
+                            + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                } else {
+                    __protocol
+                        .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
+                        + __protocol.i64_field_len(Some(1), *&self.id)
+                        + __protocol.faststr_field_len(Some(2), &self.name)
+                        + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+        }
+        impl Item {
+            pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {
+                self._field_mask = Some(field_mask.clone());
+            }
+        }
+
+        #[derive(Debug, Default, Clone, PartialEq)]
+        pub struct EnumKeyMapTest {
+            pub status_map: ::pilota::AHashMap<Status, ::pilota::FastStr>,
+
+            pub status_item_map: ::pilota::AHashMap<Status, Item>,
+
+            pub status_list_map:
+                ::std::option::Option<::pilota::AHashMap<Status, ::std::vec::Vec<Item>>>,
+            pub _field_mask: ::std::option::Option<::pilota_thrift_fieldmask::FieldMask>,
+        }
+        impl ::pilota::thrift::Message for EnumKeyMapTest {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        ::std::result::Result::Ok(())
+                    } else {
+                        let struct_ident = ::pilota::thrift::TStructIdentifier {
+                            name: "EnumKeyMapTest",
+                        };
+                        __protocol.write_struct_begin(&struct_ident)?;
+                        let (field_fm, _) = struct_fm.field(1);
+                        if let Some(map_fm) = field_fm {
+                            __protocol.write_field_begin(::pilota::thrift::TType::Map, 1)?;
+                            __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                key_type: ::pilota::thrift::TType::I32,
+                                value_type: ::pilota::thrift::TType::Binary,
+                                size: (&self.status_map)
+                                    .keys()
+                                    .filter(|key| map_fm.int(key.inner() as i32).1)
+                                    .count(),
+                            })?;
+                            for (key, val) in &self.status_map {
+                                let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                if is_exist {
+                                    __protocol.write_struct(key)?;
+                                    __protocol.write_faststr((val).clone())?;
+                                }
+                            }
+                            __protocol.write_map_end()?;
+                            __protocol.write_field_end()?;
+                        } else {
+                            __protocol.write_map_field(
+                                1,
+                                ::pilota::thrift::TType::I32,
+                                ::pilota::thrift::TType::Binary,
+                                &&self.status_map,
+                                |__protocol, key| {
+                                    __protocol.write_struct(key)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_faststr((val).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                        }
+                        let (field_fm, _) = struct_fm.field(2);
+                        if let Some(map_fm) = field_fm {
+                            __protocol.write_field_begin(::pilota::thrift::TType::Map, 2)?;
+                            __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                key_type: ::pilota::thrift::TType::I32,
+                                value_type: ::pilota::thrift::TType::Struct,
+                                size: (&self.status_item_map)
+                                    .keys()
+                                    .filter(|key| map_fm.int(key.inner() as i32).1)
+                                    .count(),
+                            })?;
+                            for (key, val) in &self.status_item_map {
+                                let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                if is_exist {
+                                    __protocol.write_struct(key)?;
+                                    __protocol.write_struct(val)?;
+                                }
+                            }
+                            __protocol.write_map_end()?;
+                            __protocol.write_field_end()?;
+                        } else {
+                            __protocol.write_map_field(
+                                2,
+                                ::pilota::thrift::TType::I32,
+                                ::pilota::thrift::TType::Struct,
+                                &&self.status_item_map,
+                                |__protocol, key| {
+                                    __protocol.write_struct(key)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_struct(val)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
+                        }
+                        if let Some(value) = self.status_list_map.as_ref() {
+                            let (field_fm, exist) = struct_fm.field(3);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    __protocol
+                                        .write_field_begin(::pilota::thrift::TType::Map, 3)?;
+                                    __protocol.write_map_begin(
+                                        ::pilota::thrift::TMapIdentifier {
+                                            key_type: ::pilota::thrift::TType::I32,
+                                            value_type: ::pilota::thrift::TType::List,
+                                            size: (value)
+                                                .keys()
+                                                .filter(|key| map_fm.int(key.inner() as i32).1)
+                                                .count(),
+                                        },
+                                    )?;
+                                    for (key, val) in value {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            __protocol.write_struct(key)?;
+                                            if let Some(list_fm) = item_fm {
+                                                __protocol.write_list_begin(
+                                                    ::pilota::thrift::TListIdentifier {
+                                                        element_type:
+                                                            ::pilota::thrift::TType::Struct,
+                                                        size: (0..(val).len())
+                                                            .filter(|idx| {
+                                                                list_fm.int(*idx as i32).1
+                                                            })
+                                                            .count(),
+                                                    },
+                                                )?;
+                                                let mut idx = 0;
+                                                for val in val {
+                                                    let (item_fm, exist) = list_fm.int(idx as i32);
+                                                    if exist {
+                                                        __protocol.write_struct(val)?;
+                                                    }
+                                                    idx += 1;
+                                                }
+                                                __protocol.write_list_end()?;
+                                            } else {
+                                                __protocol.write_list(
+                                                    ::pilota::thrift::TType::Struct,
+                                                    &val,
+                                                    |__protocol, val| {
+                                                        __protocol.write_struct(val)?;
+                                                        ::std::result::Result::Ok(())
+                                                    },
+                                                )?;
+                                            }
+                                        }
+                                    }
+                                    __protocol.write_map_end()?;
+                                    __protocol.write_field_end()?;
+                                } else {
+                                    __protocol.write_map_field(
+                                        3,
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::List,
+                                        &value,
+                                        |__protocol, key| {
+                                            __protocol.write_struct(key)?;
+                                            ::std::result::Result::Ok(())
+                                        },
+                                        |__protocol, val| {
+                                            __protocol.write_list(
+                                                ::pilota::thrift::TType::Struct,
+                                                &val,
+                                                |__protocol, val| {
+                                                    __protocol.write_struct(val)?;
+                                                    ::std::result::Result::Ok(())
+                                                },
+                                            )?;
+                                            ::std::result::Result::Ok(())
+                                        },
+                                    )?;
+                                }
+                            }
+                        }
+                        __protocol.write_field_stop()?;
+                        __protocol.write_struct_end()?;
+                        ::std::result::Result::Ok(())
+                    }
+                } else {
+                    let struct_ident = ::pilota::thrift::TStructIdentifier {
+                        name: "EnumKeyMapTest",
+                    };
+
+                    __protocol.write_struct_begin(&struct_ident)?;
+                    __protocol.write_map_field(
+                        1,
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::Binary,
+                        &&self.status_map,
+                        |__protocol, key| {
+                            __protocol.write_struct(key)?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_faststr((val).clone())?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                    __protocol.write_map_field(
+                        2,
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::Struct,
+                        &&self.status_item_map,
+                        |__protocol, key| {
+                            __protocol.write_struct(key)?;
+                            ::std::result::Result::Ok(())
+                        },
+                        |__protocol, val| {
+                            __protocol.write_struct(val)?;
+                            ::std::result::Result::Ok(())
+                        },
+                    )?;
+                    if let Some(value) = self.status_list_map.as_ref() {
+                        __protocol.write_map_field(
+                            3,
+                            ::pilota::thrift::TType::I32,
+                            ::pilota::thrift::TType::List,
+                            &value,
+                            |__protocol, key| {
+                                __protocol.write_struct(key)?;
+                                ::std::result::Result::Ok(())
+                            },
+                            |__protocol, val| {
+                                __protocol.write_list(
+                                    ::pilota::thrift::TType::Struct,
+                                    &val,
+                                    |__protocol, val| {
+                                        __protocol.write_struct(val)?;
+                                        ::std::result::Result::Ok(())
+                                    },
+                                )?;
+                                ::std::result::Result::Ok(())
+                            },
+                        )?;
+                    }
+                    __protocol.write_field_stop()?;
+                    __protocol.write_struct_end()?;
+                    ::std::result::Result::Ok(())
+                }
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+                let mut var_2 = None;
+                let mut var_3 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_1 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                            __protocol.read_faststr()?,
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(2) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_2 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map => {
+                                var_3 = Some({
+                                    let map_ident = __protocol.read_map_begin()?;
+                                    let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                                    for _ in 0..map_ident.size {
+                                        val.insert(
+                                            ::pilota::thrift::Message::decode(__protocol)?,
+                                            unsafe {
+                                                let list_ident = __protocol.read_list_begin()?;
+                                                let mut val: ::std::vec::Vec<Item> =
+                                                    ::std::vec::Vec::with_capacity(list_ident.size);
+                                                for i in 0..list_ident.size {
+                                                    val.as_mut_ptr().offset(i as isize).write(
+                                                        ::pilota::thrift::Message::decode(
+                                                            __protocol,
+                                                        )?,
+                                                    );
+                                                }
+                                                val.set_len(list_ident.size);
+                                                __protocol.read_list_end()?;
+                                                val
+                                            },
+                                        );
+                                    }
+                                    __protocol.read_map_end()?;
+                                    val
+                                });
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `EnumKeyMapTest` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field status_map is required".to_string(),
+                    ));
+                };
+                let Some(var_2) = var_2 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field status_item_map is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    status_map: var_1,
+                    status_item_map: var_2,
+                    status_list_map: var_3,
+                    _field_mask: ::std::option::Option::None,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = None;
+                    let mut var_3 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                    loop {
+
+
+                let field_ident = __protocol.read_field_begin().await?;
+                if field_ident.field_type == ::pilota::thrift::TType::Stop {
+
+                    break;
+                } else {
+
+                }
+                __pilota_decoding_field_id = field_ident.id;
+                match field_ident.id {
+                    Some(1) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_1 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(<Status as ::pilota::thrift::Message>::decode_async(__protocol).await?, __protocol.read_faststr().await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },Some(2) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_2 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(<Status as ::pilota::thrift::Message>::decode_async(__protocol).await?, <Item as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },Some(3) if field_ident.field_type == ::pilota::thrift::TType::Map  => {
+                    var_3 = Some({
+                        let map_ident = __protocol.read_map_begin().await?;
+                        let mut val = ::pilota::AHashMap::with_capacity(map_ident.size);
+                        for _ in 0..map_ident.size {
+                            val.insert(<Status as ::pilota::thrift::Message>::decode_async(__protocol).await?, {
+                            let list_ident = __protocol.read_list_begin().await?;
+                            let mut val = ::std::vec::Vec::with_capacity(list_ident.size);
+                            for _ in 0..list_ident.size {
+                                val.push(<Item as ::pilota::thrift::Message>::decode_async(__protocol).await?);
+                            };
+                            __protocol.read_list_end().await?;
+                            val
+                        });
+                        }
+                        __protocol.read_map_end().await?;
+                        val
+                    });
+
+                },
+                    _ => {
+                        __protocol.skip(field_ident.field_type).await?;
+
+                    },
+                }
+
+                __protocol.read_field_end().await?;
+
+
+            };
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                }.await {
+                if let Some(field_id) = __pilota_decoding_field_id {
+                    err.prepend_msg(&format!("decode struct `EnumKeyMapTest` field(#{}) failed, caused by: ", field_id));
+                }
+                return ::std::result::Result::Err(err);
+            };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field status_map is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_2) = var_2 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field status_item_map is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        status_map: var_1,
+                        status_item_map: var_2,
+                        status_list_map: var_3,
+                        _field_mask: ::std::option::Option::None,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                if let Some(struct_fm) = self._field_mask.as_ref() {
+                    if !struct_fm.exist() {
+                        0
+                    } else {
+                        __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                            name: "EnumKeyMapTest",
+                        }) + {
+                            let (field_fm, exist) = struct_fm.field(1);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::I32,
+                                                value_type: ::pilota::thrift::TType::Binary,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in &self.status_map {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            size += __protocol.struct_len(key);
+                                            size += __protocol.faststr_len(val);
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(1),
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::Binary,
+                                        &self.status_map,
+                                        |__protocol, key| __protocol.struct_len(key),
+                                        |__protocol, val| __protocol.faststr_len(val),
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        } + {
+                            let (field_fm, exist) = struct_fm.field(2);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::I32,
+                                                value_type: ::pilota::thrift::TType::Struct,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in &self.status_item_map {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            size += __protocol.struct_len(key);
+                                            size += __protocol.struct_len(val);
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(2),
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::Struct,
+                                        &self.status_item_map,
+                                        |__protocol, key| __protocol.struct_len(key),
+                                        |__protocol, val| __protocol.struct_len(val),
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        } + self.status_list_map.as_ref().map_or(0, |value| {
+                            let (field_fm, exist) = struct_fm.field(3);
+                            if exist {
+                                if let Some(map_fm) = field_fm {
+                                    let mut size = __protocol
+                                        .field_begin_len(::pilota::thrift::TType::Map, None)
+                                        + __protocol.field_end_len()
+                                        + __protocol.map_begin_len(
+                                            ::pilota::thrift::TMapIdentifier {
+                                                key_type: ::pilota::thrift::TType::I32,
+                                                value_type: ::pilota::thrift::TType::List,
+                                                size: 0,
+                                            },
+                                        )
+                                        + __protocol.map_end_len();
+                                    for (key, val) in value {
+                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                        if is_exist {
+                                            size += __protocol.struct_len(key);
+                                            size += if let Some(list_fm) = item_fm {
+                                                let mut idx = 0;
+                                                let mut size = __protocol.list_begin_len(
+                                                    ::pilota::thrift::TListIdentifier {
+                                                        element_type:
+                                                            ::pilota::thrift::TType::Struct,
+                                                        size: 0,
+                                                    },
+                                                ) + __protocol.list_end_len();
+                                                for el in val {
+                                                    let item_fm = list_fm.int(idx as i32);
+                                                    size += __protocol.struct_len(el);
+                                                    idx += 1;
+                                                }
+                                                size
+                                            } else {
+                                                __protocol.list_len(
+                                                    ::pilota::thrift::TType::Struct,
+                                                    val,
+                                                    |__protocol, el| __protocol.struct_len(el),
+                                                )
+                                            };
+                                        }
+                                    }
+                                    size
+                                } else {
+                                    __protocol.map_field_len(
+                                        Some(3),
+                                        ::pilota::thrift::TType::I32,
+                                        ::pilota::thrift::TType::List,
+                                        value,
+                                        |__protocol, key| __protocol.struct_len(key),
+                                        |__protocol, val| {
+                                            __protocol.list_len(
+                                                ::pilota::thrift::TType::Struct,
+                                                val,
+                                                |__protocol, el| __protocol.struct_len(el),
+                                            )
+                                        },
+                                    )
+                                }
+                            } else {
+                                0
+                            }
+                        }) + __protocol.field_stop_len()
+                            + __protocol.struct_end_len()
+                    }
+                } else {
+                    __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
+                        name: "EnumKeyMapTest",
+                    }) + __protocol.map_field_len(
+                        Some(1),
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::Binary,
+                        &self.status_map,
+                        |__protocol, key| __protocol.struct_len(key),
+                        |__protocol, val| __protocol.faststr_len(val),
+                    ) + __protocol.map_field_len(
+                        Some(2),
+                        ::pilota::thrift::TType::I32,
+                        ::pilota::thrift::TType::Struct,
+                        &self.status_item_map,
+                        |__protocol, key| __protocol.struct_len(key),
+                        |__protocol, val| __protocol.struct_len(val),
+                    ) + self.status_list_map.as_ref().map_or(0, |value| {
+                        __protocol.map_field_len(
+                            Some(3),
+                            ::pilota::thrift::TType::I32,
+                            ::pilota::thrift::TType::List,
+                            value,
+                            |__protocol, key| __protocol.struct_len(key),
+                            |__protocol, val| {
+                                __protocol.list_len(
+                                    ::pilota::thrift::TType::Struct,
+                                    val,
+                                    |__protocol, el| __protocol.struct_len(el),
+                                )
+                            },
+                        )
+                    }) + __protocol.field_stop_len()
+                        + __protocol.struct_end_len()
+                }
+            }
+        }
+        impl EnumKeyMapTest {
+            pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {
+                self._field_mask = Some(field_mask.clone());
+                if let Some(map_mask) = field_mask.field(2).0 {
+                    if !map_mask.all() {
+                        for (key, item) in self.status_item_map.iter_mut() {
+                            if let Some(item_fm) = map_mask.int(key.inner() as i32).0 {
+                                item.set_field_mask(item_fm.clone());
+                            }
+                        }
+                    }
+                }
+                if let Some(value) = &mut self.status_list_map {
+                    if let Some(map_mask) = field_mask.field(3).0 {
+                        if !map_mask.all() {
+                            for (key, item) in value.iter_mut() {
+                                if let Some(item_fm) = map_mask.int(key.inner() as i32).0 {
+                                    if !item_fm.all() {
+                                        for (idx, item) in item.iter_mut().enumerate() {
+                                            if let Some(item_fm) = item_fm.int(idx as i32).0 {
+                                                item.set_field_mask(item_fm.clone());
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift_with_field_mask/enum_key_map.thrift
+++ b/pilota-build/test_data/thrift_with_field_mask/enum_key_map.thrift
@@ -1,0 +1,16 @@
+enum Status {
+    Active = 1,
+    Inactive = 2,
+    Pending = 3,
+}
+
+struct Item {
+    1: required i64 id,
+    2: required string name,
+}
+
+struct EnumKeyMapTest {
+    1: required map<Status, string> status_map,
+    2: required map<Status, Item> status_item_map,
+    3: optional map<Status, list<Item>> status_list_map,
+}

--- a/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
@@ -238,13 +238,6 @@ pub mod struct_init_with_field_mask {
             }
         }
         impl Item {
-            pub fn get_descriptor()
-            -> Option<&'static ::pilota_thrift_reflect::thrift_reflection::StructDescriptor>
-            {
-                let file_descriptor = get_file_descriptor_struct_init_with_field_mask();
-                file_descriptor.find_struct_by_name("Item")
-            }
-
             pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {
                 self._field_mask = Some(field_mask.clone());
             }
@@ -869,13 +862,6 @@ pub mod struct_init_with_field_mask {
             }
         }
         impl GetItemRequest {
-            pub fn get_descriptor()
-            -> Option<&'static ::pilota_thrift_reflect::thrift_reflection::StructDescriptor>
-            {
-                let file_descriptor = get_file_descriptor_struct_init_with_field_mask();
-                file_descriptor.find_struct_by_name("GetItemRequest")
-            }
-
             pub fn set_field_mask(&mut self, field_mask: ::pilota_thrift_fieldmask::FieldMask) {
                 self._field_mask = Some(field_mask.clone());
                 if let Some(value) = &mut self.item_opt {

--- a/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
@@ -23,14 +23,10 @@ pub mod struct_init_with_field_mask {
                     } else {
                         let struct_ident = ::pilota::thrift::TStructIdentifier { name: "Item" };
                         __protocol.write_struct_begin(&struct_ident)?;
-                        let (field_fm, exist) = struct_fm.field(1);
-                        if exist {
-                            __protocol.write_i64_field(1, *&self.id)?;
-                        }
-                        let (field_fm, exist) = struct_fm.field(2);
-                        if exist {
-                            __protocol.write_faststr_field(2, (&self.title).clone())?;
-                        }
+                        let (field_fm, _) = struct_fm.field(1);
+                        __protocol.write_i64_field(1, *&self.id)?;
+                        let (field_fm, _) = struct_fm.field(2);
+                        __protocol.write_faststr_field(2, (&self.title).clone())?;
                         __protocol.write_field_stop()?;
                         __protocol.write_struct_end()?;
                         ::std::result::Result::Ok(())
@@ -316,10 +312,8 @@ pub mod struct_init_with_field_mask {
                             name: "GetItemRequest",
                         };
                         __protocol.write_struct_begin(&struct_ident)?;
-                        let (field_fm, exist) = struct_fm.field(1);
-                        if exist {
-                            __protocol.write_i64_field(1, *&self.id)?;
-                        }
+                        let (field_fm, _) = struct_fm.field(1);
+                        __protocol.write_i64_field(1, *&self.id)?;
                         if let Some(value) = self.item_opt.as_ref() {
                             let (field_fm, exist) = struct_fm.field(2);
                             if exist {
@@ -340,81 +334,77 @@ pub mod struct_init_with_field_mask {
                                 )?;
                             }
                         }
-                        let (field_fm, exist) = struct_fm.field(4);
-                        if exist {
-                            if let Some(map_fm) = field_fm {
-                                __protocol.write_field_begin(::pilota::thrift::TType::Map, 4)?;
-                                __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
-                                    key_type: ::pilota::thrift::TType::Binary,
-                                    value_type: ::pilota::thrift::TType::Binary,
-                                    size: (&self.test_map)
-                                        .keys()
-                                        .filter(|key| map_fm.str(key).1)
-                                        .count(),
-                                })?;
-                                for (key, val) in &self.test_map {
-                                    let (item_fm, is_exist) = map_fm.str(key);
-                                    if is_exist {
-                                        __protocol.write_faststr((key).clone())?;
-                                        __protocol.write_faststr((val).clone())?;
-                                    }
+                        let (field_fm, _) = struct_fm.field(4);
+                        if let Some(map_fm) = field_fm {
+                            __protocol.write_field_begin(::pilota::thrift::TType::Map, 4)?;
+                            __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                key_type: ::pilota::thrift::TType::Binary,
+                                value_type: ::pilota::thrift::TType::Binary,
+                                size: (&self.test_map)
+                                    .keys()
+                                    .filter(|key| map_fm.str(key).1)
+                                    .count(),
+                            })?;
+                            for (key, val) in &self.test_map {
+                                let (item_fm, is_exist) = map_fm.str(key);
+                                if is_exist {
+                                    __protocol.write_faststr((key).clone())?;
+                                    __protocol.write_faststr((val).clone())?;
                                 }
-                                __protocol.write_map_end()?;
-                                __protocol.write_field_end()?;
-                            } else {
-                                __protocol.write_map_field(
-                                    4,
-                                    ::pilota::thrift::TType::Binary,
-                                    ::pilota::thrift::TType::Binary,
-                                    &&self.test_map,
-                                    |__protocol, key| {
-                                        __protocol.write_faststr((key).clone())?;
-                                        ::std::result::Result::Ok(())
-                                    },
-                                    |__protocol, val| {
-                                        __protocol.write_faststr((val).clone())?;
-                                        ::std::result::Result::Ok(())
-                                    },
-                                )?;
                             }
+                            __protocol.write_map_end()?;
+                            __protocol.write_field_end()?;
+                        } else {
+                            __protocol.write_map_field(
+                                4,
+                                ::pilota::thrift::TType::Binary,
+                                ::pilota::thrift::TType::Binary,
+                                &&self.test_map,
+                                |__protocol, key| {
+                                    __protocol.write_faststr((key).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_faststr((val).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
                         }
-                        let (field_fm, exist) = struct_fm.field(5);
-                        if exist {
-                            if let Some(map_fm) = field_fm {
-                                __protocol.write_field_begin(::pilota::thrift::TType::Map, 5)?;
-                                __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
-                                    key_type: ::pilota::thrift::TType::I64,
-                                    value_type: ::pilota::thrift::TType::Binary,
-                                    size: (&self.test_map2)
-                                        .keys()
-                                        .filter(|key| map_fm.int(**key as i32).1)
-                                        .count(),
-                                })?;
-                                for (key, val) in &self.test_map2 {
-                                    let (item_fm, is_exist) = map_fm.int(*key as i32);
-                                    if is_exist {
-                                        __protocol.write_i64(*key)?;
-                                        __protocol.write_faststr((val).clone())?;
-                                    }
+                        let (field_fm, _) = struct_fm.field(5);
+                        if let Some(map_fm) = field_fm {
+                            __protocol.write_field_begin(::pilota::thrift::TType::Map, 5)?;
+                            __protocol.write_map_begin(::pilota::thrift::TMapIdentifier {
+                                key_type: ::pilota::thrift::TType::I64,
+                                value_type: ::pilota::thrift::TType::Binary,
+                                size: (&self.test_map2)
+                                    .keys()
+                                    .filter(|key| map_fm.int(**key as i32).1)
+                                    .count(),
+                            })?;
+                            for (key, val) in &self.test_map2 {
+                                let (item_fm, is_exist) = map_fm.int(*key as i32);
+                                if is_exist {
+                                    __protocol.write_i64(*key)?;
+                                    __protocol.write_faststr((val).clone())?;
                                 }
-                                __protocol.write_map_end()?;
-                                __protocol.write_field_end()?;
-                            } else {
-                                __protocol.write_map_field(
-                                    5,
-                                    ::pilota::thrift::TType::I64,
-                                    ::pilota::thrift::TType::Binary,
-                                    &&self.test_map2,
-                                    |__protocol, key| {
-                                        __protocol.write_i64(*key)?;
-                                        ::std::result::Result::Ok(())
-                                    },
-                                    |__protocol, val| {
-                                        __protocol.write_faststr((val).clone())?;
-                                        ::std::result::Result::Ok(())
-                                    },
-                                )?;
                             }
+                            __protocol.write_map_end()?;
+                            __protocol.write_field_end()?;
+                        } else {
+                            __protocol.write_map_field(
+                                5,
+                                ::pilota::thrift::TType::I64,
+                                ::pilota::thrift::TType::Binary,
+                                &&self.test_map2,
+                                |__protocol, key| {
+                                    __protocol.write_i64(*key)?;
+                                    ::std::result::Result::Ok(())
+                                },
+                                |__protocol, val| {
+                                    __protocol.write_faststr((val).clone())?;
+                                    ::std::result::Result::Ok(())
+                                },
+                            )?;
                         }
                         __protocol.write_field_stop()?;
                         __protocol.write_struct_end()?;

--- a/pilota-thrift-fieldmask/Cargo.toml
+++ b/pilota-thrift-fieldmask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-fieldmask"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-fieldmask/src/fieldmask.rs
+++ b/pilota-thrift-fieldmask/src/fieldmask.rs
@@ -638,7 +638,8 @@ impl FieldMask {
                     || (self.is_black && !self.all() && !field_fm.is_some_and(|f| f.all()));
                 (field_fm, is_exist)
             }
-            _ => (None, self.is_black), // not match, return true if black mode
+            FieldMaskData::Scalar => (None, !self.is_black), // Scalar means all fields
+            _ => (None, self.is_black),                      // not match, return true if black mode
         }
     }
 
@@ -1755,5 +1756,97 @@ mod tests {
             .unwrap();
         assert!(exist);
         assert!(sub_fm.unwrap().all());
+    }
+
+    #[test]
+    fn test_struct_field_with_scalar_mask() {
+        let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
+        ast.path = Arc::from(
+            PathBuf::from("../examples/idl/fieldmask.thrift")
+                .canonicalize()
+                .unwrap(),
+        );
+        let desc: pilota_thrift_reflect::thrift_reflection::FileDescriptor = (&ast).into();
+        let key = FastStr::new(ast.path.to_string_lossy());
+        pilota_thrift_reflect::service::Register::register(key, desc.clone());
+
+        let req_desc = desc.find_struct_by_name("Request").unwrap();
+
+        let paths = &["$.f15{\"key1\"}"];
+        let fm = FieldMaskBuilder::new(&req_desc.type_descriptor(), paths)
+            .build()
+            .unwrap();
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key1\"}.a")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key1\"}.b")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key2\"}.a")
+            .unwrap();
+        assert!(!exist);
+        assert!(sub_fm.is_none());
+    }
+
+    #[test]
+    fn test_struct_field_with_scalar_mask_black_list_mode() {
+        let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
+        ast.path = Arc::from(
+            PathBuf::from("../examples/idl/fieldmask.thrift")
+                .canonicalize()
+                .unwrap(),
+        );
+        let desc: pilota_thrift_reflect::thrift_reflection::FileDescriptor = (&ast).into();
+        let key = FastStr::new(ast.path.to_string_lossy());
+        pilota_thrift_reflect::service::Register::register(key, desc.clone());
+
+        let req_desc = desc.find_struct_by_name("Request").unwrap();
+
+        let paths = &["$.f15{\"key1\"}"];
+        let fm = FieldMaskBuilder::new(&req_desc.type_descriptor(), paths)
+            .with_options(Options::new().with_black_list_mode(true))
+            .build()
+            .unwrap();
+
+        let (_sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key1\"}.a")
+            .unwrap();
+        assert!(!exist);
+
+        let (_sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key1\"}.b")
+            .unwrap();
+        assert!(!exist);
+
+        let (_sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key2\"}.a")
+            .unwrap();
+        assert!(exist);
     }
 }

--- a/pilota-thrift-fieldmask/src/fieldmask.rs
+++ b/pilota-thrift-fieldmask/src/fieldmask.rs
@@ -639,7 +639,8 @@ impl FieldMask {
                 (field_fm, is_exist)
             }
             FieldMaskData::Scalar => (None, !self.is_black), // Scalar means all fields
-            _ => (None, self.is_black),                      // not match, return true if black mode
+            _ => (None, self.is_black),                      /* not match, return true if black
+                                                               * mode */
         }
     }
 
@@ -1081,27 +1082,25 @@ impl FieldMask {
     }
 
     #[inline]
-    fn set_int_key_mask(&mut self, id: i32, data: FieldMaskData) {
+    fn set_int_key_mask(&mut self, id: i32, data: FieldMaskData) -> &mut FieldMask {
         let is_black = self.is_black;
         match &mut self.data {
             FieldMaskData::List { children, .. } | FieldMaskData::IntMap { children, .. } => {
                 children
                     .entry(id)
-                    .or_insert_with(|| Box::new(FieldMask { is_black, data }));
+                    .or_insert_with(|| Box::new(FieldMask { is_black, data }))
             }
             other => panic!("Cannot set int on {:?}", other.type_name()),
         }
     }
 
     #[inline]
-    fn set_str_key_mask(&mut self, id: FastStr, data: FieldMaskData) {
+    fn set_str_key_mask(&mut self, id: FastStr, data: FieldMaskData) -> &mut FieldMask {
         let is_black = self.is_black;
         match &mut self.data {
-            FieldMaskData::StrMap { children, .. } => {
-                children
-                    .entry(id)
-                    .or_insert_with(|| Box::new(FieldMask { is_black, data }));
-            }
+            FieldMaskData::StrMap { children, .. } => children
+                .entry(id)
+                .or_insert_with(|| Box::new(FieldMask { is_black, data })),
             other => panic!("Cannot set str on {:?}", other.type_name()),
         }
     }
@@ -1339,13 +1338,10 @@ impl FieldMask {
                 self.set_int_key_mask(id, FieldMaskData::Scalar);
             }
         } else {
-            let mut sub_mask = FieldMask {
-                is_black: self.is_black,
-                data: FieldMaskData::new(element_desc),
-            };
-            sub_mask.add_path(it, element_desc, original_path)?;
             for id in ids {
-                self.set_int_key_mask(id, sub_mask.data.clone());
+                let sub_mask = self.set_int_key_mask(id, FieldMaskData::new(element_desc));
+                let mut it_clone = (*it).clone();
+                sub_mask.add_path(&mut it_clone, element_desc, original_path)?;
             }
         }
         Ok(())
@@ -1480,19 +1476,18 @@ impl FieldMask {
                 }
             }
         } else {
-            let mut sub_mask = FieldMask {
-                is_black: self.is_black,
-                data: FieldMaskData::new(element_desc),
-            };
-            sub_mask.add_path(it, element_desc, original_path)?;
-
             if is_int_map {
                 for id in int_keys {
-                    self.set_int_key_mask(id, sub_mask.data.clone());
+                    let sub_mask = self.set_int_key_mask(id, FieldMaskData::new(element_desc));
+                    let mut it_clone = (*it).clone();
+                    sub_mask.add_path(&mut it_clone, element_desc, original_path)?;
                 }
             } else {
                 for key in str_keys {
-                    self.set_str_key_mask(FastStr::new(key), sub_mask.data.clone());
+                    let sub_mask =
+                        self.set_str_key_mask(FastStr::new(key), FieldMaskData::new(element_desc));
+                    let mut it_clone = (*it).clone();
+                    sub_mask.add_path(&mut it_clone, element_desc, original_path)?;
                 }
             }
         }
@@ -1848,5 +1843,194 @@ mod tests {
             .get_path(&req_desc.type_descriptor(), "$.f15{\"key2\"}.a")
             .unwrap();
         assert!(exist);
+    }
+
+    #[test]
+    fn test_str_map_multi_path_merge_same_key() {
+        let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
+        ast.path = Arc::from(
+            PathBuf::from("../examples/idl/fieldmask.thrift")
+                .canonicalize()
+                .unwrap(),
+        );
+        let desc: pilota_thrift_reflect::thrift_reflection::FileDescriptor = (&ast).into();
+        let key = FastStr::new(ast.path.to_string_lossy());
+        pilota_thrift_reflect::service::Register::register(key, desc.clone());
+
+        let req_desc = desc.find_struct_by_name("Request").unwrap();
+
+        let paths = &["$.f15{\"key1\"}.a", "$.f15{\"key1\"}.b"];
+        let fm = FieldMaskBuilder::new(&req_desc.type_descriptor(), paths)
+            .build()
+            .unwrap();
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key1\"}.a")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key1\"}.b")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (_sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key2\"}.a")
+            .unwrap();
+        assert!(!exist);
+    }
+
+    #[test]
+    fn test_list_index_multi_path_merge() {
+        let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
+        ast.path = Arc::from(
+            PathBuf::from("../examples/idl/fieldmask.thrift")
+                .canonicalize()
+                .unwrap(),
+        );
+        let desc: pilota_thrift_reflect::thrift_reflection::FileDescriptor = (&ast).into();
+        let key = FastStr::new(ast.path.to_string_lossy());
+        pilota_thrift_reflect::service::Register::register(key, desc.clone());
+
+        let req_desc = desc.find_struct_by_name("Request").unwrap();
+
+        let paths = &["$.f13[0].a", "$.f13[0].b"];
+        let fm = FieldMaskBuilder::new(&req_desc.type_descriptor(), paths)
+            .build()
+            .unwrap();
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f13[0].a")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f13[0].b")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (_sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f13[1].a")
+            .unwrap();
+        assert!(!exist);
+    }
+
+    #[test]
+    fn test_int_map_multi_path_merge() {
+        let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
+        ast.path = Arc::from(
+            PathBuf::from("../examples/idl/fieldmask.thrift")
+                .canonicalize()
+                .unwrap(),
+        );
+        let desc: pilota_thrift_reflect::thrift_reflection::FileDescriptor = (&ast).into();
+        let key = FastStr::new(ast.path.to_string_lossy());
+        pilota_thrift_reflect::service::Register::register(key, desc.clone());
+
+        let req_desc = desc.find_struct_by_name("Request").unwrap();
+
+        let paths = &["$.f14{1}", "$.f14{2}"];
+        let fm = FieldMaskBuilder::new(&req_desc.type_descriptor(), paths)
+            .build()
+            .unwrap();
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f14{1}")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f14{2}")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (_sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f14{3}")
+            .unwrap();
+        assert!(!exist);
+    }
+
+    #[test]
+    fn test_different_keys_independent() {
+        let content = std::fs::read_to_string("../examples/idl/fieldmask.thrift").unwrap();
+        let mut ast = pilota_thrift_parser::FileParser::new(
+            pilota_thrift_parser::FileSource::new_with_path(
+                PathBuf::from("../examples/idl/fieldmask.thrift"),
+                &content,
+            )
+            .unwrap(),
+        )
+        .parse()
+        .unwrap();
+        ast.path = Arc::from(
+            PathBuf::from("../examples/idl/fieldmask.thrift")
+                .canonicalize()
+                .unwrap(),
+        );
+        let desc: pilota_thrift_reflect::thrift_reflection::FileDescriptor = (&ast).into();
+        let key = FastStr::new(ast.path.to_string_lossy());
+        pilota_thrift_reflect::service::Register::register(key, desc.clone());
+
+        let req_desc = desc.find_struct_by_name("Request").unwrap();
+
+        let paths = &["$.f15{\"key1\"}.a", "$.f15{\"key2\"}.b"];
+        let fm = FieldMaskBuilder::new(&req_desc.type_descriptor(), paths)
+            .build()
+            .unwrap();
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key1\"}.a")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (_sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key1\"}.b")
+            .unwrap();
+        assert!(!exist);
+
+        let (sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key2\"}.b")
+            .unwrap();
+        assert!(exist);
+        assert!(sub_fm.unwrap().all());
+
+        let (_sub_fm, exist) = fm
+            .get_path(&req_desc.type_descriptor(), "$.f15{\"key2\"}.a")
+            .unwrap();
+        assert!(!exist);
     }
 }


### PR DESCRIPTION
## Motivation

Fix some unexpected behavior for thrift field mask.

### Required fields gated by field mask

Pilota-generated code checks `_field_mask.field(id)` for ALL fields, including `required`
ones. If the field mask selects `$.some_struct.optional_field` but not `$.some_struct.required_field`, the required
`required_field` field is omitted from the output.

### Scalar not treated as all fields while map encoding

`set_field_mask(fm)` propagates a **scalar (leaf)** FieldMask to each map value struct's
`_field_mask` field. A scalar FM has no field-level children, so all inner fields are gated and NOT serialized.

## Solution

1. Do not check existence of required field mask while encoding.
2. Treat Scalar as all fields.
