### PR TITLE
fix(pilota-build): don't gate required field size by field mask

### DIFF
--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -345,6 +345,36 @@ fn test_thrift_fieldmask() {
     let mut protocol = pilota::thrift::binary::TBinaryProtocol::new(&mut encoded_buf, true);
     let parsed_request = fieldmask::fieldmask::fieldmask::Request::decode(&mut protocol).unwrap();
     println!("{:?}", parsed_request);
+
+    // 白名单模式，且 mask 不包含 required 字段 f9：f9 的 field mask `exist` 为
+    // false。 required 字段不应被 field mask 门控，因此 f9
+    // 必须照常编码。这里断言 size() 与 encode() 写出的字节数一致，从而回归验证
+    // size 生成器与 encode 生成器对 required 字段的处理保持一致（否则 framed
+    // 传输的长度前缀会与实际载荷不符）。
+    let mut request_required = request_clone.clone();
+    let required_mask = pilota_thrift_fieldmask::FieldMaskBuilder::new(&desc, &["$.f1"])
+        .build()
+        .unwrap();
+    request_required.set_field_mask(required_mask);
+
+    let required_size =
+        request_required.size(&mut pilota::thrift::binary::TBinaryProtocol::new((), false));
+    let mut required_buf = pilota::BytesMut::new();
+    request_required
+        .encode(&mut pilota::thrift::binary::TBinaryProtocol::new(
+            &mut required_buf,
+            false,
+        ))
+        .unwrap();
+    assert_eq!(required_size, required_buf.len());
+
+    let mut required_encoded = required_buf.freeze();
+    let mut required_protocol =
+        pilota::thrift::binary::TBinaryProtocol::new(&mut required_encoded, false);
+    let required_parsed =
+        fieldmask::fieldmask::fieldmask::Request::decode(&mut required_protocol).unwrap();
+    // required 字段即使不在白名单中也必须被序列化并可解码回来。
+    assert_eq!(required_parsed.f9, request_clone.f9);
 }
 
 #[test]

--- a/pilota-build/src/codegen/thrift/mod.rs
+++ b/pilota-build/src/codegen/thrift/mod.rs
@@ -94,12 +94,8 @@ impl ThriftBackend {
                 );
                 format! {
                     r#"{{
-                        let (field_fm, exist) = struct_fm.field({field_id});
-                        if exist {{
-                            {write_field_size_with_field_mask}
-                        }} else {{
-                            0
-                        }}
+                        let (field_fm, _) = struct_fm.field({field_id});
+                        {write_field_size_with_field_mask}
                     }}"#
                 }
                 .into()

--- a/pilota-build/test_data/thrift_with_field_mask/complex_enum_key_map.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/complex_enum_key_map.rs
@@ -303,12 +303,8 @@ pub mod complex_enum_key_map {
                         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                             name: "NestedItem",
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(1);
-                            if exist {
-                                __protocol.i32_field_len(Some(1), *&self.value)
-                            } else {
-                                0
-                            }
+                            let (field_fm, _) = struct_fm.field(1);
+                            __protocol.i32_field_len(Some(1), *&self.value)
                         } + self.label.as_ref().map_or(0, |value| {
                             let (field_fm, exist) = struct_fm.field(2);
                             if exist {
@@ -1007,132 +1003,98 @@ pub mod complex_enum_key_map {
                         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                             name: "ComplexEnumKeyMapTest",
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(1);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::I32,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.priority_counts {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += __protocol.i32_len(*val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(1);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::I32,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.priority_counts {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += __protocol.i32_len(*val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(1),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::I32,
-                                        &self.priority_counts,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| __protocol.i32_len(*val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(1),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::I32,
+                                    &self.priority_counts,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| __protocol.i32_len(*val),
+                                )
                             }
                         } + {
-                            let (field_fm, exist) = struct_fm.field(2);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::Struct,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.priority_items {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += __protocol.struct_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(2);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::Struct,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.priority_items {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += __protocol.struct_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(2),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::Struct,
-                                        &self.priority_items,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| __protocol.struct_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(2),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::Struct,
+                                    &self.priority_items,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| __protocol.struct_len(val),
+                                )
                             }
                         } + {
-                            let (field_fm, exist) = struct_fm.field(3);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::Map,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.nested_maps {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += if let Some(map_fm) = item_fm {
-                                                let mut size = __protocol.map_begin_len(
-                                                    ::pilota::thrift::TMapIdentifier {
-                                                        key_type: ::pilota::thrift::TType::Binary,
-                                                        value_type: ::pilota::thrift::TType::I32,
-                                                        size: 0,
-                                                    },
-                                                ) + __protocol.map_end_len();
-                                                for (key, val) in val {
-                                                    let (item_fm, exist) = map_fm.str(key);
-                                                    if exist {
-                                                        size += __protocol.faststr_len(key);
-                                                        size += __protocol.i32_len(*val);
-                                                    }
+                            let (field_fm, _) = struct_fm.field(3);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::Map,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.nested_maps {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += if let Some(map_fm) = item_fm {
+                                            let mut size = __protocol.map_begin_len(
+                                                ::pilota::thrift::TMapIdentifier {
+                                                    key_type: ::pilota::thrift::TType::Binary,
+                                                    value_type: ::pilota::thrift::TType::I32,
+                                                    size: 0,
+                                                },
+                                            ) + __protocol.map_end_len();
+                                            for (key, val) in val {
+                                                let (item_fm, exist) = map_fm.str(key);
+                                                if exist {
+                                                    size += __protocol.faststr_len(key);
+                                                    size += __protocol.i32_len(*val);
                                                 }
-                                                size
-                                            } else {
-                                                __protocol.map_len(
-                                                    ::pilota::thrift::TType::Binary,
-                                                    ::pilota::thrift::TType::I32,
-                                                    val,
-                                                    |__protocol, key| __protocol.faststr_len(key),
-                                                    |__protocol, val| __protocol.i32_len(*val),
-                                                )
-                                            };
-                                        }
-                                    }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(3),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::Map,
-                                        &self.nested_maps,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| {
+                                            }
+                                            size
+                                        } else {
                                             __protocol.map_len(
                                                 ::pilota::thrift::TType::Binary,
                                                 ::pilota::thrift::TType::I32,
@@ -1140,11 +1102,27 @@ pub mod complex_enum_key_map {
                                                 |__protocol, key| __protocol.faststr_len(key),
                                                 |__protocol, val| __protocol.i32_len(*val),
                                             )
-                                        },
-                                    )
+                                        };
+                                    }
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(3),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::Map,
+                                    &self.nested_maps,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| {
+                                        __protocol.map_len(
+                                            ::pilota::thrift::TType::Binary,
+                                            ::pilota::thrift::TType::I32,
+                                            val,
+                                            |__protocol, key| __protocol.faststr_len(key),
+                                            |__protocol, val| __protocol.i32_len(*val),
+                                        )
+                                    },
+                                )
                             }
                         } + self.priority_item_lists.as_ref().map_or(0, |value| {
                             let (field_fm, exist) = struct_fm.field(4);

--- a/pilota-build/test_data/thrift_with_field_mask/enum_key_map.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/enum_key_map.rs
@@ -310,20 +310,12 @@ pub mod enum_key_map {
                         __protocol
                             .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
                             + {
-                                let (field_fm, exist) = struct_fm.field(1);
-                                if exist {
-                                    __protocol.i64_field_len(Some(1), *&self.id)
-                                } else {
-                                    0
-                                }
+                                let (field_fm, _) = struct_fm.field(1);
+                                __protocol.i64_field_len(Some(1), *&self.id)
                             }
                             + {
-                                let (field_fm, exist) = struct_fm.field(2);
-                                if exist {
-                                    __protocol.faststr_field_len(Some(2), &self.name)
-                                } else {
-                                    0
-                                }
+                                let (field_fm, _) = struct_fm.field(2);
+                                __protocol.faststr_field_len(Some(2), &self.name)
                             }
                             + __protocol.field_stop_len()
                             + __protocol.struct_end_len()
@@ -839,76 +831,64 @@ pub mod enum_key_map {
                         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                             name: "EnumKeyMapTest",
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(1);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::Binary,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.status_map {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += __protocol.faststr_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(1);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::Binary,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.status_map {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += __protocol.faststr_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(1),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::Binary,
-                                        &self.status_map,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| __protocol.faststr_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(1),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::Binary,
+                                    &self.status_map,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
                             }
                         } + {
-                            let (field_fm, exist) = struct_fm.field(2);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I32,
-                                                value_type: ::pilota::thrift::TType::Struct,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.status_item_map {
-                                        let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
-                                        if is_exist {
-                                            size += __protocol.struct_len(key);
-                                            size += __protocol.struct_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(2);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I32,
+                                        value_type: ::pilota::thrift::TType::Struct,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.status_item_map {
+                                    let (item_fm, is_exist) = map_fm.int(key.inner() as i32);
+                                    if is_exist {
+                                        size += __protocol.struct_len(key);
+                                        size += __protocol.struct_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(2),
-                                        ::pilota::thrift::TType::I32,
-                                        ::pilota::thrift::TType::Struct,
-                                        &self.status_item_map,
-                                        |__protocol, key| __protocol.struct_len(key),
-                                        |__protocol, val| __protocol.struct_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(2),
+                                    ::pilota::thrift::TType::I32,
+                                    ::pilota::thrift::TType::Struct,
+                                    &self.status_item_map,
+                                    |__protocol, key| __protocol.struct_len(key),
+                                    |__protocol, val| __protocol.struct_len(val),
+                                )
                             }
                         } + self.status_list_map.as_ref().map_or(0, |value| {
                             let (field_fm, exist) = struct_fm.field(3);

--- a/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
+++ b/pilota-build/test_data/thrift_with_field_mask/struct_init_with_field_mask.rs
@@ -209,20 +209,12 @@ pub mod struct_init_with_field_mask {
                         __protocol
                             .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "Item" })
                             + {
-                                let (field_fm, exist) = struct_fm.field(1);
-                                if exist {
-                                    __protocol.i64_field_len(Some(1), *&self.id)
-                                } else {
-                                    0
-                                }
+                                let (field_fm, _) = struct_fm.field(1);
+                                __protocol.i64_field_len(Some(1), *&self.id)
                             }
                             + {
-                                let (field_fm, exist) = struct_fm.field(2);
-                                if exist {
-                                    __protocol.faststr_field_len(Some(2), &self.title)
-                                } else {
-                                    0
-                                }
+                                let (field_fm, _) = struct_fm.field(2);
+                                __protocol.faststr_field_len(Some(2), &self.title)
                             }
                             + __protocol.field_stop_len()
                             + __protocol.struct_end_len()
@@ -733,12 +725,8 @@ pub mod struct_init_with_field_mask {
                         __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier {
                             name: "GetItemRequest",
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(1);
-                            if exist {
-                                __protocol.i64_field_len(Some(1), *&self.id)
-                            } else {
-                                0
-                            }
+                            let (field_fm, _) = struct_fm.field(1);
+                            __protocol.i64_field_len(Some(1), *&self.id)
                         } + self.item_opt.as_ref().map_or(0, |value| {
                             let (field_fm, exist) = struct_fm.field(2);
                             if exist {
@@ -754,76 +742,64 @@ pub mod struct_init_with_field_mask {
                                 0
                             }
                         }) + {
-                            let (field_fm, exist) = struct_fm.field(4);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::Binary,
-                                                value_type: ::pilota::thrift::TType::Binary,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.test_map {
-                                        let (item_fm, exist) = map_fm.str(key);
-                                        if exist {
-                                            size += __protocol.faststr_len(key);
-                                            size += __protocol.faststr_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(4);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::Binary,
+                                        value_type: ::pilota::thrift::TType::Binary,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.test_map {
+                                    let (item_fm, exist) = map_fm.str(key);
+                                    if exist {
+                                        size += __protocol.faststr_len(key);
+                                        size += __protocol.faststr_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(4),
-                                        ::pilota::thrift::TType::Binary,
-                                        ::pilota::thrift::TType::Binary,
-                                        &self.test_map,
-                                        |__protocol, key| __protocol.faststr_len(key),
-                                        |__protocol, val| __protocol.faststr_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(4),
+                                    ::pilota::thrift::TType::Binary,
+                                    ::pilota::thrift::TType::Binary,
+                                    &self.test_map,
+                                    |__protocol, key| __protocol.faststr_len(key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
                             }
                         } + {
-                            let (field_fm, exist) = struct_fm.field(5);
-                            if exist {
-                                if let Some(map_fm) = field_fm {
-                                    let mut size = __protocol
-                                        .field_begin_len(::pilota::thrift::TType::Map, None)
-                                        + __protocol.field_end_len()
-                                        + __protocol.map_begin_len(
-                                            ::pilota::thrift::TMapIdentifier {
-                                                key_type: ::pilota::thrift::TType::I64,
-                                                value_type: ::pilota::thrift::TType::Binary,
-                                                size: 0,
-                                            },
-                                        )
-                                        + __protocol.map_end_len();
-                                    for (key, val) in &self.test_map2 {
-                                        let (item_fm, is_exist) = map_fm.int(*key as i32);
-                                        if is_exist {
-                                            size += __protocol.i64_len(*key);
-                                            size += __protocol.faststr_len(val);
-                                        }
+                            let (field_fm, _) = struct_fm.field(5);
+                            if let Some(map_fm) = field_fm {
+                                let mut size = __protocol
+                                    .field_begin_len(::pilota::thrift::TType::Map, None)
+                                    + __protocol.field_end_len()
+                                    + __protocol.map_begin_len(::pilota::thrift::TMapIdentifier {
+                                        key_type: ::pilota::thrift::TType::I64,
+                                        value_type: ::pilota::thrift::TType::Binary,
+                                        size: 0,
+                                    })
+                                    + __protocol.map_end_len();
+                                for (key, val) in &self.test_map2 {
+                                    let (item_fm, is_exist) = map_fm.int(*key as i32);
+                                    if is_exist {
+                                        size += __protocol.i64_len(*key);
+                                        size += __protocol.faststr_len(val);
                                     }
-                                    size
-                                } else {
-                                    __protocol.map_field_len(
-                                        Some(5),
-                                        ::pilota::thrift::TType::I64,
-                                        ::pilota::thrift::TType::Binary,
-                                        &self.test_map2,
-                                        |__protocol, key| __protocol.i64_len(*key),
-                                        |__protocol, val| __protocol.faststr_len(val),
-                                    )
                                 }
+                                size
                             } else {
-                                0
+                                __protocol.map_field_len(
+                                    Some(5),
+                                    ::pilota::thrift::TType::I64,
+                                    ::pilota::thrift::TType::Binary,
+                                    &self.test_map2,
+                                    |__protocol, key| __protocol.i64_len(*key),
+                                    |__protocol, val| __protocol.faststr_len(val),
+                                )
                             }
                         } + __protocol.field_stop_len()
                             + __protocol.struct_end_len()


### PR DESCRIPTION
## What changed

- Always include required Thrift fields when generating field-mask-aware `size()` code.
- Keep the nested field mask available for sizing child values while ignoring whether the required field itself appears in the mask.
- Add a regression test that verifies `size()` matches the encoded byte length and that a required field excluded from a whitelist mask is still serialized.
- Refresh the affected field-mask codegen fixtures.

## Why

Required fields are always encoded, even when they are absent from a field-mask whitelist. The generated `size()` implementation incorrectly checked the mask's `exist` flag and returned zero for those fields, so its result could differ from the actual encoded payload size.

## Impact

This keeps generated size calculations consistent with encoding and prevents incorrect length prefixes in framed transports when a required field is not selected by the field mask.

## Validation

- `cargo test -p examples test_thrift_fieldmask`