### PR TITLE
fix: align pilota parsing with standard grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "pilota-thrift-parser"
-version = "0.13.6"
+version = "0.13.7"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/pilota-thrift-parser/Cargo.toml
+++ b/pilota-thrift-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pilota-thrift-parser"
-version = "0.13.6"
+version = "0.13.7"
 edition.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/pilota-thrift-parser/src/parser/constant.rs
+++ b/pilota-thrift-parser/src/parser/constant.rs
@@ -44,8 +44,8 @@ impl ConstValue {
 
             choice((
                 Literal::parse().map(ConstValue::String),
-                just("true").to(ConstValue::Bool(true)),
-                just("false").to(ConstValue::Bool(false)),
+                Components::keyword("true").to(ConstValue::Bool(true)),
+                Components::keyword("false").to(ConstValue::Bool(false)),
                 Path::parse().map(ConstValue::Path),
                 DoubleConstant::parse().map(ConstValue::Double),
                 IntConstant::parse().map(ConstValue::Int),
@@ -63,7 +63,7 @@ impl Constant {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("const"))
+            .then_ignore(Components::keyword("const"))
             .then(Type::get_parser().padded_by(Components::blank_with_comments()))
             .then(Ident::get_parser())
             .then_ignore(just("=").padded_by(Components::blank_with_comments().or_not()))
@@ -89,39 +89,58 @@ impl Constant {
 
 impl IntConstant {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, IntConstant, extra::Err<Rich<'a, char>>> {
-        recursive(|int_constant| {
-            choice((
-                just("-")
-                    .ignore_then(int_constant)
-                    .map(|d: IntConstant| IntConstant(-d.0)),
-                just("0x")
-                    .ignore_then(
-                        any()
-                            .filter(|c: &char| c.is_ascii_hexdigit())
-                            .repeated()
-                            .at_least(1)
-                            .collect::<String>(),
-                    )
-                    .map(|d| IntConstant(i64::from_str_radix(d.as_str(), 16).unwrap())),
+        // A single optional sign, per `IntConstant ::= ('+' | '-')? Digit+`
+        let sign = one_of("+-").or_not();
+
+        let hex_digits = just("0x")
+            .ignore_then(
                 any()
-                    .filter(|c: &char| c.is_ascii_digit())
+                    .filter(char::is_ascii_hexdigit)
                     .repeated()
                     .at_least(1)
-                    .collect::<String>()
-                    .map(|d| IntConstant(d.as_str().parse::<i64>().unwrap())),
-            ))
-        })
+                    .to_slice(),
+            )
+            .map(|digits: &str| (16u32, digits));
+
+        let decimal_digits = any()
+            .filter(char::is_ascii_digit)
+            .repeated()
+            .at_least(1)
+            .to_slice()
+            .and_is(just("0x").not())
+            .map(|digits: &str| (10u32, digits));
+
+        sign.then(choice((hex_digits, decimal_digits))).validate(
+            |(sign, (radix, digits)), e, emitter| {
+                let result = match sign {
+                    Some('-') => {
+                        let signed = format!("-{digits}");
+                        i64::from_str_radix(&signed, radix)
+                    }
+                    _ => i64::from_str_radix(digits, radix),
+                };
+
+                match result {
+                    Ok(value) => IntConstant(value),
+                    Err(_) => {
+                        emitter.emit(Rich::custom(
+                            e.span(),
+                            "integer constant does not fit in an i64",
+                        ));
+                        IntConstant(0)
+                    }
+                }
+            },
+        )
     }
 }
 
 impl DoubleConstant {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, DoubleConstant, extra::Err<Rich<'a, char>>> {
-        let digits = any()
-            .filter(|c: &char| c.is_ascii_digit())
-            .repeated()
-            .at_least(1);
+        let digits = any().filter(char::is_ascii_digit).repeated().at_least(1);
         let sign = one_of("+-").or_not();
-        let integer_part = digits;
+        // `Digit*` — the integer part is optional so that `.5` parses.
+        let integer_part = any().filter(char::is_ascii_digit).repeated();
         let fractional_part = just('.').then(digits);
         let exponent_part = one_of("eE").then(one_of("+-").or_not()).then(digits);
         let with_fraction = sign
@@ -131,7 +150,7 @@ impl DoubleConstant {
             .to_slice()
             .map(|s: &str| DoubleConstant(s.into()));
         let with_exponent_only = sign
-            .then(integer_part)
+            .then(digits)
             .then(exponent_part)
             .to_slice()
             .map(|s: &str| DoubleConstant(s.into()));
@@ -204,5 +223,200 @@ mod tests {
         /* comment */ const /* comment */ string /* comment */ aXa1 = /* comment */ "hello" // comment
         "#;
         let _c = Constant::get_parser().parse(input).unwrap();
+    }
+
+    /// `IntConstant ::= ('+' | '-')? Digit+` — exactly one optional sign.
+    #[test]
+    fn test_int_constant_sign() {
+        assert_eq!(IntConstant::parse().parse("+1").unwrap().0, 1);
+        assert_eq!(IntConstant::parse().parse("-1").unwrap().0, -1);
+        assert_eq!(IntConstant::parse().parse("-0x10").unwrap().0, -16);
+        // The sign is preserved separately, allowing `i64::MIN` to round-trip.
+        assert_eq!(
+            IntConstant::parse()
+                .parse("-9223372036854775808")
+                .unwrap()
+                .0,
+            i64::MIN
+        );
+        // A doubled or contradictory sign is not a valid integer constant.
+        assert!(IntConstant::parse().parse("--1").has_errors());
+        assert!(IntConstant::parse().parse("+-1").has_errors());
+    }
+
+    /// A hex literal that does not fit in an i64 must report the overflow over
+    /// the span of the whole literal.
+    #[test]
+    fn test_hex_constant_out_of_range() {
+        for input in [
+            "0x8000000000000000",
+            "-0x8000000000000001",
+            "0xFFFFFFFFFFFFFFFF",
+            "0x10000000000000000",
+        ] {
+            let result = IntConstant::parse().parse(input);
+            assert!(
+                result.has_errors(),
+                "{input} is out of range and must not parse"
+            );
+
+            let errors: Vec<_> = result.errors().collect();
+            assert_eq!(errors.len(), 1, "{input} should report exactly one error");
+            assert!(
+                errors[0].to_string().contains("does not fit in an i64"),
+                "{input} should report an overflow, got {}",
+                errors[0]
+            );
+            assert_eq!(
+                errors[0].span().into_range(),
+                0..input.len(),
+                "{input} should be reported over its full span"
+            );
+        }
+
+        // The i64 boundaries themselves still parse.
+        assert_eq!(
+            IntConstant::parse().parse("0x7fffffffffffffff").unwrap().0,
+            i64::MAX
+        );
+        assert_eq!(
+            IntConstant::parse().parse("-0x8000000000000000").unwrap().0,
+            i64::MIN
+        );
+    }
+
+    #[test]
+    fn test_hex_constant_requires_digits() {
+        assert!(IntConstant::parse().parse("0x").has_errors());
+        assert!(IntConstant::parse().parse("-0x").has_errors());
+        // A plain `0` is unaffected.
+        assert_eq!(IntConstant::parse().parse("0").unwrap().0, 0);
+    }
+
+    /// Well-formed literals, in both radices and with every sign, across zero,
+    /// the i64 boundaries and the digit casings hex allows.
+    #[test]
+    fn test_int_constant_accepted_forms() {
+        for (input, expected) in [
+            ("0", 0),
+            ("-0", 0),
+            ("+0", 0),
+            ("0x0", 0),
+            ("-0x0", 0),
+            ("1", 1),
+            ("+1", 1),
+            ("-1", -1),
+            ("0x10", 16),
+            ("+0x10", 16),
+            ("-0x10", -16),
+            ("0xABCDEF", 11_259_375),
+            ("0xabcdef", 11_259_375),
+            ("0xAbCdEf", 11_259_375),
+            ("007", 7),
+            ("-007", -7),
+            ("0x007", 7),
+            ("9223372036854775807", i64::MAX),
+            ("+9223372036854775807", i64::MAX),
+            ("-9223372036854775808", i64::MIN),
+            ("0x7fffffffffffffff", i64::MAX),
+            ("-0x8000000000000000", i64::MIN),
+        ] {
+            assert_eq!(
+                IntConstant::parse().parse(input).unwrap().0,
+                expected,
+                "{input} should parse as {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_decimal_constant_out_of_range() {
+        for input in [
+            "9223372036854775808",
+            "+9223372036854775808",
+            "-9223372036854775809",
+            "99999999999999999999999999",
+            "-99999999999999999999999999",
+        ] {
+            let result = IntConstant::parse().parse(input);
+            let errors: Vec<_> = result.errors().collect();
+            assert_eq!(errors.len(), 1, "{input} should report exactly one error");
+            assert!(
+                errors[0].to_string().contains("does not fit in an i64"),
+                "{input} should report an overflow, got {}",
+                errors[0]
+            );
+            assert_eq!(
+                errors[0].span().into_range(),
+                0..input.len(),
+                "{input} should be reported over its full span"
+            );
+        }
+    }
+
+    #[test]
+    fn test_out_of_range_reported_in_context() {
+        for input in [
+            "0x8000000000000000",
+            "9223372036854775808",
+            "[1, 0x8000000000000000]",
+            "{1: 9223372036854775808}",
+        ] {
+            let result = ConstValue::get_parser().parse(input);
+            assert!(
+                result
+                    .errors()
+                    .any(|e| e.to_string().contains("does not fit in an i64")),
+                "{input} should report an overflow"
+            );
+        }
+
+        for input in [
+            "const i64 A = 0x8000000000000000",
+            "const i64 A = 9223372036854775808",
+            "const i64 A = -9223372036854775809",
+        ] {
+            let result = Constant::get_parser().parse(input);
+            assert!(
+                result
+                    .errors()
+                    .any(|e| e.to_string().contains("does not fit in an i64")),
+                "{input} should report an overflow"
+            );
+            assert_eq!(result.output().expect("recovered").name.0.to_string(), "A");
+        }
+    }
+
+    /// `DoubleConstant ::= ('+'|'-')? Digit* ('.' Digit+)? (('E'|'e')
+    /// IntConstant)?` — the integer part is optional, so `.5` is a valid
+    /// double.
+    #[test]
+    fn test_double_constant_forms() {
+        for input in ["-.5", ".5", "1.5", "+1.5", "1e10", "1.5e-10"] {
+            assert!(
+                DoubleConstant::parse().parse(input).into_result().is_ok(),
+                "{input} should parse as a double"
+            );
+        }
+    }
+
+    #[test]
+    fn test_const_keyword_boundary() {
+        // `const` glued to an identifier is not the `const` keyword.
+        assert!(
+            Constant::get_parser()
+                .parse("constbool A = true")
+                .has_errors()
+        );
+
+        // Identifiers that begin with `true`/`false` are not bool literals.
+        let v = ConstValue::get_parser().parse("trueValue").unwrap();
+        assert!(matches!(v, ConstValue::Path(p) if p.segments[0].as_str() == "trueValue"));
+        let v = ConstValue::get_parser().parse("true").unwrap();
+        assert!(matches!(v, ConstValue::Bool(true)));
+        let v = ConstValue::get_parser().parse("falseValue").unwrap();
+        assert!(matches!(v, ConstValue::Path(p) if p.segments[0].as_str() == "falseValue"));
+        let v = ConstValue::get_parser().parse("false").unwrap();
+        assert!(matches!(v, ConstValue::Bool(false)));
     }
 }

--- a/pilota-thrift-parser/src/parser/enum_.rs
+++ b/pilota-thrift-parser/src/parser/enum_.rs
@@ -44,7 +44,7 @@ impl Enum {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("enum"))
+            .then_ignore(Components::keyword("enum"))
             .then_ignore(Components::blank_with_comments())
             .then(Ident::get_parser())
             .then(Components::comment().repeated().collect::<Vec<_>>())
@@ -125,5 +125,11 @@ mod tests {
             /* comment */ FEMALE = 2, // comment
         }"#;
         let _ = Enum::get_parser().parse(input).unwrap();
+    }
+
+    /// `enum` glued to an identifier is not the `enum` keyword.
+    #[test]
+    fn test_keyword_boundary() {
+        assert!(Enum::get_parser().parse("enumFoo { A = 1 }").has_errors());
     }
 }

--- a/pilota-thrift-parser/src/parser/field.rs
+++ b/pilota-thrift-parser/src/parser/field.rs
@@ -5,13 +5,13 @@ use super::super::{
     descriptor::{Attribute, Field},
     parser::*,
 };
-use crate::{Annotation, ConstValue, Type};
+use crate::{Annotation, ConstValue, IntConstant, Type};
 
 impl Attribute {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Attribute, extra::Err<Rich<'a, char>>> {
         choice((
-            just("required").to(Attribute::Required),
-            just("optional").to(Attribute::Optional),
+            Components::keyword("required").to(Attribute::Required),
+            Components::keyword("optional").to(Attribute::Optional),
         ))
     }
 }
@@ -22,7 +22,11 @@ impl Field {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then(text::int(10))
+            .then(IntConstant::parse().try_map(|id, span| {
+                i16::try_from(id.0)
+                    .map(i32::from)
+                    .map_err(|_| Rich::custom(span, "field id does not fit in an i16"))
+            }))
             .then_ignore(just(":").padded_by(Components::blank_with_comments().or_not()))
             .then(Attribute::get_parser().or_not())
             .then(Type::get_parser().padded_by(Components::blank_with_comments().or_not()))
@@ -43,7 +47,7 @@ impl Field {
                     trailing_comments,
                 )| Field {
                     leading_comments: FastStr::from(comments.join("\n\n")),
-                    id: id.parse().unwrap(),
+                    id,
                     attribute: attribute.unwrap_or_default(),
                     ty: r#type,
                     name: Ident(name.into()),
@@ -87,5 +91,31 @@ mod tests {
         /* comment */ 1: /* comment */ required /* comment */ string /* comment */ LogID = /* comment */ "xxx" // comment
         "#;
         let _f = Field::get_parser().parse(input).unwrap();
+    }
+
+    /// Field ids are an `i16` on the wire; anything outside that range would be
+    /// silently truncated by codegen, so it must be a parse error, not a panic.
+    #[test]
+    fn test_field_id_range() {
+        assert_eq!(Field::get_parser().parse("-1: i32 a").unwrap().id, -1);
+        assert_eq!(
+            Field::get_parser().parse("32767: i32 a").unwrap().id,
+            i16::MAX as i32
+        );
+        assert!(Field::get_parser().parse("32768: i32 a").has_errors());
+        assert!(Field::get_parser().parse("-32769: i32 a").has_errors());
+        assert!(Field::get_parser().parse("99999999999: i32 a").has_errors());
+    }
+
+    /// A type merely starting with `required`/`optional` is a plain type, so
+    /// the field keeps the default requiredness.
+    #[test]
+    fn test_requiredness_keyword_boundary() {
+        let f = Field::get_parser().parse("1: requiredThing a").unwrap();
+        assert_eq!(f.attribute, crate::Attribute::Default);
+        assert!(matches!(&f.ty.0, crate::Ty::Path(p) if p.segments[0].as_str() == "requiredThing"));
+
+        let f = Field::get_parser().parse("1: optionalThing a").unwrap();
+        assert_eq!(f.attribute, crate::Attribute::Default);
     }
 }

--- a/pilota-thrift-parser/src/parser/function.rs
+++ b/pilota-thrift-parser/src/parser/function.rs
@@ -18,7 +18,7 @@ impl Function {
 
         let throws = Components::blank()
             .or_not()
-            .ignore_then(just("throws"))
+            .ignore_then(Components::keyword("throws"))
             .ignore_then(Components::blank().or_not())
             .ignore_then(just("("))
             .ignore_then(fields.clone())
@@ -29,7 +29,11 @@ impl Function {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then(just("oneway").then_ignore(Components::blank()).or_not())
+            .then(
+                Components::keyword("oneway")
+                    .then_ignore(Components::blank())
+                    .or_not(),
+            )
             .then(Type::get_parser())
             .then_ignore(Components::blank())
             .then(Ident::get_parser())
@@ -115,5 +119,16 @@ mod tests {
                             2: optional list<map<i64 /* comment */ , set<double>>> nestedDataPoints /* comment */
                         ) /* comment */ (api.version = "2.5", deprecated = "false")"#)
             .unwrap();
+    }
+
+    /// `onewayvoid` is a return type named `onewayvoid`, not `oneway void`, so
+    /// the `oneway` keyword must end at an identifier boundary.
+    #[test]
+    fn test_oneway_keyword_boundary() {
+        let f = Function::get_parser().parse("onewayvoid f()").unwrap();
+        assert!(!f.oneway);
+        assert!(
+            matches!(&f.result_type.0, crate::Ty::Path(p) if p.segments[0].as_str() == "onewayvoid")
+        );
     }
 }

--- a/pilota-thrift-parser/src/parser/include.rs
+++ b/pilota-thrift-parser/src/parser/include.rs
@@ -13,7 +13,7 @@ impl Include {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("include").padded_by(Components::blank().or_not()))
+            .then_ignore(Components::keyword("include").padded_by(Components::blank().or_not()))
             .then(Literal::parse())
             .then_ignore(Components::list_separator().or_not())
             .then(Components::trailing_comment().or_not())
@@ -32,7 +32,7 @@ impl CppInclude {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("cpp_include").padded_by(Components::blank().or_not()))
+            .then_ignore(Components::keyword("cpp_include").padded_by(Components::blank().or_not()))
             .then(Literal::parse())
             .then_ignore(Components::list_separator().or_not())
             .then(Components::trailing_comment().or_not())
@@ -82,5 +82,31 @@ mod tests {
                         cpp_include "shared.thrift" // comment"#,
             )
             .unwrap();
+    }
+
+    /// `include`/`cpp_include` must end at an identifier boundary, so
+    /// `includes` is not read as `include` followed by `s`. A quote is a
+    /// boundary, so the separating blank stays optional.
+    #[test]
+    fn test_include_keyword_boundary() {
+        assert!(
+            Include::get_parser()
+                .parse(r#"includes "shared.thrift""#)
+                .has_errors()
+        );
+        assert!(
+            CppInclude::parse()
+                .parse(r#"cpp_includes "shared.thrift""#)
+                .has_errors()
+        );
+
+        let f = Include::get_parser()
+            .parse(r#"include"shared.thrift""#)
+            .unwrap();
+        assert_eq!(f.path.0.as_str(), "shared.thrift");
+        let f = CppInclude::parse()
+            .parse(r#"cpp_include"shared.thrift""#)
+            .unwrap();
+        assert_eq!(f.path.0.as_str(), "shared.thrift");
     }
 }

--- a/pilota-thrift-parser/src/parser/mod.rs
+++ b/pilota-thrift-parser/src/parser/mod.rs
@@ -155,6 +155,20 @@ impl Components {
             .rewind()
             .filter(|c: &char| !c.is_alphanumeric() && *c != '_')
     }
+
+    /// Succeeds without consuming input when the next character cannot continue
+    /// an identifier, i.e. at an identifier boundary or at the end of input.
+    pub fn word_boundary<'a>() -> impl Parser<'a, &'a str, (), extra::Err<Rich<'a, char>>> {
+        Components::not_alphanumeric_or_underscore()
+            .ignored()
+            .or(end())
+    }
+
+    /// A reserved word that must not be immediately followed by more identifier
+    /// characters, so that `structFoo` is not read as `struct Foo`.
+    pub fn keyword<'a>(kw: &'a str) -> impl Parser<'a, &'a str, (), extra::Err<Rich<'a, char>>> {
+        just(kw).ignore_then(Components::word_boundary())
+    }
 }
 
 #[cfg(test)]
@@ -207,5 +221,30 @@ mod tests {
     #[test]
     fn test_blank_without_newline() {
         let _ = Components::blank_without_newline().parse(" \t\r").unwrap();
+    }
+
+    #[test]
+    fn test_keyword() {
+        // A keyword matches at an identifier boundary, including end of input,
+        // but not when more identifier characters follow (`structFoo`).
+        assert!(
+            Components::keyword("struct")
+                .parse("struct")
+                .into_result()
+                .is_ok()
+        );
+        assert!(
+            Components::keyword("struct")
+                .then_ignore(just("{"))
+                .parse("struct{")
+                .into_result()
+                .is_ok()
+        );
+        assert!(
+            Components::keyword("struct")
+                .parse("structFoo")
+                .has_errors()
+        );
+        assert!(Components::keyword("enum").parse("enumValue").has_errors());
     }
 }

--- a/pilota-thrift-parser/src/parser/namespace.rs
+++ b/pilota-thrift-parser/src/parser/namespace.rs
@@ -10,7 +10,7 @@ impl Namespace {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("namespace"))
+            .then_ignore(Components::keyword("namespace"))
             .then_ignore(Components::blank())
             .then(Scope::parse())
             .then_ignore(Components::blank())
@@ -31,18 +31,15 @@ impl Namespace {
     }
 }
 
-fn is_white_space(c: &char) -> bool {
-    *c == ' ' || *c == '\t' || *c == '\n' || *c == '\r'
-}
-
 impl Scope {
+    /// `NamespaceScope ::= '*' | Identifier` — dotted scopes such as
+    /// `py.twisted` are also in use, so the identifier form allows dots.
     fn parse<'a>() -> impl Parser<'a, &'a str, Scope, extra::Err<Rich<'a, char>>> {
-        any()
-            .filter(|c: &char| !is_white_space(c))
-            .repeated()
-            .at_least(1)
-            .collect::<String>()
-            .map(|s: String| Scope(s))
+        just("*")
+            .to_slice()
+            .map(str::to_string)
+            .or(Ident::ident_with_dot())
+            .map(Scope)
     }
 }
 
@@ -66,5 +63,40 @@ mod tests {
         /* comment */ namespace * foo.bar // comment
         "#;
         let _ = Namespace::get_parser().parse(input).unwrap();
+    }
+
+    /// `NamespaceScope ::= '*' | Identifier` — a wildcard or a (dotted)
+    /// identifier, not an arbitrary run of non-whitespace.
+    #[test]
+    fn test_namespace_scope() {
+        assert!(
+            Namespace::get_parser()
+                .parse("namespace * foo.bar")
+                .into_result()
+                .is_ok()
+        );
+        assert!(
+            Namespace::get_parser()
+                .parse("namespace py.twisted ThriftTest")
+                .into_result()
+                .is_ok()
+        );
+        assert!(
+            Namespace::get_parser()
+                .parse("namespace @@!! foo.bar")
+                .has_errors()
+        );
+        // A scope is mandatory.
+        assert!(
+            Namespace::get_parser()
+                .parse("namespace foo.bar")
+                .has_errors()
+        );
+        // `namespace` glued to the scope is not the keyword.
+        assert!(
+            Namespace::get_parser()
+                .parse("namespacego foo")
+                .has_errors()
+        );
     }
 }

--- a/pilota-thrift-parser/src/parser/service.rs
+++ b/pilota-thrift-parser/src/parser/service.rs
@@ -6,7 +6,7 @@ use crate::{Annotation, Function, Ident};
 
 impl Service {
     pub fn get_parser<'a>() -> impl Parser<'a, &'a str, Service, extra::Err<Rich<'a, char>>> {
-        let extends = just("extends")
+        let extends = Components::keyword("extends")
             .padded_by(Components::blank())
             .ignore_then(Path::parse());
         let functions = Components::blank()
@@ -19,7 +19,7 @@ impl Service {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("service"))
+            .then_ignore(Components::keyword("service"))
             .then_ignore(Components::blank())
             .then(Ident::get_parser())
             .then(extends.or_not())
@@ -105,5 +105,22 @@ mod tests {
                         }"#,
             )
             .unwrap();
+    }
+
+    /// `service`/`extends` glued to an identifier are not those keywords.
+    #[test]
+    fn test_keyword_boundary() {
+        assert!(Service::get_parser().parse("serviceFoo { }").has_errors());
+        assert!(
+            Service::get_parser()
+                .parse("service Foo extendsBar { }")
+                .has_errors()
+        );
+
+        let s = Service::get_parser()
+            .parse("service Foo extends Bar { }")
+            .unwrap();
+        assert_eq!(&*s.name.0, "Foo");
+        assert!(s.extends.is_some());
     }
 }

--- a/pilota-thrift-parser/src/parser/struct_.rs
+++ b/pilota-thrift-parser/src/parser/struct_.rs
@@ -13,7 +13,7 @@ impl Struct {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("struct"))
+            .then_ignore(Components::keyword("struct"))
             .then_ignore(Components::blank())
             .then(StructLike::parse())
             .then(Components::trailing_comment().or_not())
@@ -39,7 +39,7 @@ impl Union {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("union"))
+            .then_ignore(Components::keyword("union"))
             .then_ignore(Components::blank())
             .then(StructLike::parse())
             .then(Components::trailing_comment().or_not())
@@ -58,7 +58,7 @@ impl Exception {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("exception"))
+            .then_ignore(Components::keyword("exception"))
             .then_ignore(Components::blank())
             .then(StructLike::parse())
             .then(Components::trailing_comment().or_not())
@@ -158,5 +158,22 @@ mod tests {
             /* comment */ 1: /* comment */ required /* comment */ string /* comment */ Service, // comment
         }"#;
         let _ = Struct::get_parser().parse(input).unwrap();
+    }
+
+    /// The `struct`/`union`/`exception` keywords must end at an identifier
+    /// boundary, so `structFoo { ... }` is not `struct Foo { ... }`.
+    #[test]
+    fn test_keyword_boundary() {
+        assert!(
+            Struct::get_parser()
+                .parse("structFoo { 1: i32 a }")
+                .has_errors()
+        );
+        assert!(Union::parse().parse("unionFoo { 1: i32 a }").has_errors());
+        assert!(
+            Exception::parse()
+                .parse("exceptionFoo { 1: i32 a }")
+                .has_errors()
+        );
     }
 }

--- a/pilota-thrift-parser/src/parser/ty.rs
+++ b/pilota-thrift-parser/src/parser/ty.rs
@@ -10,7 +10,7 @@ use crate::{Annotation, Literal};
 
 impl CppType {
     pub fn parse<'a>() -> impl Parser<'a, &'a str, CppType, extra::Err<Rich<'a, char>>> {
-        just("cpp_type")
+        Components::keyword("cpp_type")
             .ignore_then(Components::blank())
             .ignore_then(Literal::parse())
             .map(CppType)
@@ -33,7 +33,7 @@ impl Type {
                 just("double").to(Ty::Double),
                 just("uuid").to(Ty::Uuid),
             ))
-            .then_ignore(Components::not_alphanumeric_or_underscore());
+            .then_ignore(Components::word_boundary());
 
             let list = just("list")
                 .ignore_then(just("<").padded_by(Components::blank_with_comments().or_not()))
@@ -76,10 +76,7 @@ impl Type {
                 .then_ignore(just("<").padded_by(Components::blank_with_comments().or_not()))
                 .then(self_parser.clone())
                 .then_ignore(Components::blank_with_comments().or_not())
-                .then_ignore(
-                    Components::list_separator()
-                        .padded_by(Components::blank_with_comments().or_not()),
-                )
+                .then_ignore(just(",").padded_by(Components::blank_with_comments().or_not()))
                 .then(self_parser.clone())
                 .then_ignore(Components::blank_with_comments().or_not())
                 .then_ignore(just(">"))
@@ -183,5 +180,31 @@ mod tests {
         let parser = Type::get_parser();
         let input = "bytet_i.Injection";
         let _res = parser.parse(input).unwrap();
+    }
+
+    /// A base type keyword must end at an identifier boundary — even at end of
+    /// input — so `i32foo` is a path, not `i32` followed by junk.
+    #[test]
+    fn test_base_type_boundary() {
+        assert!(matches!(
+            Type::get_parser().parse("i32").unwrap().0,
+            Ty::I32
+        ));
+        assert!(
+            matches!(Type::get_parser().parse("i32foo").unwrap().0, Ty::Path(p) if p.segments[0].as_str() == "i32foo")
+        );
+    }
+
+    /// `MapType ::= 'map' CppType? '<' FieldType ',' FieldType '>'` — the key
+    /// and value are separated by a comma only, never a `;`.
+    #[test]
+    fn test_map_separator() {
+        assert!(
+            Type::get_parser()
+                .parse("map<i32, string>")
+                .into_result()
+                .is_ok()
+        );
+        assert!(Type::get_parser().parse("map<i32; string>").has_errors());
     }
 }

--- a/pilota-thrift-parser/src/parser/typedef.rs
+++ b/pilota-thrift-parser/src/parser/typedef.rs
@@ -10,7 +10,7 @@ impl Typedef {
             .repeated()
             .collect::<Vec<_>>()
             .then_ignore(Components::blank().or_not())
-            .then_ignore(just("typedef"))
+            .then_ignore(Components::keyword("typedef"))
             .then_ignore(Components::blank())
             .then(Type::get_parser())
             .then_ignore(Components::blank())
@@ -45,5 +45,11 @@ mod tests {
         let _td = Typedef::get_parser()
             .parse("typedef i32 Int32 /* comment */")
             .unwrap();
+    }
+
+    /// `typedef` glued to a type is not the `typedef` keyword.
+    #[test]
+    fn test_keyword_boundary() {
+        assert!(Typedef::get_parser().parse("typedefi32 Foo").has_errors());
     }
 }

--- a/pilota-thrift-reflect/src/lib.rs
+++ b/pilota-thrift-reflect/src/lib.rs
@@ -1,5 +1,7 @@
-use std::collections::BTreeMap;
-use std::path::{Component, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Component, PathBuf},
+};
 
 use ahash::AHashMap;
 use descriptor::thrift_reflection::ConstValueType;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/cloudwego/pilota/blob/main/CONTRIBUTING.md
-->

## Motivation
Current parser behaviour deviates from the specs [Thrift IDL grammar](https://thrift.apache.org/docs/idl)
in numerous places, causing the parser to accept inputs that should be rejected or reject inputs that should be valid. Some of the deviations include:

| # | Example | Original | Expected
| -------- | -------- | -------- | -------- |
| 1 | struct Demo { 40000: required i32 value }  | accepted — codegen emits field id -25536 (40000 as i16) in encode/decode  | reject — field ids must fit in i16 |
| 2 | structFoo { i: i32 a} | accepted — parsed as struct Foo { … } (keyword glued to ident), same behaviour for unionFoo, enumFoo... | reject — no identifier boundary |
| 3 | const i32 A = --1  | accepted — double negation allowed | reject — grammar allows one optional sign |
| 4 | struct S { 1: map<i32; string> a }  | accepted — ; treated as separator | reject — map key/value separator is , only |
| 5 | namespace @@!! foo.bar | accepted — @@!! treated as valid namespace | reject  — scope is * or an identifier |
| 6 | const i32 A = +1 | rejected | accept — IntConstant ::= ('+'\|'-')? Digit+ |
| 7 | const double A = .5 | rejected | accept — integer part is optional (Digit*) |

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
- Add `Components::keyword()` (a `just()` followed by a non-consuming word boundary that also succeeds at end of input) and use it for every reserved word
- Rewrite `IntConstant` as `('+' | '-')? (0x HexDigit+ | Digit+)` with the sign kept inside the matched slice, and convert via `try_map`, so out-of-range values become parse errors rather than panics and `i64::MIN` round-trips.
- `DoubleConstant`'s integer part becomes `Digit*` for the `.5` form, with the exponent-only form still requiring at least one digit.
- Field ids now go through `IntConstant` and are range-checked into `i16` with a `try_map`, so negative ids work and oversized ids are a diagnostic instead of a silent truncation. 
- `Scope` becomes `'*' | Identifier` (dots allowed, since `py.twisted` is in real-world use), which also makes a missing scope an error.
- The map parser uses `just(",")` instead of `list_separator`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
