### PR TITLE
feat(pilota-build): add ConfiguredSerdePlugin to preserve IDL fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-build"
-version = "0.13.9"
+version = "0.13.10"
 dependencies = [
  "ahash",
  "anyhow",

--- a/pilota-build/Cargo.toml
+++ b/pilota-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-build"
-version = "0.13.9"
+version = "0.13.10"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-build/src/parser/protobuf/mod.rs
+++ b/pilota-build/src/parser/protobuf/mod.rs
@@ -458,7 +458,7 @@ impl Lower {
                                     &nested_messages,
                                     false,
                                 )],
-                                tags: Default::default(),
+                                tags: Arc::new(self.extract_field_tags(f)),
                                 item_exts: ext::ItemExts::Pb(ext::pb::ItemExts {
                                     used_options: ext::pb::UsedOptions::from_pb_unknown_fields(
                                         ExtendeeKind::Field,

--- a/pilota-build/src/parser/thrift/mod.rs
+++ b/pilota-build/src/parser/thrift/mod.rs
@@ -505,7 +505,7 @@ impl ThriftLower {
                     name: self.lower_ident(&f.name),
                     discr: None,
                     fields: vec![self.lower_ty(&f.ty)],
-                    tags: Default::default(),
+                    tags: Arc::new(self.extract_tags(&f.annotations)),
                     item_exts: ext::ItemExts::Thrift,
                 })
                 .collect(),

--- a/pilota-build/src/plugin/mod.rs
+++ b/pilota-build/src/plugin/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 mod serde;
 mod workspace;
 
-pub use self::serde::SerdePlugin;
+pub use self::serde::{ConfiguredSerdePlugin, SerdePlugin};
 
 pub trait Plugin: Sync + Send {
     fn on_codegen_uint(&mut self, cx: &Context, items: &[DefId]) {

--- a/pilota-build/src/plugin/serde.rs
+++ b/pilota-build/src/plugin/serde.rs
@@ -1,9 +1,122 @@
-use crate::tags::SerdeAttribute;
+use syn::{Meta, Token, parse::Parser, punctuated::Punctuated};
 
-#[derive(Clone, Copy)]
+use crate::{Plugin, tags::SerdeAttribute};
+
+#[derive(Clone, Copy, Default)]
 pub struct SerdePlugin;
 
-impl crate::Plugin for SerdePlugin {
+#[derive(Clone, Copy)]
+pub struct ConfiguredSerdePlugin {
+    preserve_idl_field_names: bool,
+}
+
+impl SerdePlugin {
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Preserve the original IDL field names in the generated serde
+    /// attributes instead of pilota's Rust-cased identifiers.
+    ///
+    /// When enabled, the emitted `#[serde(rename = "...")]` attributes use
+    /// each field's name exactly as written in the IDL rather than the
+    /// generated Rust names. Disabled by default.
+    pub const fn preserve_idl_field_names(self, enable: bool) -> ConfiguredSerdePlugin {
+        ConfiguredSerdePlugin {
+            preserve_idl_field_names: enable,
+        }
+    }
+}
+
+/// Which directions the serde attributes in `s` already rename, as
+/// `(serialize, deserialize)`.
+///
+/// `rename = "x"` renames both, while `rename(serialize = "x")` renames only
+/// one and leaves the other still spelled as the Rust ident.
+fn serde_renames(s: &str) -> (bool, bool) {
+    let Ok(attrs) = syn::Attribute::parse_outer.parse_str(s) else {
+        return (false, false);
+    };
+    let renames = attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("serde"))
+        .filter_map(|attr| {
+            attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                .ok()
+        })
+        .flatten()
+        .filter(|meta| meta.path().is_ident("rename"));
+
+    let (mut ser, mut de) = (false, false);
+    for rename in renames {
+        match rename {
+            Meta::NameValue(_) => return (true, true),
+            Meta::List(list) => {
+                if let Ok(dirs) =
+                    list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)
+                {
+                    ser |= dirs.iter().any(|d| d.path().is_ident("serialize"));
+                    de |= dirs.iter().any(|d| d.path().is_ident("deserialize"));
+                }
+            }
+            Meta::Path(_) => {}
+        }
+    }
+    (ser, de)
+}
+
+/// Emits the `#[serde(rename = ..)]` that keeps `name`, the IDL spelling, for
+/// whichever directions `idl_attr` has not already renamed itself.
+fn preserve_idl_name(
+    cx: &crate::Context,
+    def_id: crate::DefId,
+    name: &str,
+    idl_attr: Option<&str>,
+) {
+    // A `rename` from the IDL is the more specific one, so it wins over the one
+    // we would derive from the name.
+    let attr = match idl_attr.map(serde_renames).unwrap_or((false, false)) {
+        (true, true) => return,
+        (false, false) => format!("#[serde(rename = {name:?})]"),
+        (true, false) => format!("#[serde(rename(deserialize = {name:?}))]"),
+        (false, true) => format!("#[serde(rename(serialize = {name:?}))]"),
+    };
+    cx.with_adjust_mut(def_id, |adj| adj.add_attrs(&[attr.into()]));
+}
+
+/// Plain `SerdePlugin` is just the configured one with every option off.
+impl Plugin for SerdePlugin {
+    fn on_item(
+        &mut self,
+        cx: &crate::Context,
+        def_id: crate::DefId,
+        item: std::sync::Arc<crate::rir::Item>,
+    ) {
+        self.preserve_idl_field_names(false)
+            .on_item(cx, def_id, item)
+    }
+
+    fn on_field(
+        &mut self,
+        cx: &crate::Context,
+        def_id: crate::DefId,
+        f: std::sync::Arc<crate::rir::Field>,
+    ) {
+        self.preserve_idl_field_names(false).on_field(cx, def_id, f)
+    }
+
+    fn on_variant(
+        &mut self,
+        cx: &crate::Context,
+        def_id: crate::DefId,
+        variant: std::sync::Arc<crate::rir::EnumVariant>,
+    ) {
+        self.preserve_idl_field_names(false)
+            .on_variant(cx, def_id, variant)
+    }
+}
+
+impl Plugin for ConfiguredSerdePlugin {
     fn on_item(
         &mut self,
         cx: &crate::Context,
@@ -49,12 +162,17 @@ impl crate::Plugin for SerdePlugin {
         def_id: crate::DefId,
         f: std::sync::Arc<crate::rir::Field>,
     ) {
-        if let Some(attribute) = cx
+        let idl_attr = cx
             .tags(f.tags_id)
             .and_then(|tags| tags.get::<SerdeAttribute>().cloned())
-        {
-            let attr = attribute.0.replace('\\', "");
+            .map(|attribute| attribute.0.replace('\\', ""));
+
+        if let Some(attr) = idl_attr.clone() {
             cx.with_adjust_mut(def_id, |adj| adj.add_attrs(&[attr.into()]))
+        }
+
+        if self.preserve_idl_field_names {
+            preserve_idl_name(cx, def_id, &f.name.raw_str(), idl_attr.as_deref());
         }
     }
 
@@ -64,12 +182,66 @@ impl crate::Plugin for SerdePlugin {
         def_id: crate::DefId,
         variant: std::sync::Arc<crate::rir::EnumVariant>,
     ) {
-        if let Some(attribute) = cx
+        let idl_attr = cx
             .node_tags(variant.did)
             .and_then(|tags| tags.get::<SerdeAttribute>().cloned())
-        {
-            let attr = attribute.0.replace('\\', "");
+            .map(|attribute| attribute.0.replace('\\', ""));
+
+        if let Some(attr) = idl_attr.clone() {
             cx.with_adjust_mut(def_id, |adj| adj.add_attrs(&[attr.into()]))
+        }
+
+        if self.preserve_idl_field_names {
+            preserve_idl_name(cx, def_id, &variant.name.raw_str(), idl_attr.as_deref());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::serde_renames;
+
+    #[test]
+    fn detects_rename_of_both_directions() {
+        assert_eq!(serde_renames(r#"#[serde(rename = "AA")]"#), (true, true));
+        assert_eq!(
+            serde_renames(r#"#[serde(default, rename = "AA")]"#),
+            (true, true)
+        );
+        assert_eq!(
+            serde_renames(r#"#[serde(rename(serialize = "a", deserialize = "b"))]"#),
+            (true, true)
+        );
+    }
+
+    #[test]
+    fn detects_rename_of_one_direction() {
+        assert_eq!(
+            serde_renames(r#"#[serde(rename(serialize = "a"))]"#),
+            (true, false)
+        );
+        assert_eq!(
+            serde_renames(r#"#[serde(rename(deserialize = "b"))]"#),
+            (false, true)
+        );
+    }
+
+    #[test]
+    fn ignores_attrs_that_merely_embed_the_word() {
+        for s in [
+            r#"#[serde(alias = "renamed_value")]"#,
+            r#"#[serde(rename_all = "camelCase")]"#,
+            r#"#[serde(untagged)]"#,
+            r#"#[serde(skip_serializing_if = "rename")]"#,
+        ] {
+            assert_eq!(serde_renames(s), (false, false), "{s}");
+        }
+    }
+
+    #[test]
+    fn ignores_non_serde_and_unparsable_attrs() {
+        for s in [r#"#[other(rename = "AA")]"#, "not an attribute", ""] {
+            assert_eq!(serde_renames(s), (false, false), "{s}");
         }
     }
 }

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -347,7 +347,12 @@ fn test_plugin_preserve_idl_names_thrift(source: impl AsRef<Path>, target: impl 
 fn test_plugin_preserve_idl_names_pb(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     test_with_builder(source, target, |source, target| {
         crate::Builder::pb()
-            .ignore_unused(false)
+            // The IDL imports `pilota.proto` for the option extensions, which
+            // transitively pulls in `descriptor.proto`. Keeping unused items
+            // would generate all of it, burying the cases under test, so touch
+            // `A` instead: it is the only root here, as there is no service.
+            .ignore_unused(true)
+            .touch([(source.to_path_buf(), vec!["A"])])
             .plugin(SerdePlugin.preserve_idl_field_names(true))
             .include_dirs(vec![source.parent().unwrap().to_path_buf()])
             .compile_with_config(

--- a/pilota-build/src/test/mod.rs
+++ b/pilota-build/src/test/mod.rs
@@ -332,6 +332,31 @@ fn test_plugin_thrift(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     });
 }
 
+fn test_plugin_preserve_idl_names_thrift(source: impl AsRef<Path>, target: impl AsRef<Path>) {
+    test_with_builder(source, target, |source, target| {
+        crate::Builder::thrift()
+            .ignore_unused(false)
+            .plugin(SerdePlugin.preserve_idl_field_names(true))
+            .compile_with_config(
+                vec![IdlService::from_path(source.to_path_buf())],
+                crate::Output::File(target.into()),
+            )
+    });
+}
+
+fn test_plugin_preserve_idl_names_pb(source: impl AsRef<Path>, target: impl AsRef<Path>) {
+    test_with_builder(source, target, |source, target| {
+        crate::Builder::pb()
+            .ignore_unused(false)
+            .plugin(SerdePlugin.preserve_idl_field_names(true))
+            .include_dirs(vec![source.parent().unwrap().to_path_buf()])
+            .compile_with_config(
+                vec![IdlService::from_path(source.to_path_buf())],
+                crate::Output::File(target.into()),
+            )
+    });
+}
+
 fn test_plugin_pb(source: impl AsRef<Path>, target: impl AsRef<Path>) {
     test_with_builder(source, target, |source, target| {
         crate::Builder::pb()
@@ -534,6 +559,32 @@ fn test_plugin_gen() {
             }
         }
     });
+}
+
+#[test]
+fn test_serde_preserve_idl_names_gen() {
+    let file_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test_data")
+        .join("plugin_preserve_idl_names")
+        .join("serde_preserve_idl_names.thrift");
+
+    let mut out_path = file_path.clone();
+    out_path.set_extension("rs");
+
+    test_plugin_preserve_idl_names_thrift(file_path, out_path);
+}
+
+#[test]
+fn test_serde_preserve_idl_names_pb_gen() {
+    let file_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test_data")
+        .join("plugin_preserve_idl_names")
+        .join("serde_preserve_idl_names_pb.proto");
+
+    let mut out_path = file_path.clone();
+    out_path.set_extension("rs");
+
+    test_plugin_preserve_idl_names_pb(file_path, out_path);
 }
 
 #[test]

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.rs
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.rs
@@ -381,7 +381,7 @@ pub mod serde_preserve_idl_names {
         }
         impl ::std::default::Default for TestUnion {
             fn default() -> Self {
-                TestUnion::StringValue(::std::default::Default::default())
+                TestUnion::Type(::std::default::Default::default())
             }
         }
         #[derive(
@@ -396,14 +396,29 @@ pub mod serde_preserve_idl_names {
             PartialEq,
         )]
         pub enum TestUnion {
-            #[serde(rename = "StringValue")]
-            StringValue(::pilota::FastStr),
+            #[serde(rename = "type")]
+            Type(::pilota::FastStr),
 
-            #[serde(rename = "pub")]
-            Pub(i32),
+            #[serde(rename = "some_field")]
+            SomeField(::pilota::FastStr),
 
-            #[serde(rename = "int_value")]
-            IntValue(::pilota::FastStr),
+            #[serde(rename = "CC")]
+            C(::pilota::FastStr),
+
+            #[serde(alias = "renamed_value")]
+            #[serde(rename = "d")]
+            D(::pilota::FastStr),
+
+            #[serde(rename(serialize = "EE"))]
+            #[serde(rename(deserialize = "ser_only"))]
+            SerOnly(::pilota::FastStr),
+
+            #[serde(rename(deserialize = "FF"))]
+            #[serde(rename(serialize = "de_only"))]
+            DeOnly(::pilota::FastStr),
+
+            #[serde(rename(serialize = "GS", deserialize = "GD"))]
+            BothDirs(::pilota::FastStr),
         }
 
         impl ::pilota::thrift::Message for TestUnion {
@@ -417,14 +432,26 @@ pub mod serde_preserve_idl_names {
                     name: "TestUnion",
                 })?;
                 match self {
-                    TestUnion::StringValue(value) => {
+                    TestUnion::Type(value) => {
                         __protocol.write_faststr_field(1, (value).clone())?;
                     }
-                    TestUnion::Pub(value) => {
-                        __protocol.write_i32_field(2, *value)?;
+                    TestUnion::SomeField(value) => {
+                        __protocol.write_faststr_field(2, (value).clone())?;
                     }
-                    TestUnion::IntValue(value) => {
+                    TestUnion::C(value) => {
                         __protocol.write_faststr_field(3, (value).clone())?;
+                    }
+                    TestUnion::D(value) => {
+                        __protocol.write_faststr_field(4, (value).clone())?;
+                    }
+                    TestUnion::SerOnly(value) => {
+                        __protocol.write_faststr_field(5, (value).clone())?;
+                    }
+                    TestUnion::DeOnly(value) => {
+                        __protocol.write_faststr_field(6, (value).clone())?;
+                    }
+                    TestUnion::BothDirs(value) => {
+                        __protocol.write_faststr_field(7, (value).clone())?;
                     }
                 }
                 __protocol.write_field_stop()?;
@@ -452,7 +479,7 @@ pub mod serde_preserve_idl_names {
                             if ret.is_none() {
                                 let field_ident = __protocol.read_faststr()?;
                                 __protocol.faststr_len(&field_ident);
-                                ret = Some(TestUnion::StringValue(field_ident));
+                                ret = Some(TestUnion::Type(field_ident));
                             } else {
                                 return ::std::result::Result::Err(
                                     ::pilota::thrift::new_protocol_exception(
@@ -464,9 +491,9 @@ pub mod serde_preserve_idl_names {
                         }
                         Some(2) => {
                             if ret.is_none() {
-                                let field_ident = __protocol.read_i32()?;
-                                __protocol.i32_len(*&field_ident);
-                                ret = Some(TestUnion::Pub(field_ident));
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::SomeField(field_ident));
                             } else {
                                 return ::std::result::Result::Err(
                                     ::pilota::thrift::new_protocol_exception(
@@ -480,7 +507,63 @@ pub mod serde_preserve_idl_names {
                             if ret.is_none() {
                                 let field_ident = __protocol.read_faststr()?;
                                 __protocol.faststr_len(&field_ident);
-                                ret = Some(TestUnion::IntValue(field_ident));
+                                ret = Some(TestUnion::C(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        Some(4) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::D(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        Some(5) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::SerOnly(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        Some(6) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::DeOnly(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        Some(7) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::BothDirs(field_ident));
                             } else {
                                 return ::std::result::Result::Err(
                                     ::pilota::thrift::new_protocol_exception(
@@ -531,7 +614,7 @@ pub mod serde_preserve_idl_names {
                                 if ret.is_none() {
                                     let field_ident = __protocol.read_faststr().await?;
 
-                                    ret = Some(TestUnion::StringValue(field_ident));
+                                    ret = Some(TestUnion::Type(field_ident));
                                 } else {
                                     return ::std::result::Result::Err(
                                         ::pilota::thrift::new_protocol_exception(
@@ -543,9 +626,9 @@ pub mod serde_preserve_idl_names {
                             }
                             Some(2) => {
                                 if ret.is_none() {
-                                    let field_ident = __protocol.read_i32().await?;
+                                    let field_ident = __protocol.read_faststr().await?;
 
-                                    ret = Some(TestUnion::Pub(field_ident));
+                                    ret = Some(TestUnion::SomeField(field_ident));
                                 } else {
                                     return ::std::result::Result::Err(
                                         ::pilota::thrift::new_protocol_exception(
@@ -559,7 +642,63 @@ pub mod serde_preserve_idl_names {
                                 if ret.is_none() {
                                     let field_ident = __protocol.read_faststr().await?;
 
-                                    ret = Some(TestUnion::IntValue(field_ident));
+                                    ret = Some(TestUnion::C(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            Some(4) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_faststr().await?;
+
+                                    ret = Some(TestUnion::D(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            Some(5) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_faststr().await?;
+
+                                    ret = Some(TestUnion::SerOnly(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            Some(6) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_faststr().await?;
+
+                                    ret = Some(TestUnion::DeOnly(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            Some(7) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_faststr().await?;
+
+                                    ret = Some(TestUnion::BothDirs(field_ident));
                                 } else {
                                     return ::std::result::Result::Err(
                                         ::pilota::thrift::new_protocol_exception(
@@ -593,11 +732,13 @@ pub mod serde_preserve_idl_names {
                 __protocol
                     .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "TestUnion" })
                     + match self {
-                        TestUnion::StringValue(value) => {
-                            __protocol.faststr_field_len(Some(1), value)
-                        }
-                        TestUnion::Pub(value) => __protocol.i32_field_len(Some(2), *value),
-                        TestUnion::IntValue(value) => __protocol.faststr_field_len(Some(3), value),
+                        TestUnion::Type(value) => __protocol.faststr_field_len(Some(1), value),
+                        TestUnion::SomeField(value) => __protocol.faststr_field_len(Some(2), value),
+                        TestUnion::C(value) => __protocol.faststr_field_len(Some(3), value),
+                        TestUnion::D(value) => __protocol.faststr_field_len(Some(4), value),
+                        TestUnion::SerOnly(value) => __protocol.faststr_field_len(Some(5), value),
+                        TestUnion::DeOnly(value) => __protocol.faststr_field_len(Some(6), value),
+                        TestUnion::BothDirs(value) => __protocol.faststr_field_len(Some(7), value),
                     }
                     + __protocol.field_stop_len()
                     + __protocol.struct_end_len()

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.rs
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.rs
@@ -1,0 +1,607 @@
+pub mod serde_preserve_idl_names {
+    #![allow(warnings, clippy::all)]
+
+    pub mod serde_preserve_idl_names {
+
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            Default,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
+        pub struct A {
+            #[serde(rename = "type")]
+            pub r#type: ::pilota::FastStr,
+
+            #[serde(rename = "SomeField")]
+            pub some_field: ::pilota::FastStr,
+
+            #[serde(rename = "CC")]
+            pub c: ::pilota::FastStr,
+
+            #[serde(alias = "renamed_value")]
+            #[serde(rename = "d")]
+            pub d: ::pilota::FastStr,
+
+            #[serde(rename(serialize = "EE"))]
+            #[serde(rename(deserialize = "SerOnly"))]
+            pub ser_only: ::pilota::FastStr,
+
+            #[serde(rename(deserialize = "FF"))]
+            #[serde(rename(serialize = "DeOnly"))]
+            pub de_only: ::pilota::FastStr,
+
+            #[serde(rename(serialize = "GS", deserialize = "GD"))]
+            pub both_dirs: ::pilota::FastStr,
+        }
+        impl ::pilota::thrift::Message for A {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                let struct_ident = ::pilota::thrift::TStructIdentifier { name: "A" };
+
+                __protocol.write_struct_begin(&struct_ident)?;
+                __protocol.write_faststr_field(1, (&self.r#type).clone())?;
+                __protocol.write_faststr_field(2, (&self.some_field).clone())?;
+                __protocol.write_faststr_field(3, (&self.c).clone())?;
+                __protocol.write_faststr_field(4, (&self.d).clone())?;
+                __protocol.write_faststr_field(5, (&self.ser_only).clone())?;
+                __protocol.write_faststr_field(6, (&self.de_only).clone())?;
+                __protocol.write_faststr_field(7, (&self.both_dirs).clone())?;
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+
+                let mut var_1 = None;
+                let mut var_2 = None;
+                let mut var_3 = None;
+                let mut var_4 = None;
+                let mut var_5 = None;
+                let mut var_6 = None;
+                let mut var_7 = None;
+
+                let mut __pilota_decoding_field_id = None;
+
+                __protocol.read_struct_begin()?;
+                if let ::std::result::Result::Err(mut err) = (|| {
+                    loop {
+                        let field_ident = __protocol.read_field_begin()?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            __protocol.field_stop_len();
+                            break;
+                        } else {
+                            __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                        }
+                        __pilota_decoding_field_id = field_ident.id;
+                        match field_ident.id {
+                            Some(1)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_1 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(2)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_2 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(3)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_3 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(4)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_4 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(5)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_5 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(6)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_6 = Some(__protocol.read_faststr()?);
+                            }
+                            Some(7)
+                                if field_ident.field_type == ::pilota::thrift::TType::Binary =>
+                            {
+                                var_7 = Some(__protocol.read_faststr()?);
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type)?;
+                            }
+                        }
+
+                        __protocol.read_field_end()?;
+                        __protocol.field_end_len();
+                    }
+                    ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                })() {
+                    if let Some(field_id) = __pilota_decoding_field_id {
+                        err.prepend_msg(&format!(
+                            "decode struct `A` field(#{}) failed, caused by: ",
+                            field_id
+                        ));
+                    }
+                    return ::std::result::Result::Err(err);
+                };
+                __protocol.read_struct_end()?;
+
+                let Some(var_1) = var_1 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field r#type is required".to_string(),
+                    ));
+                };
+                let Some(var_2) = var_2 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field some_field is required".to_string(),
+                    ));
+                };
+                let Some(var_3) = var_3 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field c is required".to_string(),
+                    ));
+                };
+                let Some(var_4) = var_4 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field d is required".to_string(),
+                    ));
+                };
+                let Some(var_5) = var_5 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field ser_only is required".to_string(),
+                    ));
+                };
+                let Some(var_6) = var_6 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field de_only is required".to_string(),
+                    ));
+                };
+                let Some(var_7) = var_7 else {
+                    return ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "field both_dirs is required".to_string(),
+                    ));
+                };
+
+                let data = Self {
+                    r#type: var_1,
+                    some_field: var_2,
+                    c: var_3,
+                    d: var_4,
+                    ser_only: var_5,
+                    de_only: var_6,
+                    both_dirs: var_7,
+                };
+                ::std::result::Result::Ok(data)
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut var_1 = None;
+                    let mut var_2 = None;
+                    let mut var_3 = None;
+                    let mut var_4 = None;
+                    let mut var_5 = None;
+                    let mut var_6 = None;
+                    let mut var_7 = None;
+
+                    let mut __pilota_decoding_field_id = None;
+
+                    __protocol.read_struct_begin().await?;
+                    if let ::std::result::Result::Err(mut err) = async {
+                        loop {
+                            let field_ident = __protocol.read_field_begin().await?;
+                            if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                                break;
+                            } else {
+                            }
+                            __pilota_decoding_field_id = field_ident.id;
+                            match field_ident.id {
+                                Some(1)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_1 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(2)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_2 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(3)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_3 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(4)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_4 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(5)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_5 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(6)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_6 = Some(__protocol.read_faststr().await?);
+                                }
+                                Some(7)
+                                    if field_ident.field_type
+                                        == ::pilota::thrift::TType::Binary =>
+                                {
+                                    var_7 = Some(__protocol.read_faststr().await?);
+                                }
+                                _ => {
+                                    __protocol.skip(field_ident.field_type).await?;
+                                }
+                            }
+
+                            __protocol.read_field_end().await?;
+                        }
+                        ::std::result::Result::Ok::<_, ::pilota::thrift::ThriftException>(())
+                    }
+                    .await
+                    {
+                        if let Some(field_id) = __pilota_decoding_field_id {
+                            err.prepend_msg(&format!(
+                                "decode struct `A` field(#{}) failed, caused by: ",
+                                field_id
+                            ));
+                        }
+                        return ::std::result::Result::Err(err);
+                    };
+                    __protocol.read_struct_end().await?;
+
+                    let Some(var_1) = var_1 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field r#type is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_2) = var_2 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field some_field is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_3) = var_3 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field c is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_4) = var_4 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field d is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_5) = var_5 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field ser_only is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_6) = var_6 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field de_only is required".to_string(),
+                            ),
+                        );
+                    };
+                    let Some(var_7) = var_7 else {
+                        return ::std::result::Result::Err(
+                            ::pilota::thrift::new_protocol_exception(
+                                ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                "field both_dirs is required".to_string(),
+                            ),
+                        );
+                    };
+
+                    let data = Self {
+                        r#type: var_1,
+                        some_field: var_2,
+                        c: var_3,
+                        d: var_4,
+                        ser_only: var_5,
+                        de_only: var_6,
+                        both_dirs: var_7,
+                    };
+                    ::std::result::Result::Ok(data)
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol.struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "A" })
+                    + __protocol.faststr_field_len(Some(1), &self.r#type)
+                    + __protocol.faststr_field_len(Some(2), &self.some_field)
+                    + __protocol.faststr_field_len(Some(3), &self.c)
+                    + __protocol.faststr_field_len(Some(4), &self.d)
+                    + __protocol.faststr_field_len(Some(5), &self.ser_only)
+                    + __protocol.faststr_field_len(Some(6), &self.de_only)
+                    + __protocol.faststr_field_len(Some(7), &self.both_dirs)
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+        impl ::std::default::Default for TestUnion {
+            fn default() -> Self {
+                TestUnion::StringValue(::std::default::Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
+        pub enum TestUnion {
+            #[serde(rename = "StringValue")]
+            StringValue(::pilota::FastStr),
+
+            #[serde(rename = "pub")]
+            Pub(i32),
+
+            #[serde(rename = "int_value")]
+            IntValue(::pilota::FastStr),
+        }
+
+        impl ::pilota::thrift::Message for TestUnion {
+            fn encode<T: ::pilota::thrift::TOutputProtocol>(
+                &self,
+                __protocol: &mut T,
+            ) -> ::std::result::Result<(), ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TOutputProtocolExt;
+                __protocol.write_struct_begin(&::pilota::thrift::TStructIdentifier {
+                    name: "TestUnion",
+                })?;
+                match self {
+                    TestUnion::StringValue(value) => {
+                        __protocol.write_faststr_field(1, (value).clone())?;
+                    }
+                    TestUnion::Pub(value) => {
+                        __protocol.write_i32_field(2, *value)?;
+                    }
+                    TestUnion::IntValue(value) => {
+                        __protocol.write_faststr_field(3, (value).clone())?;
+                    }
+                }
+                __protocol.write_field_stop()?;
+                __protocol.write_struct_end()?;
+                ::std::result::Result::Ok(())
+            }
+
+            fn decode<T: ::pilota::thrift::TInputProtocol>(
+                __protocol: &mut T,
+            ) -> ::std::result::Result<Self, ::pilota::thrift::ThriftException> {
+                #[allow(unused_imports)]
+                use ::pilota::{Buf, thrift::TLengthProtocolExt};
+                let mut ret = None;
+                __protocol.read_struct_begin()?;
+                loop {
+                    let field_ident = __protocol.read_field_begin()?;
+                    if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                        __protocol.field_stop_len();
+                        break;
+                    } else {
+                        __protocol.field_begin_len(field_ident.field_type, field_ident.id);
+                    }
+                    match field_ident.id {
+                        Some(1) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::StringValue(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        Some(2) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_i32()?;
+                                __protocol.i32_len(*&field_ident);
+                                ret = Some(TestUnion::Pub(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        Some(3) => {
+                            if ret.is_none() {
+                                let field_ident = __protocol.read_faststr()?;
+                                __protocol.faststr_len(&field_ident);
+                                ret = Some(TestUnion::IntValue(field_ident));
+                            } else {
+                                return ::std::result::Result::Err(
+                                    ::pilota::thrift::new_protocol_exception(
+                                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                        "received multiple fields for union from remote Message",
+                                    ),
+                                );
+                            }
+                        }
+                        _ => {
+                            __protocol.skip(field_ident.field_type)?;
+                        }
+                    }
+                }
+                __protocol.read_field_end()?;
+                __protocol.read_struct_end()?;
+                if let Some(ret) = ret {
+                    ::std::result::Result::Ok(ret)
+                } else {
+                    ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                        ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                        "received empty union from remote Message",
+                    ))
+                }
+            }
+
+            fn decode_async<'a, T: ::pilota::thrift::TAsyncInputProtocol>(
+                __protocol: &'a mut T,
+            ) -> ::std::pin::Pin<
+                ::std::boxed::Box<
+                    dyn ::std::future::Future<
+                            Output = ::std::result::Result<Self, ::pilota::thrift::ThriftException>,
+                        > + Send
+                        + 'a,
+                >,
+            > {
+                ::std::boxed::Box::pin(async move {
+                    let mut ret = None;
+                    __protocol.read_struct_begin().await?;
+                    loop {
+                        let field_ident = __protocol.read_field_begin().await?;
+                        if field_ident.field_type == ::pilota::thrift::TType::Stop {
+                            break;
+                        } else {
+                        }
+                        match field_ident.id {
+                            Some(1) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_faststr().await?;
+
+                                    ret = Some(TestUnion::StringValue(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            Some(2) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_i32().await?;
+
+                                    ret = Some(TestUnion::Pub(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            Some(3) => {
+                                if ret.is_none() {
+                                    let field_ident = __protocol.read_faststr().await?;
+
+                                    ret = Some(TestUnion::IntValue(field_ident));
+                                } else {
+                                    return ::std::result::Result::Err(
+                                        ::pilota::thrift::new_protocol_exception(
+                                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                                            "received multiple fields for union from remote Message",
+                                        ),
+                                    );
+                                }
+                            }
+                            _ => {
+                                __protocol.skip(field_ident.field_type).await?;
+                            }
+                        }
+                    }
+                    __protocol.read_field_end().await?;
+                    __protocol.read_struct_end().await?;
+                    if let Some(ret) = ret {
+                        ::std::result::Result::Ok(ret)
+                    } else {
+                        ::std::result::Result::Err(::pilota::thrift::new_protocol_exception(
+                            ::pilota::thrift::ProtocolExceptionKind::InvalidData,
+                            "received empty union from remote Message",
+                        ))
+                    }
+                })
+            }
+
+            fn size<T: ::pilota::thrift::TLengthProtocol>(&self, __protocol: &mut T) -> usize {
+                #[allow(unused_imports)]
+                use ::pilota::thrift::TLengthProtocolExt;
+                __protocol
+                    .struct_begin_len(&::pilota::thrift::TStructIdentifier { name: "TestUnion" })
+                    + match self {
+                        TestUnion::StringValue(value) => {
+                            __protocol.faststr_field_len(Some(1), value)
+                        }
+                        TestUnion::Pub(value) => __protocol.i32_field_len(Some(2), *value),
+                        TestUnion::IntValue(value) => __protocol.faststr_field_len(Some(3), value),
+                    }
+                    + __protocol.field_stop_len()
+                    + __protocol.struct_end_len()
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.thrift
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.thrift
@@ -17,12 +17,11 @@ struct A {
 }
 
 union TestUnion {
-    // Already PascalCase: should stay StringValue
-    1: string StringValue,
-
-    // Rust keyword: should become Pub, but serialized name must stay "pub"
-    2: i32 pub,
-
-    // Rewritten to IntValue but renamed to int_value
-    3: string int_value,
+    1: string type,
+    2: string some_field,
+    3: string c(pilota.serde_attribute = "#[serde(rename = \"CC\")]"),
+    4: string d(pilota.serde_attribute = "#[serde(alias = \"renamed_value\")]"),
+    5: string ser_only(pilota.serde_attribute = "#[serde(rename(serialize = \"EE\"))]"),
+    6: string de_only(pilota.serde_attribute = "#[serde(rename(deserialize = \"FF\"))]"),
+    7: string both_dirs(pilota.serde_attribute = "#[serde(rename(serialize = \"GS\", deserialize = \"GD\"))]"),
 }

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.thrift
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names.thrift
@@ -1,0 +1,28 @@
+struct A {
+    // Rust keyword: should become r#type, but renamed to "type"
+    1: required string type,
+    // A name that is rewritten to a snake_case ident: `some_field`.
+    2: required string SomeField,
+    // An explicit rename wins over the generated one.
+    3: required string c(pilota.serde_attribute = "#[serde(rename = \"CC\")]"),
+    // An attribute that merely embeds the word "rename" does not count as one.
+    4: required string d(pilota.serde_attribute = "#[serde(alias = \"renamed_value\")]"),
+    // A rename covering only serialization: deserialization is still spelled
+    // with the Rust ident, so that direction alone gets the IDL name.
+    5: required string SerOnly(pilota.serde_attribute = "#[serde(rename(serialize = \"EE\"))]"),
+    // The mirror case: only serialization is left to preserve.
+    6: required string DeOnly(pilota.serde_attribute = "#[serde(rename(deserialize = \"FF\"))]"),
+    // Both directions renamed explicitly, so preserve has nothing to add.
+    7: required string BothDirs(pilota.serde_attribute = "#[serde(rename(serialize = \"GS\", deserialize = \"GD\"))]"),
+}
+
+union TestUnion {
+    // Already PascalCase: should stay StringValue
+    1: string StringValue,
+
+    // Rust keyword: should become Pub, but serialized name must stay "pub"
+    2: i32 pub,
+
+    // Rewritten to IntValue but renamed to int_value
+    3: string int_value,
+}

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.proto
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+message A { 
+    string SomeField = 1;
+    string type = 2;
+
+    oneof TestOneof {
+        string StringValue = 3;
+        string pub = 4;
+        int32 int_value = 5;
+    }
+}

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.proto
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.proto
@@ -1,12 +1,30 @@
 syntax = "proto3";
 
-message A { 
-    string SomeField = 1;
-    string type = 2;
+import "pilota.proto";
+
+message A {
+    // Rust keyword: should become r#type, but renamed to "type"
+    string type = 1;
+    // A name that is rewritten to a snake_case ident: `some_field`.
+    string SomeField = 2;
+    // An explicit rename wins over the generated one.
+    string c = 3 [(pilota.serde_attribute_field) = "#[serde(rename = \"CC\")]"];
+    // An attribute that merely embeds the word "rename" does not count as one.
+    string d = 4 [(pilota.serde_attribute_field) = "#[serde(alias = \"renamed_value\")]"];
+    // Rename covering only serialization.
+    string SerOnly = 5 [(pilota.serde_attribute_field) = "#[serde(rename(serialize = \"EE\"))]"];
+    // Rename covering only deserialization.
+    string DeOnly = 6 [(pilota.serde_attribute_field) = "#[serde(rename(deserialize = \"FF\"))]"];
+    // Both directions renamed explicitly.
+    string BothDirs = 7 [(pilota.serde_attribute_field) = "#[serde(rename(serialize = \"GS\", deserialize = \"GD\"))]"];
 
     oneof TestOneof {
-        string StringValue = 3;
-        string pub = 4;
-        int32 int_value = 5;
+        string pub = 8;
+        string some_field = 9;
+        string e = 10 [(pilota.serde_attribute_field) = "#[serde(rename = \"CC\")]"];
+        string f = 11 [(pilota.serde_attribute_field) = "#[serde(alias = \"renamed_value\")]"];
+        string ser_only = 12 [(pilota.serde_attribute_field) = "#[serde(rename(serialize = \"EE\"))]"];
+        string de_only = 13 [(pilota.serde_attribute_field) = "#[serde(rename(deserialize = \"FF\"))]"];
+        string both_dirs = 14 [(pilota.serde_attribute_field) = "#[serde(rename(serialize = \"GS\", deserialize = \"GD\"))]"];
     }
 }

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.rs
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.rs
@@ -1,0 +1,197 @@
+pub mod serde_preserve_idl_names_pb {
+    #![allow(warnings, clippy::all)]
+    use ::pilota::{Buf as _, BufMut as _};
+    #[derive(
+        PartialOrd,
+        Hash,
+        Eq,
+        Ord,
+        Debug,
+        Default,
+        ::pilota::serde::Serialize,
+        ::pilota::serde::Deserialize,
+        Clone,
+        PartialEq,
+    )]
+    pub struct A {
+        #[serde(rename = "SomeField")]
+        pub some_field: ::pilota::FastStr,
+
+        #[serde(rename = "type")]
+        pub r#type: ::pilota::FastStr,
+
+        #[serde(rename = "TestOneof")]
+        pub test_oneof: ::std::option::Option<a::TestOneof>,
+    }
+    impl ::pilota::pb::Message for A {
+        #[inline]
+        fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.some_field)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, &self.r#type)
+                + self
+                    .test_oneof
+                    .as_ref()
+                    .map_or(0, |msg| msg.encoded_len(ctx))
+        }
+
+        #[allow(unused_variables)]
+        fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
+            ::pilota::pb::encoding::faststr::encode(1, &self.some_field, buf);
+            ::pilota::pb::encoding::faststr::encode(2, &self.r#type, buf);
+            if let Some(_pilota_inner_value) = self.test_oneof.as_ref() {
+                _pilota_inner_value.encode(buf);
+            }
+        }
+
+        #[allow(unused_variables)]
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: ::pilota::pb::encoding::WireType,
+            buf: &mut ::pilota::Bytes,
+            ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            is_root: bool,
+        ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+            const STRUCT_NAME: &'static str = stringify!(A);
+
+            match tag {
+                1 => {
+                    let mut _inner_pilota_value = &mut self.some_field;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(some_field));
+                            error
+                        })
+                }
+                2 => {
+                    let mut _inner_pilota_value = &mut self.r#type;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(r#type));
+                            error
+                        })
+                }
+                3 | 4 | 5 => {
+                    let mut _inner_pilota_value = &mut self.test_oneof;
+                    a::TestOneof::merge(_inner_pilota_value, tag, wire_type, buf, ctx).map_err(
+                        |mut error| {
+                            error.push(STRUCT_NAME, stringify!(test_oneof));
+                            error
+                        },
+                    )
+                }
+                _ => ::pilota::pb::encoding::skip_field(wire_type, tag, buf, ctx),
+            }
+        }
+    }
+
+    pub mod a {
+        use ::pilota::{Buf as _, BufMut as _};
+
+        impl ::std::default::Default for TestOneof {
+            fn default() -> Self {
+                TestOneof::StringValue(::std::default::Default::default())
+            }
+        }
+        #[derive(
+            PartialOrd,
+            Hash,
+            Eq,
+            Ord,
+            Debug,
+            ::pilota::serde::Serialize,
+            ::pilota::serde::Deserialize,
+            Clone,
+            PartialEq,
+        )]
+        pub enum TestOneof {
+            #[serde(rename = "StringValue")]
+            StringValue(::pilota::FastStr),
+
+            #[serde(rename = "pub")]
+            Pub(::pilota::FastStr),
+
+            #[serde(rename = "int_value")]
+            IntValue(i32),
+        }
+
+        impl TestOneof {
+            pub fn encode(&self, buf: &mut ::pilota::LinkedBytes) {
+                match self {
+                    TestOneof::StringValue(value) => {
+                        ::pilota::pb::encoding::faststr::encode(3, &*value, buf);
+                    }
+                    TestOneof::Pub(value) => {
+                        ::pilota::pb::encoding::faststr::encode(4, &*value, buf);
+                    }
+                    TestOneof::IntValue(value) => {
+                        ::pilota::pb::encoding::int32::encode(5, &*value, buf);
+                    }
+                }
+            }
+
+            #[inline]
+            pub fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
+                match self {
+                    TestOneof::StringValue(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 3, &*value)
+                    }
+                    TestOneof::Pub(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 4, &*value)
+                    }
+                    TestOneof::IntValue(value) => {
+                        ::pilota::pb::encoding::int32::encoded_len(ctx, 5, &*value)
+                    }
+                }
+            }
+
+            #[inline]
+            pub fn merge(
+                field: &mut ::core::option::Option<Self>,
+                tag: u32,
+                wire_type: ::pilota::pb::encoding::WireType,
+                buf: &mut ::pilota::Bytes,
+                ctx: &mut ::pilota::pb::encoding::DecodeContext,
+            ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
+                match tag {
+                    3 => match field {
+                        ::core::option::Option::Some(TestOneof::StringValue(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field =
+                                ::core::option::Option::Some(TestOneof::StringValue(owned_value));
+                        }
+                    },
+                    4 => match field {
+                        ::core::option::Option::Some(TestOneof::Pub(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::Pub(owned_value));
+                        }
+                    },
+                    5 => match field {
+                        ::core::option::Option::Some(TestOneof::IntValue(value)) => {
+                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::IntValue(owned_value));
+                        }
+                    },
+                    _ => unreachable!(concat!("invalid ", stringify!(TestOneof), " tag: {}"), tag),
+                };
+                ::core::result::Result::Ok(())
+            }
+        }
+    }
+}

--- a/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.rs
+++ b/pilota-build/test_data/plugin_preserve_idl_names/serde_preserve_idl_names_pb.rs
@@ -14,11 +14,29 @@ pub mod serde_preserve_idl_names_pb {
         PartialEq,
     )]
     pub struct A {
+        #[serde(rename = "type")]
+        pub r#type: ::pilota::FastStr,
+
         #[serde(rename = "SomeField")]
         pub some_field: ::pilota::FastStr,
 
-        #[serde(rename = "type")]
-        pub r#type: ::pilota::FastStr,
+        #[serde(rename = "CC")]
+        pub c: ::pilota::FastStr,
+
+        #[serde(alias = "renamed_value")]
+        #[serde(rename = "d")]
+        pub d: ::pilota::FastStr,
+
+        #[serde(rename(serialize = "EE"))]
+        #[serde(rename(deserialize = "SerOnly"))]
+        pub ser_only: ::pilota::FastStr,
+
+        #[serde(rename(deserialize = "FF"))]
+        #[serde(rename(serialize = "DeOnly"))]
+        pub de_only: ::pilota::FastStr,
+
+        #[serde(rename(serialize = "GS", deserialize = "GD"))]
+        pub both_dirs: ::pilota::FastStr,
 
         #[serde(rename = "TestOneof")]
         pub test_oneof: ::std::option::Option<a::TestOneof>,
@@ -26,8 +44,13 @@ pub mod serde_preserve_idl_names_pb {
     impl ::pilota::pb::Message for A {
         #[inline]
         fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
-            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.some_field)
-                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, &self.r#type)
+            0 + ::pilota::pb::encoding::faststr::encoded_len(ctx, 1, &self.r#type)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 2, &self.some_field)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 3, &self.c)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 4, &self.d)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 5, &self.ser_only)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 6, &self.de_only)
+                + ::pilota::pb::encoding::faststr::encoded_len(ctx, 7, &self.both_dirs)
                 + self
                     .test_oneof
                     .as_ref()
@@ -36,8 +59,13 @@ pub mod serde_preserve_idl_names_pb {
 
         #[allow(unused_variables)]
         fn encode_raw(&self, buf: &mut ::pilota::LinkedBytes) {
-            ::pilota::pb::encoding::faststr::encode(1, &self.some_field, buf);
-            ::pilota::pb::encoding::faststr::encode(2, &self.r#type, buf);
+            ::pilota::pb::encoding::faststr::encode(1, &self.r#type, buf);
+            ::pilota::pb::encoding::faststr::encode(2, &self.some_field, buf);
+            ::pilota::pb::encoding::faststr::encode(3, &self.c, buf);
+            ::pilota::pb::encoding::faststr::encode(4, &self.d, buf);
+            ::pilota::pb::encoding::faststr::encode(5, &self.ser_only, buf);
+            ::pilota::pb::encoding::faststr::encode(6, &self.de_only, buf);
+            ::pilota::pb::encoding::faststr::encode(7, &self.both_dirs, buf);
             if let Some(_pilota_inner_value) = self.test_oneof.as_ref() {
                 _pilota_inner_value.encode(buf);
             }
@@ -56,14 +84,6 @@ pub mod serde_preserve_idl_names_pb {
 
             match tag {
                 1 => {
-                    let mut _inner_pilota_value = &mut self.some_field;
-                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
-                        .map_err(|mut error| {
-                            error.push(STRUCT_NAME, stringify!(some_field));
-                            error
-                        })
-                }
-                2 => {
                     let mut _inner_pilota_value = &mut self.r#type;
                     ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
                         .map_err(|mut error| {
@@ -71,7 +91,55 @@ pub mod serde_preserve_idl_names_pb {
                             error
                         })
                 }
-                3 | 4 | 5 => {
+                2 => {
+                    let mut _inner_pilota_value = &mut self.some_field;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(some_field));
+                            error
+                        })
+                }
+                3 => {
+                    let mut _inner_pilota_value = &mut self.c;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(c));
+                            error
+                        })
+                }
+                4 => {
+                    let mut _inner_pilota_value = &mut self.d;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(d));
+                            error
+                        })
+                }
+                5 => {
+                    let mut _inner_pilota_value = &mut self.ser_only;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(ser_only));
+                            error
+                        })
+                }
+                6 => {
+                    let mut _inner_pilota_value = &mut self.de_only;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(de_only));
+                            error
+                        })
+                }
+                7 => {
+                    let mut _inner_pilota_value = &mut self.both_dirs;
+                    ::pilota::pb::encoding::faststr::merge(wire_type, _inner_pilota_value, buf, ctx)
+                        .map_err(|mut error| {
+                            error.push(STRUCT_NAME, stringify!(both_dirs));
+                            error
+                        })
+                }
+                8 | 9 | 10 | 11 | 12 | 13 | 14 => {
                     let mut _inner_pilota_value = &mut self.test_oneof;
                     a::TestOneof::merge(_inner_pilota_value, tag, wire_type, buf, ctx).map_err(
                         |mut error| {
@@ -90,7 +158,7 @@ pub mod serde_preserve_idl_names_pb {
 
         impl ::std::default::Default for TestOneof {
             fn default() -> Self {
-                TestOneof::StringValue(::std::default::Default::default())
+                TestOneof::Pub(::std::default::Default::default())
             }
         }
         #[derive(
@@ -105,27 +173,54 @@ pub mod serde_preserve_idl_names_pb {
             PartialEq,
         )]
         pub enum TestOneof {
-            #[serde(rename = "StringValue")]
-            StringValue(::pilota::FastStr),
-
             #[serde(rename = "pub")]
             Pub(::pilota::FastStr),
 
-            #[serde(rename = "int_value")]
-            IntValue(i32),
+            #[serde(rename = "some_field")]
+            SomeField(::pilota::FastStr),
+
+            #[serde(rename = "CC")]
+            E(::pilota::FastStr),
+
+            #[serde(alias = "renamed_value")]
+            #[serde(rename = "f")]
+            F(::pilota::FastStr),
+
+            #[serde(rename(serialize = "EE"))]
+            #[serde(rename(deserialize = "ser_only"))]
+            SerOnly(::pilota::FastStr),
+
+            #[serde(rename(deserialize = "FF"))]
+            #[serde(rename(serialize = "de_only"))]
+            DeOnly(::pilota::FastStr),
+
+            #[serde(rename(serialize = "GS", deserialize = "GD"))]
+            BothDirs(::pilota::FastStr),
         }
 
         impl TestOneof {
             pub fn encode(&self, buf: &mut ::pilota::LinkedBytes) {
                 match self {
-                    TestOneof::StringValue(value) => {
-                        ::pilota::pb::encoding::faststr::encode(3, &*value, buf);
-                    }
                     TestOneof::Pub(value) => {
-                        ::pilota::pb::encoding::faststr::encode(4, &*value, buf);
+                        ::pilota::pb::encoding::faststr::encode(8, &*value, buf);
                     }
-                    TestOneof::IntValue(value) => {
-                        ::pilota::pb::encoding::int32::encode(5, &*value, buf);
+                    TestOneof::SomeField(value) => {
+                        ::pilota::pb::encoding::faststr::encode(9, &*value, buf);
+                    }
+                    TestOneof::E(value) => {
+                        ::pilota::pb::encoding::faststr::encode(10, &*value, buf);
+                    }
+                    TestOneof::F(value) => {
+                        ::pilota::pb::encoding::faststr::encode(11, &*value, buf);
+                    }
+                    TestOneof::SerOnly(value) => {
+                        ::pilota::pb::encoding::faststr::encode(12, &*value, buf);
+                    }
+                    TestOneof::DeOnly(value) => {
+                        ::pilota::pb::encoding::faststr::encode(13, &*value, buf);
+                    }
+                    TestOneof::BothDirs(value) => {
+                        ::pilota::pb::encoding::faststr::encode(14, &*value, buf);
                     }
                 }
             }
@@ -133,14 +228,26 @@ pub mod serde_preserve_idl_names_pb {
             #[inline]
             pub fn encoded_len(&self, ctx: &mut ::pilota::pb::EncodeLengthContext) -> usize {
                 match self {
-                    TestOneof::StringValue(value) => {
-                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 3, &*value)
-                    }
                     TestOneof::Pub(value) => {
-                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 4, &*value)
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 8, &*value)
                     }
-                    TestOneof::IntValue(value) => {
-                        ::pilota::pb::encoding::int32::encoded_len(ctx, 5, &*value)
+                    TestOneof::SomeField(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 9, &*value)
+                    }
+                    TestOneof::E(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 10, &*value)
+                    }
+                    TestOneof::F(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 11, &*value)
+                    }
+                    TestOneof::SerOnly(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 12, &*value)
+                    }
+                    TestOneof::DeOnly(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 13, &*value)
+                    }
+                    TestOneof::BothDirs(value) => {
+                        ::pilota::pb::encoding::faststr::encoded_len(ctx, 14, &*value)
                     }
                 }
             }
@@ -154,19 +261,7 @@ pub mod serde_preserve_idl_names_pb {
                 ctx: &mut ::pilota::pb::encoding::DecodeContext,
             ) -> ::core::result::Result<(), ::pilota::pb::DecodeError> {
                 match tag {
-                    3 => match field {
-                        ::core::option::Option::Some(TestOneof::StringValue(value)) => {
-                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
-                        }
-                        _ => {
-                            let mut owned_value = ::core::default::Default::default();
-                            let value = &mut owned_value;
-                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
-                            *field =
-                                ::core::option::Option::Some(TestOneof::StringValue(owned_value));
-                        }
-                    },
-                    4 => match field {
+                    8 => match field {
                         ::core::option::Option::Some(TestOneof::Pub(value)) => {
                             ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
                         }
@@ -177,15 +272,71 @@ pub mod serde_preserve_idl_names_pb {
                             *field = ::core::option::Option::Some(TestOneof::Pub(owned_value));
                         }
                     },
-                    5 => match field {
-                        ::core::option::Option::Some(TestOneof::IntValue(value)) => {
-                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
+                    9 => match field {
+                        ::core::option::Option::Some(TestOneof::SomeField(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
                         }
                         _ => {
                             let mut owned_value = ::core::default::Default::default();
                             let value = &mut owned_value;
-                            ::pilota::pb::encoding::int32::merge(wire_type, value, buf, ctx)?;
-                            *field = ::core::option::Option::Some(TestOneof::IntValue(owned_value));
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field =
+                                ::core::option::Option::Some(TestOneof::SomeField(owned_value));
+                        }
+                    },
+                    10 => match field {
+                        ::core::option::Option::Some(TestOneof::E(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::E(owned_value));
+                        }
+                    },
+                    11 => match field {
+                        ::core::option::Option::Some(TestOneof::F(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::F(owned_value));
+                        }
+                    },
+                    12 => match field {
+                        ::core::option::Option::Some(TestOneof::SerOnly(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::SerOnly(owned_value));
+                        }
+                    },
+                    13 => match field {
+                        ::core::option::Option::Some(TestOneof::DeOnly(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::DeOnly(owned_value));
+                        }
+                    },
+                    14 => match field {
+                        ::core::option::Option::Some(TestOneof::BothDirs(value)) => {
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                        }
+                        _ => {
+                            let mut owned_value = ::core::default::Default::default();
+                            let value = &mut owned_value;
+                            ::pilota::pb::encoding::faststr::merge(wire_type, value, buf, ctx)?;
+                            *field = ::core::option::Option::Some(TestOneof::BothDirs(owned_value));
                         }
                     },
                     _ => unreachable!(concat!("invalid ", stringify!(TestOneof), " tag: {}"), tag),
@@ -193,5 +344,9 @@ pub mod serde_preserve_idl_names_pb {
                 ::core::result::Result::Ok(())
             }
         }
+    }
+
+    pub mod pilota {
+        use ::pilota::{Buf as _, BufMut as _};
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
Currently, generated structs and enums from IDL have their field names changed to either snake_case or PascalCase respectively. Users who needs the format to line up with the IDL would have to write their own plugin logic which is inconvenient.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Adds `preserve_idl_field_names` flag (false by default) and a new plugin `ConfiguredSerdePlugin` which emits #[serde(rename = "")] on each field that doesn't already carry an explicit #[serde(rename)], restoring the IDL spelling in the serialized output without overriding user-specified renames.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
