### PR TITLE
fix(pilota-thrift-parser): incomplete escape support in string constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode
 .idea
 .trae
+.codex
 **/target
 
 */src/test/gen/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "ahash",
  "anyhow",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.13.8"
+version = "0.13.9"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/middle/context.rs
+++ b/pilota-build/src/middle/context.rs
@@ -1224,14 +1224,21 @@ impl Context {
 
                 self.ident_into_ty(p.did, &ident_ty, ty)
             }
-            (Literal::String(s), CodegenTy::Str) => (format!("\"{s}\"").into(), true),
-            (Literal::String(s), CodegenTy::String) => {
-                (format! {"\"{s}\".to_string()"}.into(), false)
+            (Literal::String(s), CodegenTy::Str) => {
+                let escaped = s.escape_debug().to_string();
+                (format!("\"{escaped}\"").into(), true)
             }
-            (Literal::String(s), CodegenTy::FastStr) => (
-                format! { "::pilota::FastStr::from_static_str(\"{s}\")" }.into(),
-                true,
-            ),
+            (Literal::String(s), CodegenTy::String) => {
+                let escaped = s.escape_debug().to_string();
+                (format!("\"{escaped}\".to_string()").into(), false)
+            }
+            (Literal::String(s), CodegenTy::FastStr) => {
+                let escaped = s.escape_debug().to_string();
+                (
+                    format!("::pilota::FastStr::from_static_str(\"{escaped}\")").into(),
+                    true,
+                )
+            }
             (Literal::Int(i), CodegenTy::I8) => (format! { "{i}i8" }.into(), true),
             (Literal::Int(i), CodegenTy::I16) => (format! { "{i}i16" }.into(), true),
             (Literal::Int(i), CodegenTy::I32) => (format! { "{i}i32" }.into(), true),
@@ -1337,9 +1344,9 @@ impl Context {
                 (format! { "{b}" }.into(), true)
             }
             (Literal::String(s), CodegenTy::Bytes) => {
-                let s = &**s;
+                let escaped = s.escape_debug().to_string();
                 (
-                    format! { "::pilota::Bytes::from_static(\"{s}\".as_bytes())" }.into(),
+                    format!("::pilota::Bytes::from_static(\"{escaped}\".as_bytes())").into(),
                     true,
                 )
             }

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.13.4"
+version = "0.13.5"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-parser/src/parser/literal.rs
+++ b/pilota-thrift-parser/src/parser/literal.rs
@@ -5,11 +5,20 @@ use super::super::descriptor::Literal;
 fn quoted_string<'a>(quote: char) -> impl Parser<'a, &'a str, String, extra::Err<Rich<'a, char>>> {
     let normal_char = none_of([quote, '\\']);
 
-    let escape_char = just('\\').ignore_then(one_of(['\'', '"', 'n', '\\']));
+    let escape_char = just('\\').ignore_then(one_of([
+        '\'', '"', '\\', 'n', 't', 'r', '0', 'a', 'b', 'f', 'v',
+    ]));
 
     let content_char = escape_char
         .map(|c| match c {
             'n' => '\n',
+            't' => '\t',
+            'r' => '\r',
+            '0' => '\0',
+            'a' => '\x07',
+            'b' => '\x08',
+            'f' => '\x0C',
+            'v' => '\x0B',
             other => other,
         })
         .or(normal_char);
@@ -45,5 +54,12 @@ mod tests {
         let _ = Literal::parse().parse(r#"'hello\nworld'"#).unwrap();
         let _ = Literal::parse().parse(r#"'hello\\world'"#).unwrap();
         let _ = Literal::parse().parse(r#"'hello\"world'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\tworld'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\rworld'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\0world'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\aworld'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\bworld'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\fworld'"#).unwrap();
+        let _ = Literal::parse().parse(r#"'hello\vworld'"#).unwrap();
     }
 }


### PR DESCRIPTION
## Motivation

Currently, only few escape characters are supported by pilota-thrift-parser.

## Solution

Add \t, \r, \0, \a, \b, \f, \v support.