### PR TITLE
feat: support idl field name preservation for SerdePlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.13.9"
+version = "0.13.10"
 dependencies = [
  "ahash",
  "anyhow",

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -345,6 +345,36 @@ fn test_thrift_fieldmask() {
     let mut protocol = pilota::thrift::binary::TBinaryProtocol::new(&mut encoded_buf, true);
     let parsed_request = fieldmask::fieldmask::fieldmask::Request::decode(&mut protocol).unwrap();
     println!("{:?}", parsed_request);
+
+    // 白名单模式，且 mask 不包含 required 字段 f9：f9 的 field mask `exist` 为
+    // false。 required 字段不应被 field mask 门控，因此 f9
+    // 必须照常编码。这里断言 size() 与 encode() 写出的字节数一致，从而回归验证
+    // size 生成器与 encode 生成器对 required 字段的处理保持一致（否则 framed
+    // 传输的长度前缀会与实际载荷不符）。
+    let mut request_required = request_clone.clone();
+    let required_mask = pilota_thrift_fieldmask::FieldMaskBuilder::new(&desc, &["$.f1"])
+        .build()
+        .unwrap();
+    request_required.set_field_mask(required_mask);
+
+    let required_size =
+        request_required.size(&mut pilota::thrift::binary::TBinaryProtocol::new((), false));
+    let mut required_buf = pilota::BytesMut::new();
+    request_required
+        .encode(&mut pilota::thrift::binary::TBinaryProtocol::new(
+            &mut required_buf,
+            false,
+        ))
+        .unwrap();
+    assert_eq!(required_size, required_buf.len());
+
+    let mut required_encoded = required_buf.freeze();
+    let mut required_protocol =
+        pilota::thrift::binary::TBinaryProtocol::new(&mut required_encoded, false);
+    let required_parsed =
+        fieldmask::fieldmask::fieldmask::Request::decode(&mut required_protocol).unwrap();
+    // required 字段即使不在白名单中也必须被序列化并可解码回来。
+    assert_eq!(required_parsed.f9, request_clone.f9);
 }
 
 #[test]

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.13.9"
+version = "0.13.10"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -94,12 +94,8 @@ impl ThriftBackend {
                 );
                 format! {
                     r#"{{
-                        let (field_fm, exist) = struct_fm.field({field_id});
-                        if exist {{
-                            {write_field_size_with_field_mask}
-                        }} else {{
-                            0
-                        }}
+                        let (field_fm, _) = struct_fm.field({field_id});
+                        {write_field_size_with_field_mask}
                     }}"#
                 }
                 .into()

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 mod serde;
 mod workspace;
 
-pub use self::serde::{SerdePlugin, SerdePreserveIdlNamesPlugin};
+pub use self::serde::SerdePlugin;
 
 pub trait Plugin: Sync + Send {
     fn on_codegen_uint(&mut self, cx: &Context, items: &[DefId]) {

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 mod serde;
 mod workspace;
 
-pub use self::serde::SerdePlugin;
+pub use self::serde::{SerdePlugin, SerdeRenamePlugin};
 
 pub trait Plugin: Sync + Send {
     fn on_codegen_uint(&mut self, cx: &Context, items: &[DefId]) {

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 mod serde;
 mod workspace;
 
-pub use self::serde::{SerdePlugin, SerdeRenamePlugin};
+pub use self::serde::{SerdePlugin, SerdePreserveIdlNamesPlugin};
 
 pub trait Plugin: Sync + Send {
     fn on_codegen_uint(&mut self, cx: &Context, items: &[DefId]) {

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 mod serde;
 mod workspace;
 
-pub use self::serde::SerdePlugin;
+pub use self::serde::{ConfiguredSerdePlugin, SerdePlugin};
 
 pub trait Plugin: Sync + Send {
     fn on_codegen_uint(&mut self, cx: &Context, items: &[DefId]) {

--- a/pilota-build/src/plugin/serde.rs
+++ b/pilota-build/src/plugin/serde.rs
@@ -3,6 +3,42 @@ use crate::tags::SerdeAttribute;
 #[derive(Clone, Copy)]
 pub struct SerdePlugin;
 
+/// Emits `#[serde(rename = "..")]` on every field, so serialized output keeps
+/// the field names as spelled in the IDL rather than the snake_case idents
+/// generated for Rust.
+///
+/// Only meaningful next to [`SerdePlugin`], which emits the derives these
+/// attributes attach to; this plugin does not imply it.
+#[derive(Clone, Copy)]
+pub struct SerdeRenamePlugin;
+
+impl crate::Plugin for SerdeRenamePlugin {
+    fn on_field(
+        &mut self,
+        cx: &crate::Context,
+        def_id: crate::DefId,
+        f: std::sync::Arc<crate::rir::Field>,
+    ) {
+        // Avoid duplicating `#[serde(rename = "...")]` if the user has already specified one
+        if has_explicit_rename(cx, &f) {
+            return;
+        }
+
+        let original = f.name.to_string();
+        cx.with_adjust_mut(def_id, |adj| {
+            adj.add_attrs(&[format!("#[serde(rename = {original:?})]").into()]);
+        });
+    }
+}
+
+/// Returns true if the field has an explicit `#[serde(rename = "...")]`.
+fn has_explicit_rename(cx: &crate::Context, f: &crate::rir::Field) -> bool {
+    cx.tags(f.tags_id).is_some_and(|tags| {
+        tags.get::<SerdeAttribute>()
+            .is_some_and(|attr| attr.0.contains("rename"))
+    })
+}
+
 impl crate::Plugin for SerdePlugin {
     fn on_item(
         &mut self,

--- a/pilota-build/src/plugin/serde.rs
+++ b/pilota-build/src/plugin/serde.rs
@@ -1,22 +1,18 @@
 use syn::{Meta, Token, parse::Parser, punctuated::Punctuated};
 
-use crate::tags::SerdeAttribute;
+use crate::{Plugin, tags::SerdeAttribute};
 
 #[derive(Clone, Copy, Default)]
-pub struct SerdePlugin {
+pub struct SerdePlugin;
+
+#[derive(Clone, Copy)]
+pub struct ConfiguredSerdePlugin {
     preserve_idl_field_names: bool,
 }
 
-/// Lets `SerdePlugin` keep being used as a value, the way it could when it was
-/// a unit struct.
-#[allow(non_upper_case_globals)]
-pub const SerdePlugin: SerdePlugin = SerdePlugin::new();
-
 impl SerdePlugin {
     pub const fn new() -> Self {
-        SerdePlugin {
-            preserve_idl_field_names: false,
-        }
+        Self
     }
 
     /// Preserve the original IDL field names in the generated serde
@@ -24,28 +20,103 @@ impl SerdePlugin {
     ///
     /// When enabled, the emitted `#[serde(rename = "...")]` attributes use
     /// each field's name exactly as written in the IDL rather than the
-    /// snake_case Rust names. Disabled by default.
-    pub fn preserve_idl_field_names(mut self, enable: bool) -> Self {
-        self.preserve_idl_field_names = enable;
-        self
+    /// generated Rust names. Disabled by default.
+    pub const fn preserve_idl_field_names(self, enable: bool) -> ConfiguredSerdePlugin {
+        ConfiguredSerdePlugin {
+            preserve_idl_field_names: enable,
+        }
     }
 }
 
-/// Returns true if `s` holds an attribute of the form `#[serde(.., rename =
-/// ..)]`.
-fn is_serde_rename(s: &str) -> bool {
+/// Which directions the serde attributes in `s` already rename, as
+/// `(serialize, deserialize)`.
+///
+/// `rename = "x"` renames both, while `rename(serialize = "x")` renames only
+/// one and leaves the other still spelled as the Rust ident.
+fn serde_renames(s: &str) -> (bool, bool) {
     let Ok(attrs) = syn::Attribute::parse_outer.parse_str(s) else {
-        return false;
+        return (false, false);
     };
-    attrs.iter().any(|attr| {
-        attr.path().is_ident("serde")
-            && attr
-                .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
-                .is_ok_and(|metas| metas.iter().any(|meta| meta.path().is_ident("rename")))
-    })
+    let renames = attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("serde"))
+        .filter_map(|attr| {
+            attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                .ok()
+        })
+        .flatten()
+        .filter(|meta| meta.path().is_ident("rename"));
+
+    let (mut ser, mut de) = (false, false);
+    for rename in renames {
+        match rename {
+            Meta::NameValue(_) => return (true, true),
+            Meta::List(list) => {
+                if let Ok(dirs) =
+                    list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                {
+                    ser |= dirs.iter().any(|d| d.path().is_ident("serialize"));
+                    de |= dirs.iter().any(|d| d.path().is_ident("deserialize"));
+                }
+            }
+            Meta::Path(_) => {}
+        }
+    }
+    (ser, de)
 }
 
-impl crate::Plugin for SerdePlugin {
+/// Emits the `#[serde(rename = ..)]` that keeps `name`, the IDL spelling, for
+/// whichever directions `idl_attr` has not already renamed itself.
+fn preserve_idl_name(
+    cx: &crate::Context,
+    def_id: crate::DefId,
+    name: &str,
+    idl_attr: Option<&str>,
+) {
+    // A `rename` from the IDL is the more specific one, so it wins over the one
+    // we would derive from the name.
+    let attr = match idl_attr.map(serde_renames).unwrap_or((false, false)) {
+        (true, true) => return,
+        (false, false) => format!("#[serde(rename = {name:?})]"),
+        (true, false) => format!("#[serde(rename(deserialize = {name:?}))]"),
+        (false, true) => format!("#[serde(rename(serialize = {name:?}))]"),
+    };
+    cx.with_adjust_mut(def_id, |adj| adj.add_attrs(&[attr.into()]));
+}
+
+/// Plain `SerdePlugin` is just the configured one with every option off.
+impl Plugin for SerdePlugin {
+    fn on_item(
+        &mut self,
+        cx: &crate::Context,
+        def_id: crate::DefId,
+        item: std::sync::Arc<crate::rir::Item>,
+    ) {
+        self.preserve_idl_field_names(false)
+            .on_item(cx, def_id, item)
+    }
+
+    fn on_field(
+        &mut self,
+        cx: &crate::Context,
+        def_id: crate::DefId,
+        f: std::sync::Arc<crate::rir::Field>,
+    ) {
+        self.preserve_idl_field_names(false).on_field(cx, def_id, f)
+    }
+
+    fn on_variant(
+        &mut self,
+        cx: &crate::Context,
+        def_id: crate::DefId,
+        variant: std::sync::Arc<crate::rir::EnumVariant>,
+    ) {
+        self.preserve_idl_field_names(false)
+            .on_variant(cx, def_id, variant)
+    }
+}
+
+impl Plugin for ConfiguredSerdePlugin {
     fn on_item(
         &mut self,
         cx: &crate::Context,
@@ -100,13 +171,8 @@ impl crate::Plugin for SerdePlugin {
             cx.with_adjust_mut(def_id, |adj| adj.add_attrs(&[attr.into()]))
         }
 
-        // A `rename` from the IDL is the more specific one, so it wins over the
-        // one this option would derive from the field name.
-        if self.preserve_idl_field_names && !idl_attr.as_deref().is_some_and(is_serde_rename) {
-            let original = f.name.raw_str();
-            cx.with_adjust_mut(def_id, |adj| {
-                adj.add_attrs(&[format!("#[serde(rename = {:?})]", &*original).into()]);
-            });
+        if self.preserve_idl_field_names {
+            preserve_idl_name(cx, def_id, &f.name.raw_str(), idl_attr.as_deref());
         }
     }
 
@@ -116,43 +182,66 @@ impl crate::Plugin for SerdePlugin {
         def_id: crate::DefId,
         variant: std::sync::Arc<crate::rir::EnumVariant>,
     ) {
-        if let Some(attribute) = cx
+        let idl_attr = cx
             .node_tags(variant.did)
             .and_then(|tags| tags.get::<SerdeAttribute>().cloned())
-        {
-            let attr = attribute.0.replace('\\', "");
+            .map(|attribute| attribute.0.replace('\\', ""));
+
+        if let Some(attr) = idl_attr.clone() {
             cx.with_adjust_mut(def_id, |adj| adj.add_attrs(&[attr.into()]))
+        }
+
+        if self.preserve_idl_field_names {
+            preserve_idl_name(cx, def_id, &variant.name.raw_str(), idl_attr.as_deref());
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::is_serde_rename;
+    use super::serde_renames;
 
     #[test]
-    fn detects_rename() {
-        assert!(is_serde_rename(r#"#[serde(rename = "AA")]"#));
-        assert!(is_serde_rename(
-            r#"#[serde(rename(serialize = "a", deserialize = "b"))]"#
-        ));
-        assert!(is_serde_rename(r#"#[serde(default, rename = "AA")]"#));
+    fn detects_rename_of_both_directions() {
+        assert_eq!(serde_renames(r#"#[serde(rename = "AA")]"#), (true, true));
+        assert_eq!(
+            serde_renames(r#"#[serde(default, rename = "AA")]"#),
+            (true, true)
+        );
+        assert_eq!(
+            serde_renames(r#"#[serde(rename(serialize = "a", deserialize = "b"))]"#),
+            (true, true)
+        );
+    }
+
+    #[test]
+    fn detects_rename_of_one_direction() {
+        assert_eq!(
+            serde_renames(r#"#[serde(rename(serialize = "a"))]"#),
+            (true, false)
+        );
+        assert_eq!(
+            serde_renames(r#"#[serde(rename(deserialize = "b"))]"#),
+            (false, true)
+        );
     }
 
     #[test]
     fn ignores_attrs_that_merely_embed_the_word() {
-        assert!(!is_serde_rename(r#"#[serde(alias = "renamed_value")]"#));
-        assert!(!is_serde_rename(r#"#[serde(rename_all = "camelCase")]"#));
-        assert!(!is_serde_rename(r#"#[serde(untagged)]"#));
-        assert!(!is_serde_rename(
-            r#"#[serde(skip_serializing_if = "rename")]"#
-        ));
+        for s in [
+            r#"#[serde(alias = "renamed_value")]"#,
+            r#"#[serde(rename_all = "camelCase")]"#,
+            r#"#[serde(untagged)]"#,
+            r#"#[serde(skip_serializing_if = "rename")]"#,
+        ] {
+            assert_eq!(serde_renames(s), (false, false), "{s}");
+        }
     }
 
     #[test]
     fn ignores_non_serde_and_unparsable_attrs() {
-        assert!(!is_serde_rename(r#"#[other(rename = "AA")]"#));
-        assert!(!is_serde_rename("not an attribute"));
-        assert!(!is_serde_rename(""));
+        for s in [r#"#[other(rename = "AA")]"#, "not an attribute", ""] {
+            assert_eq!(serde_renames(s), (false, false), "{s}");
+        }
     }
 }

--- a/pilota-build/src/plugin/serde.rs
+++ b/pilota-build/src/plugin/serde.rs
@@ -1,3 +1,5 @@
+use syn::{Meta, Token, parse::Parser, punctuated::Punctuated};
+
 use crate::tags::SerdeAttribute;
 
 #[derive(Clone, Copy)]
@@ -10,32 +12,47 @@ pub struct SerdePlugin;
 /// Only meaningful next to [`SerdePlugin`], which emits the derives these
 /// attributes attach to; this plugin does not imply it.
 #[derive(Clone, Copy)]
-pub struct SerdeRenamePlugin;
+pub struct SerdePreserveIdlNamesPlugin;
 
-impl crate::Plugin for SerdeRenamePlugin {
+impl crate::Plugin for SerdePreserveIdlNamesPlugin {
     fn on_field(
         &mut self,
         cx: &crate::Context,
         def_id: crate::DefId,
         f: std::sync::Arc<crate::rir::Field>,
     ) {
-        // Avoid duplicating `#[serde(rename = "...")]` if the user has already specified one
+        // Avoid duplicating `#[serde(rename = "...")]` if the user has already
+        // specified one
         if has_explicit_rename(cx, &f) {
             return;
         }
 
-        let original = f.name.to_string();
+        let original = f.name.raw_str();
         cx.with_adjust_mut(def_id, |adj| {
-            adj.add_attrs(&[format!("#[serde(rename = {original:?})]").into()]);
+            adj.add_attrs(&[format!("#[serde(rename = {:?})]", &*original).into()]);
         });
     }
 }
 
-/// Returns true if the field has an explicit `#[serde(rename = "...")]`.
+/// Returns true if the field has an explicit `#[serde(rename = ..)]`.
 fn has_explicit_rename(cx: &crate::Context, f: &crate::rir::Field) -> bool {
     cx.tags(f.tags_id).is_some_and(|tags| {
         tags.get::<SerdeAttribute>()
-            .is_some_and(|attr| attr.0.contains("rename"))
+            .is_some_and(|attr| is_serde_rename(&attr.0.replace('\\', "")))
+    })
+}
+
+/// Returns true if `s` holds an attribute of the form `#[serde(.., rename =
+/// ..)]`.
+fn is_serde_rename(s: &str) -> bool {
+    let Ok(attrs) = syn::Attribute::parse_outer.parse_str(s) else {
+        return false;
+    };
+    attrs.iter().any(|attr| {
+        attr.path().is_ident("serde")
+            && attr
+                .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                .is_ok_and(|metas| metas.iter().any(|meta| meta.path().is_ident("rename")))
     })
 }
 

--- a/pilota-build/src/plugin/serde.rs
+++ b/pilota-build/src/plugin/serde.rs
@@ -126,3 +126,34 @@ impl crate::Plugin for SerdePlugin {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::is_serde_rename;
+
+    #[test]
+    fn detects_rename() {
+        assert!(is_serde_rename(r#"#[serde(rename = "AA")]"#));
+        assert!(is_serde_rename(
+            r#"#[serde(rename(serialize = "a", deserialize = "b"))]"#
+        ));
+        assert!(is_serde_rename(r#"#[serde(default, rename = "AA")]"#));
+    }
+
+    #[test]
+    fn ignores_attrs_that_merely_embed_the_word() {
+        assert!(!is_serde_rename(r#"#[serde(alias = "renamed_value")]"#));
+        assert!(!is_serde_rename(r#"#[serde(rename_all = "camelCase")]"#));
+        assert!(!is_serde_rename(r#"#[serde(untagged)]"#));
+        assert!(!is_serde_rename(
+            r#"#[serde(skip_serializing_if = "rename")]"#
+        ));
+    }
+
+    #[test]
+    fn ignores_non_serde_and_unparsable_attrs() {
+        assert!(!is_serde_rename(r#"#[other(rename = "AA")]"#));
+        assert!(!is_serde_rename("not an attribute"));
+        assert!(!is_serde_rename(""));
+    }
+}

--- a/pilota-build/src/plugin/serde.rs
+++ b/pilota-build/src/plugin/serde.rs
@@ -2,44 +2,33 @@ use syn::{Meta, Token, parse::Parser, punctuated::Punctuated};
 
 use crate::tags::SerdeAttribute;
 
-#[derive(Clone, Copy)]
-pub struct SerdePlugin;
-
-/// Emits `#[serde(rename = "..")]` on every field, so serialized output keeps
-/// the field names as spelled in the IDL rather than the snake_case idents
-/// generated for Rust.
-///
-/// Only meaningful next to [`SerdePlugin`], which emits the derives these
-/// attributes attach to; this plugin does not imply it.
-#[derive(Clone, Copy)]
-pub struct SerdePreserveIdlNamesPlugin;
-
-impl crate::Plugin for SerdePreserveIdlNamesPlugin {
-    fn on_field(
-        &mut self,
-        cx: &crate::Context,
-        def_id: crate::DefId,
-        f: std::sync::Arc<crate::rir::Field>,
-    ) {
-        // Avoid duplicating `#[serde(rename = "...")]` if the user has already
-        // specified one
-        if has_explicit_rename(cx, &f) {
-            return;
-        }
-
-        let original = f.name.raw_str();
-        cx.with_adjust_mut(def_id, |adj| {
-            adj.add_attrs(&[format!("#[serde(rename = {:?})]", &*original).into()]);
-        });
-    }
+#[derive(Clone, Copy, Default)]
+pub struct SerdePlugin {
+    preserve_idl_field_names: bool,
 }
 
-/// Returns true if the field has an explicit `#[serde(rename = ..)]`.
-fn has_explicit_rename(cx: &crate::Context, f: &crate::rir::Field) -> bool {
-    cx.tags(f.tags_id).is_some_and(|tags| {
-        tags.get::<SerdeAttribute>()
-            .is_some_and(|attr| is_serde_rename(&attr.0.replace('\\', "")))
-    })
+/// Lets `SerdePlugin` keep being used as a value, the way it could when it was
+/// a unit struct.
+#[allow(non_upper_case_globals)]
+pub const SerdePlugin: SerdePlugin = SerdePlugin::new();
+
+impl SerdePlugin {
+    pub const fn new() -> Self {
+        SerdePlugin {
+            preserve_idl_field_names: false,
+        }
+    }
+
+    /// Preserve the original IDL field names in the generated serde
+    /// attributes instead of pilota's Rust-cased identifiers.
+    ///
+    /// When enabled, the emitted `#[serde(rename = "...")]` attributes use
+    /// each field's name exactly as written in the IDL rather than the
+    /// snake_case Rust names. Disabled by default.
+    pub fn preserve_idl_field_names(mut self, enable: bool) -> Self {
+        self.preserve_idl_field_names = enable;
+        self
+    }
 }
 
 /// Returns true if `s` holds an attribute of the form `#[serde(.., rename =
@@ -102,12 +91,22 @@ impl crate::Plugin for SerdePlugin {
         def_id: crate::DefId,
         f: std::sync::Arc<crate::rir::Field>,
     ) {
-        if let Some(attribute) = cx
+        let idl_attr = cx
             .tags(f.tags_id)
             .and_then(|tags| tags.get::<SerdeAttribute>().cloned())
-        {
-            let attr = attribute.0.replace('\\', "");
+            .map(|attribute| attribute.0.replace('\\', ""));
+
+        if let Some(attr) = idl_attr.clone() {
             cx.with_adjust_mut(def_id, |adj| adj.add_attrs(&[attr.into()]))
+        }
+
+        // A `rename` from the IDL is the more specific one, so it wins over the
+        // one this option would derive from the field name.
+        if self.preserve_idl_field_names && !idl_attr.as_deref().is_some_and(is_serde_rename) {
+            let original = f.name.raw_str();
+            cx.with_adjust_mut(def_id, |adj| {
+                adj.add_attrs(&[format!("#[serde(rename = {:?})]", &*original).into()]);
+            });
         }
     }
 

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -8,10 +8,7 @@ use std::{
 
 use tempfile::tempdir;
 
-use crate::{
-    IdlService,
-    plugin::{SerdePlugin, SerdePreserveIdlNamesPlugin},
-};
+use crate::{IdlService, plugin::SerdePlugin};
 
 fn diff_file(old: impl AsRef<Path>, new: impl AsRef<Path>) {
     let old_content =
@@ -339,8 +336,7 @@ fn test_plugin_preserve_idl_names_thrift(source: impl AsRef<Path>, target: impl 
     test_with_builder(source, target, |source, target| {
         crate::Builder::thrift()
             .ignore_unused(false)
-            .plugin(SerdePlugin)
-            .plugin(SerdePreserveIdlNamesPlugin)
+            .plugin(SerdePlugin.preserve_idl_field_names(true))
             .compile_with_config(
                 vec![IdlService::from_path(source.to_path_buf())],
                 crate::Output::File(target.into()),

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -344,6 +344,19 @@ fn test_plugin_preserve_idl_names_thrift(source: impl AsRef<Path>, target: impl 
     });
 }
 
+fn test_plugin_preserve_idl_names_pb(source: impl AsRef<Path>, target: impl AsRef<Path>) {
+    test_with_builder(source, target, |source, target| {
+        crate::Builder::pb()
+            .ignore_unused(false)
+            .plugin(SerdePlugin.preserve_idl_field_names(true))
+            .include_dirs(vec![source.parent().unwrap().to_path_buf()])
+            .compile_with_config(
+                vec![IdlService::from_path(source.to_path_buf())],
+                crate::Output::File(target.into()),
+            )
+    });
+}
+
 fn test_plugin_pb(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     test_with_builder(source, target, |source, target| {
         crate::Builder::pb()
@@ -559,6 +572,19 @@ fn test_serde_preserve_idl_names_gen() {
     out_path.set_extension("rs");
 
     test_plugin_preserve_idl_names_thrift(file_path, out_path);
+}
+
+#[test]
+fn test_serde_preserve_idl_names_pb_gen() {
+    let file_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test_data")
+        .join("plugin_preserve_idl_names")
+        .join("serde_preserve_idl_names_pb.proto");
+
+    let mut out_path = file_path.clone();
+    out_path.set_extension("rs");
+
+    test_plugin_preserve_idl_names_pb(file_path, out_path);
 }
 
 #[test]

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -8,7 +8,10 @@ use std::{
 
 use tempfile::tempdir;
 
-use crate::{IdlService, plugin::SerdePlugin};
+use crate::{
+    IdlService,
+    plugin::{SerdePlugin, SerdePreserveIdlNamesPlugin},
+};
 
 fn diff_file(old: impl AsRef<Path>, new: impl AsRef<Path>) {
     let old_content =
@@ -332,6 +335,19 @@ fn test_plugin_thrift(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     });
 }
 
+fn test_plugin_preserve_idl_names_thrift(source: impl AsRef<Path>, target: impl AsRef<Path>) {
+    test_with_builder(source, target, |source, target| {
+        crate::Builder::thrift()
+            .ignore_unused(false)
+            .plugin(SerdePlugin)
+            .plugin(SerdePreserveIdlNamesPlugin)
+            .compile_with_config(
+                vec![IdlService::from_path(source.to_path_buf())],
+                crate::Output::File(target.into()),
+            )
+    });
+}
+
 fn test_plugin_pb(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     test_with_builder(source, target, |source, target| {
         crate::Builder::pb()
@@ -534,6 +550,19 @@ fn test_plugin_gen() {
             }
         }
     });
+}
+
+#[test]
+fn test_serde_preserve_idl_names_gen() {
+    let file_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test_data")
+        .join("plugin_preserve_idl_names")
+        .join("serde_preserve_idl_names.thrift");
+
+    let mut out_path = file_path.clone();
+    out_path.set_extension("rs");
+
+    test_plugin_preserve_idl_names_thrift(file_path, out_path);
 }
 
 #[test]

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.rs
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.rs
@@ -1,0 +1,279 @@
+pub mod serde_preserve_idl_names {
+    #![allow(warnings, clippy::all)]
+
+    pub mod serde_preserve_idl_names {
+
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            Default,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
+        pub struct A {
+            #[serde(rename = "type")]
+            pub r#type: ::pilota::FastStr,
+
+            #[serde(rename = "SomeField")]
+            pub some_field: ::pilota::FastStr,
+
+            #[serde(rename = "CC")]
+            pub c: ::pilota::FastStr,
+
+            #[serde(alias = "renamed_value")]
+            #[serde(rename = "d")]
+            pub d: ::pilota::FastStr,
+        }
+        impl ::pilota::thrift::Message for A {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "A" };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+                __protocol.write_faststr_field(1, (&self.r#type).clone())?;
+                __protocol.write_faststr_field(2, (&self.some_field).clone())?;
+                __protocol.write_faststr_field(3, (&self.c).clone())?;
+                __protocol.write_faststr_field(4, (&self.d).clone())?;
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+                let mut var_2 = None;
+                let mut var_3 = None;
+                let mut var_4 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_1 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(2)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_2 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(3)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_3 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(4)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_4 = Some(__protocol.read_faststr()?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `A` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field r#type is required".to_string(),
+                    ));
+                };
+                let Some(var_2) = var_2 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field some_field is required".to_string(),
+                    ));
+                };
+                let Some(var_3) = var_3 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field c is required".to_string(),
+                    ));
+                };
+                let Some(var_4) = var_4 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field d is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    r#type: var_1,
+                    some_field: var_2,
+                    c: var_3,
+                    d: var_4,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = None;
+                    let mut var_3 = None;
+                    let mut var_4 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_1 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_2 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(3)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_3 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(4)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_4 = Some(__protocol.read_faststr().await?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `A` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field r#type is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_2) = var_2 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field some_field is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_3) = var_3 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field c is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_4) = var_4 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field d is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        r#type: var_1,
+                        some_field: var_2,
+                        c: var_3,
+                        d: var_4,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "A" })
+                    + __protocol.faststr_field_len(Some(1), &self.r#type)
+                    + __protocol.faststr_field_len(Some(2), &self.some_field)
+                    + __protocol.faststr_field_len(Some(3), &self.c)
+                    + __protocol.faststr_field_len(Some(4), &self.d)
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.rs
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.rs
@@ -28,6 +28,17 @@ pub mod serde_preserve_idl_names {
             #[serde(alias = "renamed_value")]
             #[serde(rename = "d")]
             pub d: ::pilota::FastStr,
+
+            #[serde(rename(serialize = "EE"))]
+            #[serde(rename(deserialize = "SerOnly"))]
+            pub ser_only: ::pilota::FastStr,
+
+            #[serde(rename(deserialize = "FF"))]
+            #[serde(rename(serialize = "DeOnly"))]
+            pub de_only: ::pilota::FastStr,
+
+            #[serde(rename(serialize = "GS", deserialize = "GD"))]
+            pub both_dirs: ::pilota::FastStr,
         }
         impl ::pilota::thrift::Message for A {
             fn encode<T: ::pilota::thrift::TOutputProtocol>(
@@ -43,6 +54,9 @@ pub mod serde_preserve_idl_names {
                 __protocol.write_faststr_field(2, (&self.some_field).clone())?;
                 __protocol.write_faststr_field(3, (&self.c).clone())?;
                 __protocol.write_faststr_field(4, (&self.d).clone())?;
+                __protocol.write_faststr_field(5, (&self.ser_only).clone())?;
+                __protocol.write_faststr_field(6, (&self.de_only).clone())?;
+                __protocol.write_faststr_field(7, (&self.both_dirs).clone())?;
                 __protocol.write_field_stop()?;
                 __protocol.write_struct_end()?;
                 ::std::result::Result::Ok(())
@@ -58,6 +72,9 @@ pub mod serde_preserve_idl_names {
                 let mut var_2 = None;
                 let mut var_3 = None;
                 let mut var_4 = None;
+                let mut var_5 = None;
+                let mut var_6 = None;
+                let mut var_7 = None;
 
                 let mut __pilota_decoding_field_id = None;
 
@@ -92,6 +109,21 @@ pub mod serde_preserve_idl_names {
                                 if field_ident.field_type == ::pilota::thrift::TType::Binary =>
                             {
                                 var_4 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(5)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_5 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(6)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_6 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(7)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_7 = Some(__protocol.read_faststr()?);
                             }
                             _ => {
                                 __protocol.skip(field_ident.field_type)?;
@@ -137,12 +169,33 @@ pub mod serde_preserve_idl_names {
                         "field d is required".to_string(),
                     ));
                 };
+                let Some(var_5) = var_5 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field ser_only is required".to_string(),
+                    ));
+                };
+                let Some(var_6) = var_6 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field de_only is required".to_string(),
+                    ));
+                };
+                let Some(var_7) = var_7 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field both_dirs is required".to_string(),
+                    ));
+                };
 
                 let data = Self {
                     r#type: var_1,
                     some_field: var_2,
                     c: var_3,
                     d: var_4,
+                    ser_only: var_5,
+                    de_only: var_6,
+                    both_dirs: var_7,
                 };
                 ::std::result::Result::Ok(data)
             }
@@ -162,6 +215,9 @@ pub mod serde_preserve_idl_names {
                     let mut var_2 = None;
                     let mut var_3 = None;
                     let mut var_4 = None;
+                    let mut var_5 = None;
+                    let mut var_6 = None;
+                    let mut var_7 = None;
 
                     let mut __pilota_decoding_field_id = None;
 
@@ -198,6 +254,24 @@ pub mod serde_preserve_idl_names {
                                         == ::pilota::thrift::TType::Binary =>
                                 {
                                     var_4 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(5)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_5 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(6)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_6 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(7)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_7 = Some(__protocol.read_faststr().await?);
                                 }
                                 _ => {
                                     __protocol.skip(field_ident.field_type).await?;
@@ -252,12 +326,39 @@ pub mod serde_preserve_idl_names {
                             ),
                         );
                     };
+                    let Some(var_5) = var_5 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field ser_only is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_6) = var_6 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field de_only is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_7) = var_7 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field both_dirs is required".to_string(),
+                            ),
+                        );
+                    };
 
                     let data = Self {
                         r#type: var_1,
                         some_field: var_2,
                         c: var_3,
                         d: var_4,
+                        ser_only: var_5,
+                        de_only: var_6,
+                        both_dirs: var_7,
                     };
                     ::std::result::Result::Ok(data)
                 })
@@ -271,6 +372,233 @@ pub mod serde_preserve_idl_names {
                     + __protocol.faststr_field_len(Some(2), &self.some_field)
                     + __protocol.faststr_field_len(Some(3), &self.c)
                     + __protocol.faststr_field_len(Some(4), &self.d)
+                    + __protocol.faststr_field_len(Some(5), &self.ser_only)
+                    + __protocol.faststr_field_len(Some(6), &self.de_only)
+                    + __protocol.faststr_field_len(Some(7), &self.both_dirs)
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        impl ::std::default::Default for TestUnion {
+            fn default() -> Self {
+                TestUnion::StringValue(::std::default::Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
+        pub enum TestUnion {
+            #[serde(rename = "StringValue")]
+            StringValue(::pilota::FastStr),
+
+            #[serde(rename = "pub")]
+            Pub(i32),
+
+            #[serde(rename = "int_value")]
+            IntValue(::pilota::FastStr),
+        }
+
+        impl ::pilota::thrift::Message for TestUnion {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "TestUnion",
+                })?;
+                match self {
+                    TestUnion::StringValue(value) => {
+                        __protocol.write_faststr_field(1, (value).clone())?;
+                    }
+                    TestUnion::Pub(value) => {
+                        __protocol.write_i32_field(2, *value)?;
+                    }
+                    TestUnion::IntValue(value) => {
+                        __protocol.write_faststr_field(3, (value).clone())?;
+                    }
+                }
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                let mut ret = None;
+                __protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = __protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        __protocol.field_stop_len();
+                        break;
+                    } else {
+                        __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                    }
+                    match field_ident.id {
+                        Some(1) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::StringValue(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        Some(2) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_i32()?;
+                                __protocol.i32_len(*&field_ident);
+                                ret = Some(TestUnion::Pub(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        Some(3) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::IntValue(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                __protocol.read_field_end()?;
+                __protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    ::std::result::Result::Ok(ret)
+                } else {
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut ret = None;
+                    __protocol.read_struct_begin().await?;
+                    loop {
+                        let field_ident = __protocol.read_field_begin().await?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            break;
+                        } else {
+                        }
+                        match field_ident.id {
+                            Some(1) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_faststr().await?;
+
+                                    ret = Some(TestUnion::StringValue(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            Some(2) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_i32().await?;
+
+                                    ret = Some(TestUnion::Pub(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            Some(3) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_faststr().await?;
+
+                                    ret = Some(TestUnion::IntValue(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type).await?;
+                            }
+                        }
+                    }
+                    __protocol.read_field_end().await?;
+                    __protocol.read_struct_end().await?;
+                    if let Some(ret) = ret {
+                        ::std::result::Result::Ok(ret)
+                    } else {
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            "received empty union from remote Message",
+                        ))
+                    }
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol
+                    .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "TestUnion" })
+                    + match self {
+                        TestUnion::StringValue(value) => {
+                            __protocol.faststr_field_len(Some(1), value)
+                        }
+                        TestUnion::Pub(value) => __protocol.i32_field_len(Some(2), *value),
+                        TestUnion::IntValue(value) => __protocol.faststr_field_len(Some(3), value),
+                    }
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()
             }

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.thrift
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.thrift
@@ -1,6 +1,5 @@
 struct A {
-    // A name that is a Rust keyword: the generated ident is escaped to `r#type`,
-    // but the serialized name must stay `type`.
+    // Rust keyword: should become r#type, but renamed to "type"
     1: required string type,
     // A name that is rewritten to a snake_case ident: `some_field`.
     2: required string SomeField,
@@ -8,4 +7,22 @@ struct A {
     3: required string c(pilota.serde_attribute = "#[serde(rename = \"CC\")]"),
     // An attribute that merely embeds the word "rename" does not count as one.
     4: required string d(pilota.serde_attribute = "#[serde(alias = \"renamed_value\")]"),
+    // A rename covering only serialization: deserialization is still spelled
+    // with the Rust ident, so that direction alone gets the IDL name.
+    5: required string SerOnly(pilota.serde_attribute = "#[serde(rename(serialize = \"EE\"))]"),
+    // The mirror case: only serialization is left to preserve.
+    6: required string DeOnly(pilota.serde_attribute = "#[serde(rename(deserialize = \"FF\"))]"),
+    // Both directions renamed explicitly, so preserve has nothing to add.
+    7: required string BothDirs(pilota.serde_attribute = "#[serde(rename(serialize = \"GS\", deserialize = \"GD\"))]"),
+}
+
+union TestUnion {
+    // Already PascalCase: should stay StringValue
+    1: string StringValue,
+
+    // Rust keyword: should become Pub, but serialized name must stay "pub"
+    2: i32 pub,
+
+    // Rewritten to IntValue but renamed to int_value
+    3: string int_value,
 }

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.thrift
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.thrift
@@ -1,0 +1,11 @@
+struct A {
+    // A name that is a Rust keyword: the generated ident is escaped to `r#type`,
+    // but the serialized name must stay `type`.
+    1: required string type,
+    // A name that is rewritten to a snake_case ident: `some_field`.
+    2: required string SomeField,
+    // An explicit rename wins over the generated one.
+    3: required string c(pilota.serde_attribute = "#[serde(rename = \"CC\")]"),
+    // An attribute that merely embeds the word "rename" does not count as one.
+    4: required string d(pilota.serde_attribute = "#[serde(alias = \"renamed_value\")]"),
+}

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.proto
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+message A { 
+    string SomeField = 1;
+    string type = 2;
+
+    oneof TestOneof {
+        string StringValue = 3;
+        string pub = 4;
+        int32 int_value = 5;
+    }
+}
+

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.rs
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.rs
@@ -1,0 +1,197 @@
+pub mod serde_preserve_idl_names_pb {
+    #![allow(warnings, clippy::all)]
+    use ::pilota::{Buf as _, BufMut as _};
+    #[derive(
+        PartialOrd,
+        Hash,
+        Eq,
+        Ord,
+        Debug,
+        Default,
+        ::pilota::serde::Serialize,
+        ::pilota::serde::Deserialize,
+        Clone,
+        PartialEq,
+    )]
+    pub struct A {
+        #[serde(rename = "SomeField")]
+        pub some_field: ::pilota::FastStr,
+
+        #[serde(rename = "type")]
+        pub r#type: ::pilota::FastStr,
+
+        #[serde(rename = "TestOneof")]
+        pub test_oneof: ::std::option::Option<a::TestOneof>,
+    }
+    impl ::pilota::pb::Message for A {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.some_field)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, &self.r#type)
+                + self
+                    .test_oneof
+                    .as_ref()
+                    .map_or(0, |msg| msg.encoded_len(ctx))
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::faststr::encode(1, &self.some_field, buf);
+            ::pilota::pb::encoding::faststr::encode(2, &self.r#type, buf);
+            if let Some(_pilota_inner_value) = self.test_oneof.as_ref() {
+                _pilota_inner_value.encode(buf);
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(A);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.some_field;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(some_field));
+                            error
+                        })
+                }
+                2 => {
+                    let mut _inner_pilota_value = &mut self.r#type;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(r#type));
+                            error
+                        })
+                }
+                3 | 4 | 5 => {
+                    let mut _inner_pilota_value = &mut self.test_oneof;
+                    a::TestOneof::merge(_inner_pilota_value, tag, wire_type, buf, ctx).map_err(
+                        |mut error| {
+                            error.push(STRUCT_NAME, stringify!(test_oneof));
+                            error
+                        },
+                    )
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+
+    pub mod a {
+        use ::pilota::{Buf as _, BufMut as _};
+
+        impl ::std::default::Default for TestOneof {
+            fn default() -> Self {
+                TestOneof::StringValue(::std::default::Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
+        pub enum TestOneof {
+            #[serde(rename = "StringValue")]
+            StringValue(::pilota::FastStr),
+
+            #[serde(rename = "pub")]
+            Pub(::pilota::FastStr),
+
+            #[serde(rename = "int_value")]
+            IntValue(i32),
+        }
+
+        impl TestOneof {
+            pub fn encode(&self, buf: &mut ::pilota::LinkedBytes) {
+                match self {
+                    TestOneof::StringValue(value) => {
+                        ::pilota::pb::encoding::faststr::encode(3, &*value, buf);
+                    }
+                    TestOneof::Pub(value) => {
+                        ::pilota::pb::encoding::faststr::encode(4, &*value, buf);
+                    }
+                    TestOneof::IntValue(value) => {
+                        ::pilota::pb::encoding::int32::encode(5, &*value, buf);
+                    }
+                }
+            }
+
+            #[inline]
+            pub fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+                match self {
+                    TestOneof::StringValue(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 3, &*value)
+                    }
+                    TestOneof::Pub(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 4, &*value)
+                    }
+                    TestOneof::IntValue(value) => {
+                        ::pilota::pb::encoding::int32::encoded_len(ctx, 5, &*value)
+                    }
+                }
+            }
+
+            #[inline]
+            pub fn merge(
+                field: &mut ::core::option::Option<Self>,
+                tag: u32,
+                wire_type: ::pilota::pb::encoding::WireType,
+                buf: &mut ::pilota::Bytes,
+                ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+                match tag {
+                    3 => match field {
+                        ::core::option::Option::Some(TestOneof::StringValue(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field =
+                                ::core::option::Option::Some(TestOneof::StringValue(owned_value));
+                        }
+                    },
+                    4 => match field {
+                        ::core::option::Option::Some(TestOneof::Pub(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::Pub(owned_value));
+                        }
+                    },
+                    5 => match field {
+                        ::core::option::Option::Some(TestOneof::IntValue(value)) => {
+                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::IntValue(owned_value));
+                        }
+                    },
+                    _ => unreachable!(concat!("invalid ", stringify!(TestOneof), " tag: {}"), tag),
+                };
+                ::core::result::Result::Ok(())
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/thrift_with_field_mask/complex_enum_key_map.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/complex_enum_key_map.rs
@@ -303,12 +303,8 @@ pub mod complex_enum_key_map {
                         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                             name: "NestedItem",
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(1);
-                            if exist {
-                                __protocol.i32_field_len(Some(1), *&self.value)
-                            } else {
-                                0
-                            }
+                            let (field_fm, _) = struct_fm.field(1);
+                            __protocol.i32_field_len(Some(1), *&self.value)
                         } + self.label.as_ref().map_or(0, |value| {
                             let (field_fm, exist) = struct_fm.field(2);
                             if exist {
@@ -1007,132 +1003,98 @@ pub mod complex_enum_key_map {
                         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                             name: "ComplexEnumKeyMapTest",
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(1);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::I32,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.priority_counts {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += __protocol.i32_len(*val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(1);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::I32,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.priority_counts {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += __protocol.i32_len(*val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(1),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::I32,
-                                        &self.priority_counts,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| __protocol.i32_len(*val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(1),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::I32,
+                                    &self.priority_counts,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| __protocol.i32_len(*val),
+                                )
                             }
                         } + {
-                            let (field_fm, exist) = struct_fm.field(2);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::Struct,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.priority_items {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += __protocol.struct_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(2);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::Struct,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.priority_items {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += __protocol.struct_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(2),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::Struct,
-                                        &self.priority_items,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| __protocol.struct_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(2),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::Struct,
+                                    &self.priority_items,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| __protocol.struct_len(val),
+                                )
                             }
                         } + {
-                            let (field_fm, exist) = struct_fm.field(3);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::Map,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.nested_maps {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += if let Some(map_fm) = item_fm {
-                                                let mut size = __protocol.map_begin_len(
-                                                    ::pilota::thrift::TMapIdentifier {
-                                                        key_type: ::pilota::thrift::TType::Binary,
-                                                        value_type: ::pilota::thrift::TType::I32,
-                                                        size: 0,
-                                                    },
-                                                ) + __protocol.map_end_len();
-                                                for (key, val) in val {
-                                                    let (item_fm, exist) = map_fm.str(key);
-                                                    if exist {
-                                                        size += __protocol.faststr_len(key);
-                                                        size += __protocol.i32_len(*val);
-                                                    }
+                            let (field_fm, _) = struct_fm.field(3);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::Map,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.nested_maps {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += if let Some(map_fm) = item_fm {
+                                            let mut size = __protocol.map_begin_len(
+                                                ::pilota::thrift::TMapIdentifier {
+                                                    key_type: ::pilota::thrift::TType::Binary,
+                                                    value_type: ::pilota::thrift::TType::I32,
+                                                    size: 0,
+                                                },
+                                            ) + __protocol.map_end_len();
+                                            for (key, val) in val {
+                                                let (item_fm, exist) = map_fm.str(key);
+                                                if exist {
+                                                    size += __protocol.faststr_len(key);
+                                                    size += __protocol.i32_len(*val);
                                                 }
-                                                size
-                                            } else {
-                                                __protocol.map_len(
-                                                    ::pilota::thrift::TType::Binary,
-                                                    ::pilota::thrift::TType::I32,
-                                                    val,
-                                                    |__protocol, key| __protocol.faststr_len(key),
-                                                    |__protocol, val| __protocol.i32_len(*val),
-                                                )
-                                            };
-                                        }
-                                    }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(3),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::Map,
-                                        &self.nested_maps,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| {
+                                            }
+                                            size
+                                        } else {
                                             __protocol.map_len(
                                                 ::pilota::thrift::TType::Binary,
                                                 ::pilota::thrift::TType::I32,
@@ -1140,11 +1102,27 @@ pub mod complex_enum_key_map {
                                                 |__protocol, key| __protocol.faststr_len(key),
                                                 |__protocol, val| __protocol.i32_len(*val),
                                             )
-                                        },
-                                    )
+                                        };
+                                    }
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(3),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::Map,
+                                    &self.nested_maps,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| {
+                                        __protocol.map_len(
+                                            ::pilota::thrift::TType::Binary,
+                                            ::pilota::thrift::TType::I32,
+                                            val,
+                                            |__protocol, key| __protocol.faststr_len(key),
+                                            |__protocol, val| __protocol.i32_len(*val),
+                                        )
+                                    },
+                                )
                             }
                         } + self.priority_item_lists.as_ref().map_or(0, |value| {
                             let (field_fm, exist) = struct_fm.field(4);

--- a/pilota-build/test_data/thrift_with_field_mask/enum_key_map.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/enum_key_map.rs
@@ -310,20 +310,12 @@ pub mod enum_key_map {
                         __protocol
                             .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
                             + {
-                                let (field_fm, exist) = struct_fm.field(1);
-                                if exist {
-                                    __protocol.i64_field_len(Some(1), *&self.id)
-                                } else {
-                                    0
-                                }
+                                let (field_fm, _) = struct_fm.field(1);
+                                __protocol.i64_field_len(Some(1), *&self.id)
                             }
                             + {
-                                let (field_fm, exist) = struct_fm.field(2);
-                                if exist {
-                                    __protocol.faststr_field_len(Some(2), &self.name)
-                                } else {
-                                    0
-                                }
+                                let (field_fm, _) = struct_fm.field(2);
+                                __protocol.faststr_field_len(Some(2), &self.name)
                             }
                             + __protocol.field_stop_len()
                             + __protocol.struct_end_len()
@@ -839,76 +831,64 @@ pub mod enum_key_map {
                         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                             name: "EnumKeyMapTest",
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(1);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::Binary,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.status_map {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += __protocol.faststr_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(1);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::Binary,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.status_map {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += __protocol.faststr_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(1),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::Binary,
-                                        &self.status_map,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| __protocol.faststr_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(1),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::Binary,
+                                    &self.status_map,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
                             }
                         } + {
-                            let (field_fm, exist) = struct_fm.field(2);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::Struct,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.status_item_map {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += __protocol.struct_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(2);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::Struct,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.status_item_map {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += __protocol.struct_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(2),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::Struct,
-                                        &self.status_item_map,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| __protocol.struct_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(2),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::Struct,
+                                    &self.status_item_map,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| __protocol.struct_len(val),
+                                )
                             }
                         } + self.status_list_map.as_ref().map_or(0, |value| {
                             let (field_fm, exist) = struct_fm.field(3);

--- a/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
@@ -209,20 +209,12 @@ pub mod struct_init_with_field_mask {
                         __protocol
                             .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
                             + {
-                                let (field_fm, exist) = struct_fm.field(1);
-                                if exist {
-                                    __protocol.i64_field_len(Some(1), *&self.id)
-                                } else {
-                                    0
-                                }
+                                let (field_fm, _) = struct_fm.field(1);
+                                __protocol.i64_field_len(Some(1), *&self.id)
                             }
                             + {
-                                let (field_fm, exist) = struct_fm.field(2);
-                                if exist {
-                                    __protocol.faststr_field_len(Some(2), &self.title)
-                                } else {
-                                    0
-                                }
+                                let (field_fm, _) = struct_fm.field(2);
+                                __protocol.faststr_field_len(Some(2), &self.title)
                             }
                             + __protocol.field_stop_len()
                             + __protocol.struct_end_len()
@@ -733,12 +725,8 @@ pub mod struct_init_with_field_mask {
                         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                             name: "GetItemRequest",
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(1);
-                            if exist {
-                                __protocol.i64_field_len(Some(1), *&self.id)
-                            } else {
-                                0
-                            }
+                            let (field_fm, _) = struct_fm.field(1);
+                            __protocol.i64_field_len(Some(1), *&self.id)
                         } + self.item_opt.as_ref().map_or(0, |value| {
                             let (field_fm, exist) = struct_fm.field(2);
                             if exist {
@@ -754,76 +742,64 @@ pub mod struct_init_with_field_mask {
                                 0
                             }
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(4);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::Binary,
-                                                value_type: ::pilota::thrift::TType::Binary,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.test_map {
-                                        let (item_fm, exist) = map_fm.str(key);
-                                        if exist {
-                                            size += __protocol.faststr_len(key);
-                                            size += __protocol.faststr_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(4);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::Binary,
+                                        value_type: ::pilota::thrift::TType::Binary,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.test_map {
+                                    let (item_fm, exist) = map_fm.str(key);
+                                    if exist {
+                                        size += __protocol.faststr_len(key);
+                                        size += __protocol.faststr_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(4),
-                                        ::pilota::thrift::TType::Binary,
-                                        ::pilota::thrift::TType::Binary,
-                                        &self.test_map,
-                                        |__protocol, key| __protocol.faststr_len(key),
-                                        |__protocol, val| __protocol.faststr_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(4),
+                                    ::pilota::thrift::TType::Binary,
+                                    ::pilota::thrift::TType::Binary,
+                                    &self.test_map,
+                                    |__protocol, key| __protocol.faststr_len(key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
                             }
                         } + {
-                            let (field_fm, exist) = struct_fm.field(5);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I64,
-                                                value_type: ::pilota::thrift::TType::Binary,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.test_map2 {
-                                        let (item_fm, is_exist) = map_fm.int(*key as i32);
-                                        if is_exist {
-                                            size += __protocol.i64_len(*key);
-                                            size += __protocol.faststr_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(5);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I64,
+                                        value_type: ::pilota::thrift::TType::Binary,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.test_map2 {
+                                    let (item_fm, is_exist) = map_fm.int(*key as i32);
+                                    if is_exist {
+                                        size += __protocol.i64_len(*key);
+                                        size += __protocol.faststr_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(5),
-                                        ::pilota::thrift::TType::I64,
-                                        ::pilota::thrift::TType::Binary,
-                                        &self.test_map2,
-                                        |__protocol, key| __protocol.i64_len(*key),
-                                        |__protocol, val| __protocol.faststr_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(5),
+                                    ::pilota::thrift::TType::I64,
+                                    ::pilota::thrift::TType::Binary,
+                                    &self.test_map2,
+                                    |__protocol, key| __protocol.i64_len(*key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
                             }
                         } + __protocol.field_stop_len()
                             + __protocol.struct_end_len()

--- a/pilota-thrift-reflect/src/lib.rs
+++ b/pilota-thrift-reflect/src/lib.rs
@@ -1,5 +1,7 @@
-use std::collections::BTreeMap;
-use std::path::{Component, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Component, PathBuf},
+};
 
 use ahash::AHashMap;
 use descriptor::thrift_reflection::ConstValueType;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
Currently, generated structs from IDL have their field names changed to underscore format in Rust (UserBase -> user_base). Users who needs the format to line up with the IDL would have to write their own plugin which is inconvenient.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Adds `preserve_idl_field_names` flag to `SerdePlugin` which emits #[serde(rename = "<original IDL name>")] on each field that doesn't already carry an explicit #[serde(rename)], restoring the IDL spelling in the serialized output without overriding user-specified renames.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
