### PR TITLE
fix(pilota-thrift-parser): allow whitespace before set type parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.13.5"
+version = "0.13.6"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -57,8 +57,7 @@ impl Type {
                         .ignore_then(CppType::parse())
                         .or_not(),
                 )
-                .then_ignore(just("<"))
-                .padded_by(Components::blank_with_comments().or_not())
+                .then_ignore(just("<").padded_by(Components::blank_with_comments().or_not()))
                 .then(self_parser.clone())
                 .then_ignore(Components::blank_with_comments().or_not())
                 .then_ignore(just(">"))
@@ -122,6 +121,41 @@ mod tests {
         let _res = parser.parse(input).unwrap();
 
         let input = "set<i32>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "set <i32>";
+        let _res = parser.parse(input).unwrap();
+    }
+
+    #[test]
+    fn test_container_type_spacing_and_cpp_type() {
+        let parser = Type::get_parser();
+
+        let input = "list <i32>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "set <i32>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "map <i32, string>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "list /* comment */ <i32>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "set /* comment */ <i32>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "map /* comment */ <i32, string>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "list<i32> cpp_type \"Vec\"";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "set cpp_type \"HashSet\" <i32>";
+        let _res = parser.parse(input).unwrap();
+
+        let input = "map cpp_type \"HashMap\" <i32, string>";
         let _res = parser.parse(input).unwrap();
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
